### PR TITLE
Align directory identifiers and clean media cleanup

### DIFF
--- a/architecture_design.md
+++ b/architecture_design.md
@@ -468,6 +468,9 @@ final directoryRepositoryProvider = Provider<DirectoryRepository>((ref) {
   return DirectoryRepositoryImpl(
     ref.watch(sharedPreferencesDataSourceProvider),
     ref.watch(localDirectoryDataSourceProvider),
+    ref.watch(bookmarkServiceProvider),
+    ref.watch(permissionServiceProvider),
+    ref.watch(mediaDataSourceProvider),
   );
 });
 

--- a/lib/features/full_screen/presentation/view_models/full_screen_view_model.dart
+++ b/lib/features/full_screen/presentation/view_models/full_screen_view_model.dart
@@ -1,6 +1,4 @@
-import 'dart:convert';
 import 'dart:io';
-import 'package:crypto/crypto.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:video_player/video_player.dart';
 
@@ -9,6 +7,7 @@ import '../../../favorites/presentation/view_models/favorites_view_model.dart';
 import '../../../media_library/domain/entities/media_entity.dart';
 import '../../../../core/services/permission_service.dart';
 import '../../../../shared/providers/repository_providers.dart';
+import '../../../../shared/utils/directory_id_utils.dart';
 import '../../domain/use_cases/load_media_for_viewing_use_case.dart';
 import '../../domain/entities/viewer_state_entity.dart';
 import '../../../../core/services/logging_service.dart';
@@ -44,7 +43,7 @@ class FullScreenViewModel extends StateNotifier<FullScreenState> {
       } else {
         // Load media from directory
         // Generate directoryId from path for consistency
-        final directoryId = _generateDirectoryId(directoryPath);
+        final directoryId = generateDirectoryId(directoryPath);
         LoggingService.instance.debug('Generated directoryId: $directoryId');
 
         LoggingService.instance.debug('Calling _loadMediaUseCase.call($directoryPath, $directoryId, bookmarkData: $bookmarkData)');
@@ -344,13 +343,6 @@ class FullScreenViewModel extends StateNotifier<FullScreenState> {
   void dispose() {
     _videoController?.dispose();
     super.dispose();
-  }
-
-  /// Generate directory ID from path using SHA256
-  String _generateDirectoryId(String directoryPath) {
-    final bytes = utf8.encode(directoryPath);
-    final digest = sha256.convert(bytes);
-    return digest.toString();
   }
 
   /// Helper method to check if an error is permission-related.

--- a/lib/features/media_library/data/data_sources/local_directory_data_source.dart
+++ b/lib/features/media_library/data/data_sources/local_directory_data_source.dart
@@ -5,6 +5,7 @@ import 'package:path/path.dart' as path;
 import '../../../../core/error/app_error.dart';
 import '../../../../core/services/bookmark_service.dart';
 import '../../../../core/services/logging_service.dart';
+import '../../../../shared/utils/directory_id_utils.dart';
 import '../../domain/entities/directory_entity.dart';
 
 /// Data source for local directory operations on the file system.
@@ -242,8 +243,8 @@ class LocalDirectoryDataSource {
     }
   }
 
-  /// Generates a unique ID from directory path using hash.
+  /// Generates a unique ID from directory path using a shared hash strategy.
   String _generateId(String directoryPath) {
-    return directoryPath.hashCode.toString();
+    return generateDirectoryId(directoryPath);
   }
 }

--- a/lib/features/media_library/data/repositories/directory_repository_impl.dart
+++ b/lib/features/media_library/data/repositories/directory_repository_impl.dart
@@ -1,6 +1,7 @@
 import '../../domain/entities/directory_entity.dart';
 import '../../domain/repositories/directory_repository.dart';
 import '../data_sources/local_directory_data_source.dart';
+import '../data_sources/local_media_data_source.dart';
 import '../data_sources/shared_preferences_data_source.dart';
 import '../models/directory_model.dart';
 import '../../../../core/error/app_error.dart';
@@ -16,12 +17,14 @@ class DirectoryRepositoryImpl implements DirectoryRepository {
     this._localDirectoryDataSource,
     this._bookmarkService,
     this._permissionService,
+    this._mediaDataSource,
   );
 
   final SharedPreferencesDirectoryDataSource _directoryDataSource;
   final LocalDirectoryDataSource _localDirectoryDataSource;
   final BookmarkService _bookmarkService;
   final PermissionService _permissionService;
+  final SharedPreferencesMediaDataSource _mediaDataSource;
 
   @override
   Future<List<DirectoryEntity>> getDirectories() async {
@@ -231,6 +234,8 @@ class DirectoryRepositoryImpl implements DirectoryRepository {
     );
 
     final updatedModel = model.copyWith(id: expectedId);
+
+    await _mediaDataSource.migrateDirectoryId(model.id, expectedId);
 
     // Replace the legacy entry with the updated ID to keep storage consistent.
     await _directoryDataSource.removeDirectory(model.id);

--- a/lib/features/media_library/data/repositories/filesystem_media_repository_impl.dart
+++ b/lib/features/media_library/data/repositories/filesystem_media_repository_impl.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-import 'package:crypto/crypto.dart';
 import '../../domain/entities/media_entity.dart';
 import '../../domain/repositories/media_repository.dart';
 import '../../domain/repositories/directory_repository.dart';
@@ -9,6 +7,7 @@ import '../../../../core/services/permission_service.dart';
 import '../data_sources/filesystem_media_data_source.dart';
 import '../data_sources/local_media_data_source.dart';
 import '../models/media_model.dart';
+import '../../../../shared/utils/directory_id_utils.dart';
 
 /// Implementation of MediaRepository using filesystem scanning.
 class FilesystemMediaRepositoryImpl implements MediaRepository {
@@ -42,7 +41,7 @@ class FilesystemMediaRepositoryImpl implements MediaRepository {
     String directoryPath, {
     String? bookmarkData,
   }) async {
-    final directoryId = _generateDirectoryId(directoryPath);
+    final directoryId = generateDirectoryId(directoryPath);
     _permissionService.logPermissionEvent(
       'repository_get_media_start',
       path: directoryPath,
@@ -124,7 +123,7 @@ class FilesystemMediaRepositoryImpl implements MediaRepository {
     String directoryPath, {
     String? bookmarkData,
   }) async {
-    final directoryId = _generateDirectoryId(directoryPath);
+    final directoryId = generateDirectoryId(directoryPath);
     final model = await _filesystemDataSource.getMediaById(
       id,
       directoryPath,
@@ -188,7 +187,7 @@ class FilesystemMediaRepositoryImpl implements MediaRepository {
     String directoryPath, {
     String? bookmarkData,
   }) async {
-    final directoryId = _generateDirectoryId(directoryPath);
+    final directoryId = generateDirectoryId(directoryPath);
     final models = await _filesystemDataSource.filterMediaByTags(
       directoryPath,
       directoryId,
@@ -260,10 +259,8 @@ class FilesystemMediaRepositoryImpl implements MediaRepository {
     );
   }
 
-  /// Generates directory ID from path (consistent with other parts of the app)
-  String _generateDirectoryId(String directoryPath) {
-    final bytes = utf8.encode(directoryPath);
-    final digest = sha256.convert(bytes);
-    return digest.toString();
+  @override
+  Future<void> removeMediaForDirectory(String directoryId) async {
+    await _localMediaDataSource.removeMediaForDirectory(directoryId);
   }
 }

--- a/lib/features/media_library/data/repositories/media_repository_impl.dart
+++ b/lib/features/media_library/data/repositories/media_repository_impl.dart
@@ -1,6 +1,5 @@
-import 'dart:convert';
-import 'package:crypto/crypto.dart';
 import '../../../../core/services/logging_service.dart';
+import '../../../../shared/utils/directory_id_utils.dart';
 import '../../domain/entities/media_entity.dart';
 import '../../domain/repositories/media_repository.dart';
 import '../data_sources/local_media_data_source.dart';
@@ -23,7 +22,7 @@ class MediaRepositoryImpl implements MediaRepository {
     String directoryPath, {
     String? bookmarkData,
   }) async {
-    final directoryId = _generateDirectoryId(directoryPath);
+    final directoryId = generateDirectoryId(directoryPath);
     final models = await _mediaDataSource.getMediaForDirectory(directoryId);
     return models.map(_modelToEntity).toList();
   }
@@ -60,7 +59,7 @@ class MediaRepositoryImpl implements MediaRepository {
     String directoryPath, {
     String? bookmarkData,
   }) async {
-    final directoryId = _generateDirectoryId(directoryPath);
+    final directoryId = generateDirectoryId(directoryPath);
     final allMedia = await _mediaDataSource.getMediaForDirectory(directoryId);
 
     if (tagIds.isEmpty) {
@@ -78,6 +77,11 @@ class MediaRepositoryImpl implements MediaRepository {
     await _mediaDataSource.updateMediaTags(mediaId, tagIds);
   }
 
+  @override
+  Future<void> removeMediaForDirectory(String directoryId) async {
+    await _mediaDataSource.removeMediaForDirectory(directoryId);
+  }
+
   /// Converts MediaModel to MediaEntity.
   MediaEntity _modelToEntity(MediaModel model) {
     return MediaEntity(
@@ -92,10 +96,4 @@ class MediaRepositoryImpl implements MediaRepository {
     );
   }
 
-  /// Generates directory ID from path (consistent with other parts of the app)
-  String _generateDirectoryId(String directoryPath) {
-    final bytes = utf8.encode(directoryPath);
-    final digest = sha256.convert(bytes);
-    return digest.toString();
-  }
 }

--- a/lib/features/media_library/domain/repositories/media_repository.dart
+++ b/lib/features/media_library/domain/repositories/media_repository.dart
@@ -29,4 +29,7 @@ abstract class MediaRepository {
 
   /// Updates the tags for a media item.
   Future<void> updateMediaTags(String mediaId, List<String> tagIds);
+
+  /// Removes all cached media entries for a directory.
+  Future<void> removeMediaForDirectory(String directoryId);
 }

--- a/lib/features/media_library/domain/use_cases/add_directory_use_case.dart
+++ b/lib/features/media_library/domain/use_cases/add_directory_use_case.dart
@@ -1,3 +1,4 @@
+import '../../../../shared/utils/directory_id_utils.dart';
 import '../entities/directory_entity.dart';
 import '../repositories/directory_repository.dart';
 
@@ -11,8 +12,8 @@ class AddDirectoryUseCase {
   /// Creates a DirectoryEntity and delegates validation to the repository.
   /// [silent] if true, skips recovery dialogs for bookmark failures (used for drag-and-drop).
   Future<void> call(String path, {bool silent = false}) async {
-    // Generate ID from path
-    final id = path.hashCode.toString();
+    // Generate ID from path using a stable hash to keep repository layers aligned
+    final id = generateDirectoryId(path);
 
     // Get directory name from path
     final name = path.split('/').lastWhere((element) => element.isNotEmpty, orElse: () => path);

--- a/lib/features/media_library/domain/use_cases/remove_directory_use_case.dart
+++ b/lib/features/media_library/domain/use_cases/remove_directory_use_case.dart
@@ -69,6 +69,7 @@ class RemoveDirectoryUseCase {
 
       // Finally, remove the directory itself
       await _directoryRepository.removeDirectory(id);
+      await _mediaRepository.removeMediaForDirectory(directory.id);
       LoggingService.instance.info('Successfully removed directory: ${directory.path}');
     } catch (e) {
       LoggingService.instance.error('Failed to remove directory $id: $e');

--- a/lib/features/media_library/presentation/view_models/media_grid_view_model.dart
+++ b/lib/features/media_library/presentation/view_models/media_grid_view_model.dart
@@ -213,6 +213,9 @@ class MediaViewModel extends StateNotifier<MediaState> {
 
   /// Filters media by tag IDs.
   void filterByTags(List<String> tagIds) async {
+    final previousState = state;
+    final previousColumns =
+        previousState is MediaLoaded ? previousState.columns : 3;
     state = const MediaLoading();
     try {
       final media = await _mediaRepository.filterMediaByTagsForDirectory(
@@ -249,7 +252,7 @@ class MediaViewModel extends StateNotifier<MediaState> {
         media: media,
         searchQuery: '', // Reset search when filtering
         selectedTagIds: tagIds,
-        columns: state is MediaLoaded ? (state as MediaLoaded).columns : 3,
+        columns: previousColumns,
         currentDirectoryPath: _directoryPath,
         currentDirectoryName: _directoryName,
       );

--- a/lib/shared/providers/repository_providers.dart
+++ b/lib/shared/providers/repository_providers.dart
@@ -103,6 +103,7 @@ final directoryRepositoryProvider =
           ref.watch(localDirectoryDataSourceProvider),
           ref.watch(bookmarkServiceProvider),
           ref.watch(permissionServiceProvider),
+          ref.watch(mediaDataSourceProvider),
         ),
       ),
     );

--- a/lib/shared/utils/directory_id_utils.dart
+++ b/lib/shared/utils/directory_id_utils.dart
@@ -1,0 +1,14 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+
+/// Generates a stable ID for a directory path using SHA-256.
+///
+/// The ID generation is centralized to guarantee that every layer
+/// (data sources, repositories, and presentation) references directories
+/// with the same identifier regardless of platform hash implementations.
+String generateDirectoryId(String directoryPath) {
+  final normalizedPath = directoryPath.trim();
+  final bytes = utf8.encode(normalizedPath);
+  return sha256.convert(bytes).toString();
+}

--- a/test/mocks.mocks.dart
+++ b/test/mocks.mocks.dart
@@ -167,6 +167,7 @@ class MockMediaRepository extends _i1.Mock implements _i5.MediaRepository {
             returnValueForMissingStub: _i6.Future<void>.value(),
           )
           as _i6.Future<void>);
+
 }
 
 /// A class which mocks [TagRepository].
@@ -436,6 +437,21 @@ class MockSharedPreferencesMediaDataSource extends _i1.Mock
   _i6.Future<void> removeMediaForDirectory(String? directoryId) =>
       (super.noSuchMethod(
             Invocation.method(#removeMediaForDirectory, [directoryId]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> migrateDirectoryId(
+    String? legacyDirectoryId,
+    String? stableDirectoryId,
+  ) =>
+      (super.noSuchMethod(
+            Invocation.method(
+              #migrateDirectoryId,
+              [legacyDirectoryId, stableDirectoryId],
+            ),
             returnValue: _i6.Future<void>.value(),
             returnValueForMissingStub: _i6.Future<void>.value(),
           )

--- a/test/mocks.mocks.dart
+++ b/test/mocks.mocks.dart
@@ -158,6 +158,15 @@ class MockMediaRepository extends _i1.Mock implements _i5.MediaRepository {
             returnValueForMissingStub: _i6.Future<void>.value(),
           )
           as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> removeMediaForDirectory(String? directoryId) =>
+      (super.noSuchMethod(
+            Invocation.method(#removeMediaForDirectory, [directoryId]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
 }
 
 /// A class which mocks [TagRepository].


### PR DESCRIPTION
## Summary
- centralize directory ID generation with a shared SHA-256 helper and update repositories, use cases, and view models to adopt it
- migrate stored directories to the stable ID scheme and ensure metadata removal clears cached media entries
- preserve media grid layout when filtering by tags and update mocks for the expanded repository API

## Testing
- Not run (Flutter SDK unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e55c69877c8320bbe1269546b2514a