### PR TITLE
Refine tag management dialog initialization flow

### DIFF
--- a/lib/features/tagging/presentation/widgets/tag_management_dialog.dart
+++ b/lib/features/tagging/presentation/widgets/tag_management_dialog.dart
@@ -53,14 +53,21 @@ class _TagManagementDialogState extends ConsumerState<TagManagementDialog> {
   }
 
   Future<List<String>> _loadInitialAssignedTagIds() async {
-    if (widget.media == null) {
+    final requestedMediaId = widget.media?.id;
+
+    if (requestedMediaId == null) {
       _assignedTagIds = <String>[];
       _hasLoadedInitialAssignments = true;
       return const <String>[];
     }
 
     final repository = ref.read(mediaRepositoryProvider);
-    final media = await repository.getMediaById(widget.media!.id);
+    final media = await repository.getMediaById(requestedMediaId);
+
+    if (!mounted || requestedMediaId != widget.media?.id) {
+      return _assignedTagIds;
+    }
+
     final ids = media?.tagIds ?? <String>[];
     _assignedTagIds = List<String>.from(ids);
     _hasLoadedInitialAssignments = true;


### PR DESCRIPTION
## Summary
- move the tag management dialog's initial tag lookup out of the build method and into lifecycle-managed futures to match Riverpod guidance
- ensure the dialog refreshes assignments when the inspected media item changes and provide a loading state while data is fetched

## Testing
- not run (Flutter SDK is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e5e3b43b8c832088dfe6598674ed0a