### PR TITLE
Fix favorite toggling in Tag tab

### DIFF
--- a/lib/features/full_screen/presentation/screens/full_screen_viewer_screen.dart
+++ b/lib/features/full_screen/presentation/screens/full_screen_viewer_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../media_library/domain/entities/media_entity.dart';
+import '../../../tagging/presentation/view_models/tags_view_model.dart';
 import '../../domain/entities/viewer_state_entity.dart';
 import '../view_models/full_screen_view_model.dart';
 import '../widgets/full_screen_favorite_toggle.dart';
@@ -127,7 +128,7 @@ class _FullScreenViewerScreenState
                       const Spacer(),
                       FullScreenFavoriteToggle(
                         isFavorite: state.isFavorite,
-                        onToggle: _viewModel.toggleFavorite,
+                        onToggle: () => _toggleFavoriteAndRefreshTags(),
                       ),
                     ],
                   ),
@@ -286,11 +287,16 @@ class _FullScreenViewerScreenState
         ),
         PopupMenuItem(
           child: const Text('Favorite'),
-          onTap: () => _viewModel.toggleFavorite(),
+          onTap: () => _toggleFavoriteAndRefreshTags(),
         ),
         // Add more menu items as needed
       ],
     );
+  }
+
+  Future<void> _toggleFavoriteAndRefreshTags() async {
+    await _viewModel.toggleFavorite();
+    await ref.read(tagsViewModelProvider.notifier).refreshFavorites();
   }
 
   String _formatFileSize(int bytes) {
@@ -491,7 +497,7 @@ class _FullScreenViewerScreenState
         }
         return KeyEventResult.handled;
       case LogicalKeyboardKey.keyF:
-        _viewModel.toggleFavorite();
+        _toggleFavoriteAndRefreshTags();
         return KeyEventResult.handled;
       case LogicalKeyboardKey.keyI:
         _showMediaInfo(state.currentMedia);

--- a/lib/features/media_library/presentation/widgets/media_grid_item.dart
+++ b/lib/features/media_library/presentation/widgets/media_grid_item.dart
@@ -22,6 +22,7 @@ class MediaGridItem extends StatefulWidget {
     this.onLongPress,
     this.onSecondaryTap,
     this.onOperationComplete,
+    this.onFavoriteToggle,
   });
 
   final MediaEntity media;
@@ -30,6 +31,7 @@ class MediaGridItem extends StatefulWidget {
   final VoidCallback? onLongPress;
   final VoidCallback? onSecondaryTap;
   final VoidCallback? onOperationComplete;
+  final ValueChanged<bool>? onFavoriteToggle;
 
   @override
   State<MediaGridItem> createState() => _MediaGridItemState();
@@ -122,7 +124,10 @@ class _MediaGridItemState extends State<MediaGridItem> {
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            FavoriteToggleButton(media: widget.media),
+            FavoriteToggleButton(
+              media: widget.media,
+              onToggle: widget.onFavoriteToggle,
+            ),
             const SizedBox(width: 4),
             IconButton(
               icon: const Icon(Icons.tag, color: Colors.white),

--- a/lib/features/tagging/presentation/screens/tags_screen.dart
+++ b/lib/features/tagging/presentation/screens/tags_screen.dart
@@ -4,7 +4,6 @@ import 'package:path/path.dart' as p;
 
 import '../../../favorites/presentation/screens/slideshow_screen.dart';
 import '../../../favorites/presentation/view_models/favorites_view_model.dart';
-import '../../../favorites/presentation/widgets/favorite_toggle_button.dart';
 import '../../../full_screen/presentation/screens/full_screen_viewer_screen.dart';
 import '../../../media_library/domain/entities/media_entity.dart';
 import '../../../media_library/presentation/widgets/media_grid_item.dart';
@@ -282,29 +281,11 @@ class _TagsScreenState extends ConsumerState<TagsScreen> {
   }
 
   Widget _buildMediaTile(MediaEntity media, List<MediaEntity> collection) {
-    return Stack(
-      fit: StackFit.expand,
-      children: [
-        MediaGridItem(
-          media: media,
-          onTap: () => _openFullScreen(collection, media),
-          onFavoriteToggle: (_) =>
-              ref.read(tagsViewModelProvider.notifier).refreshFavorites(),
-        ),
-        Positioned(
-          top: 8,
-          right: 8,
-          child: Material(
-            color: Colors.transparent,
-            child: FavoriteToggleButton(
-              media: media,
-              onToggle: (_) => ref
-                  .read(tagsViewModelProvider.notifier)
-                  .refreshFavorites(),
-            ),
-          ),
-        ),
-      ],
+    return MediaGridItem(
+      media: media,
+      onTap: () => _openFullScreen(collection, media),
+      onFavoriteToggle: (_) =>
+          ref.read(tagsViewModelProvider.notifier).refreshFavorites(),
     );
   }
 

--- a/lib/features/tagging/presentation/screens/tags_screen.dart
+++ b/lib/features/tagging/presentation/screens/tags_screen.dart
@@ -288,14 +288,20 @@ class _TagsScreenState extends ConsumerState<TagsScreen> {
         MediaGridItem(
           media: media,
           onTap: () => _openFullScreen(collection, media),
+          onFavoriteToggle: (_) =>
+              ref.read(tagsViewModelProvider.notifier).refreshFavorites(),
         ),
         Positioned(
           top: 8,
           right: 8,
-          child: FavoriteToggleButton(
-            media: media,
-            onToggle: (_) =>
-                ref.read(tagsViewModelProvider.notifier).refreshFavorites(),
+          child: Material(
+            color: Colors.transparent,
+            child: FavoriteToggleButton(
+              media: media,
+              onToggle: (_) => ref
+                  .read(tagsViewModelProvider.notifier)
+                  .refreshFavorites(),
+            ),
           ),
         ),
       ],


### PR DESCRIPTION
## Summary
- allow Tag tab grid items to forward favorite toggles so the overlay button can be used to unfavorite media
- add propagation from full-screen favorite actions back to the tag view model so the grid refreshes immediately
- expose a favorite toggle callback on media grid items for reuse when hover controls are visible

## Testing
- not run (Flutter tooling is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68e67e146688832081896f1fc6606b17