### PR TITLE
Fix favorites toggling within the Tag tab

### DIFF
--- a/lib/features/tagging/presentation/screens/tags_screen.dart
+++ b/lib/features/tagging/presentation/screens/tags_screen.dart
@@ -20,12 +20,21 @@ class TagsScreen extends ConsumerStatefulWidget {
 class _TagsScreenState extends ConsumerState<TagsScreen> {
   late final TextEditingController _searchController;
   String _searchQuery = '';
+  ProviderSubscription<FavoritesState>? _favoritesSubscription;
 
   @override
   void initState() {
     super.initState();
     _searchController = TextEditingController();
     _searchController.addListener(_onSearchChanged);
+    _favoritesSubscription = ref.listen<FavoritesState>(
+      favoritesViewModelProvider,
+      (previous, next) {
+        if (next is FavoritesLoaded || next is FavoritesEmpty) {
+          ref.read(tagsViewModelProvider.notifier).refreshFavorites();
+        }
+      },
+    );
     Future.microtask(() async {
       await ref.read(tagsViewModelProvider.notifier).loadTags();
       await ref.read(favoritesViewModelProvider.notifier).loadFavorites();
@@ -36,6 +45,7 @@ class _TagsScreenState extends ConsumerState<TagsScreen> {
   void dispose() {
     _searchController.removeListener(_onSearchChanged);
     _searchController.dispose();
+    _favoritesSubscription?.close();
     super.dispose();
   }
 


### PR DESCRIPTION
## Summary
- convert the favorite toggle button into a stateful widget so unfavoriting from tag grids stays responsive and reports the new status
- listen for favorites state updates on the Tags screen to refresh the favorites section automatically when items are toggled

## Testing
- Not run (flutter not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68e67e146688832081896f1fc6606b17