### PR TITLE
Fix favorite toggle hover interaction

### DIFF
--- a/lib/features/favorites/presentation/widgets/favorite_toggle_button.dart
+++ b/lib/features/favorites/presentation/widgets/favorite_toggle_button.dart
@@ -16,19 +16,21 @@ class FavoriteToggleButton extends ConsumerWidget {
     final state = ref.watch(favoritesViewModelProvider);
     final viewModel = ref.read(favoritesViewModelProvider.notifier);
     final isFavorite = viewModel.isFavoriteInState(media.id);
-    final isBusy = state is FavoritesLoading;
+    final hasLoadedFavorites = viewModel.hasLoadedFavorites;
+    final isBusy = state is FavoritesLoading && hasLoadedFavorites;
 
     return IconButton(
       icon: Icon(
         isFavorite ? Icons.favorite : Icons.favorite_border,
         color: isFavorite ? Colors.red : Colors.white,
       ),
-      onPressed: isBusy
-          ? null
-          : () async {
-              await viewModel.toggleFavorite(media);
-              onToggle?.call(!isFavorite);
-            },
+      onPressed: () async {
+        if (isBusy) {
+          return;
+        }
+        await viewModel.toggleFavorite(media);
+        onToggle?.call(!isFavorite);
+      },
       tooltip: isFavorite ? 'Remove from favorites' : 'Add to favorites',
       style: IconButton.styleFrom(
         backgroundColor: Colors.black.withValues(alpha: 0.5),


### PR DESCRIPTION
## Summary
- add a dedicated initial state and load tracking to the favorites view model
- trigger an automatic favorites load when the notifier is created
- keep the hover favorite toggle clickable during initial load while still blocking concurrent toggle requests

## Testing
- flutter test *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e69e2a53888320b4ea62c364fdd2c2