### PR TITLE
Expand file operations with audit logging support

### DIFF
--- a/architecture_design.md
+++ b/architecture_design.md
@@ -14,7 +14,7 @@ Based on the requirements analysis, the application implements the following cor
 4. **Favorites System**: Marking favorites with dedicated screen and slideshow functionality
 5. **Full-Screen Viewing**: Immersive viewing with zoom, pan, and video controls
 6. **UI Interactions**: Responsive grids, animations, drag-and-drop, gestures, and keyboard shortcuts
-7. **File Operations**: Safe file deletion and permission handling
+7. **File Operations**: Secure deletion, bulk rename, folder moves, and reversible trash with security-scoped bookmark handling and audit logging
 8. **Data Persistence**: SharedPreferences-based storage for all app data
 9. **Performance Optimizations**: Lazy loading, memory management, and efficient resource handling
 

--- a/lib/core/error/app_error.dart
+++ b/lib/core/error/app_error.dart
@@ -39,6 +39,16 @@ class FileDeleteError extends FileSystemError {
   const FileDeleteError(super.message);
 }
 
+/// Error for file rename operations.
+class FileRenameError extends FileSystemError {
+  const FileRenameError(super.message);
+}
+
+/// Error for file move operations.
+class FileMoveError extends FileSystemError {
+  const FileMoveError(super.message);
+}
+
 /// Error for directory operations.
 class DirectoryError extends FileSystemError {
   const DirectoryError(super.message);
@@ -57,6 +67,16 @@ class DirectoryAccessDeniedError extends DirectoryError {
 /// Error for directory scan operations.
 class DirectoryScanError extends DirectoryError {
   const DirectoryScanError(super.message);
+}
+
+/// Error for trash operations.
+class TrashOperationError extends FileSystemError {
+  const TrashOperationError(super.message);
+}
+
+/// Error when attempting to restore an item that is no longer in trash.
+class TrashItemNotFoundError extends TrashOperationError {
+  const TrashItemNotFoundError(super.message);
 }
 
 /// Error for path validation operations.

--- a/lib/core/services/file_service.dart
+++ b/lib/core/services/file_service.dart
@@ -58,6 +58,15 @@ class FileService {
     });
   }
 
+  /// Ensures a directory exists, creating it if necessary
+  Future<Directory> ensureDirectoryExists(String directoryPath) async {
+    final directory = Directory(directoryPath);
+    if (!await directory.exists()) {
+      await directory.create(recursive: true);
+    }
+    return directory;
+  }
+
   /// Checks if a file or directory exists
   Future<bool> exists(String path) async {
     return await File(path).exists() || await Directory(path).exists();
@@ -197,5 +206,147 @@ class FileService {
         throw DirectoryScanError('Failed to calculate directory size for $directoryPath: $error');
       }
     });
+  }
+
+  /// Renames a file system entity
+  Future<String> renameEntity(String sourcePath, String destinationPath) async {
+    return _relocateEntity(
+      sourcePath,
+      destinationPath,
+      (source, destination, reason) {
+        if (reason == 'destination_exists') {
+          return FileRenameError(
+            'Cannot rename $source because $destination already exists',
+          );
+        }
+        return FileRenameError('Failed to rename $source to $destination');
+      },
+    );
+  }
+
+  /// Moves a file system entity to a specific destination path
+  Future<String> moveEntity(String sourcePath, String destinationPath) async {
+    return _relocateEntity(
+      sourcePath,
+      destinationPath,
+      (source, destination, reason) {
+        if (reason == 'destination_exists') {
+          return FileMoveError(
+            'Cannot move $source because $destination already exists',
+          );
+        }
+        return FileMoveError('Failed to move $source to $destination');
+      },
+    );
+  }
+
+  /// Moves a file system entity into the destination directory, preserving the
+  /// original name and ensuring no conflicts.
+  Future<String> moveEntityToDirectory(
+    String sourcePath,
+    String destinationDirectory,
+  ) async {
+    final baseName = path.basename(sourcePath);
+    final destinationPath =
+        await _resolveUniqueDestination(destinationDirectory, baseName);
+    return moveEntity(sourcePath, destinationPath);
+  }
+
+  /// Moves a file system entity into the trash directory and returns the
+  /// resulting trashed path.
+  Future<String> moveToTrash(String sourcePath, String trashDirectory) async {
+    await ensureDirectoryExists(trashDirectory);
+    final trashedName =
+        '${DateTime.now().millisecondsSinceEpoch}_${path.basename(sourcePath)}';
+    final destinationPath =
+        await _resolveUniqueDestination(trashDirectory, trashedName);
+    return moveEntity(sourcePath, destinationPath);
+  }
+
+  Future<String> _relocateEntity(
+    String sourcePath,
+    String destinationPath,
+    FileSystemError Function(
+      String source,
+      String destination,
+      String reason,
+    )
+        errorBuilder,
+  ) async {
+    return await RetryUtils.retryWithBackoff(
+      () async {
+        final entityType = await FileSystemEntity.type(sourcePath);
+        if (entityType == FileSystemEntityType.notFound) {
+          throw FileNotFoundError('Source does not exist: $sourcePath');
+        }
+
+        final destinationDirectory =
+            Directory(path.dirname(destinationPath));
+        if (!await destinationDirectory.exists()) {
+          await destinationDirectory.create(recursive: true);
+        }
+
+        if (await exists(destinationPath)) {
+          throw errorBuilder(
+            sourcePath,
+            destinationPath,
+            'destination_exists',
+          );
+        }
+
+        if (entityType == FileSystemEntityType.directory) {
+          await Directory(sourcePath).rename(destinationPath);
+        } else {
+          await File(sourcePath).rename(destinationPath);
+        }
+
+        return destinationPath;
+      },
+      shouldRetry: RetryUtils.shouldRetryFileOperation,
+    ).catchError((error) {
+      if (error is FileSystemError) {
+        throw error;
+      }
+
+      final errorString = error.toString().toLowerCase();
+      if (errorString.contains('permission denied') ||
+          errorString.contains('operation not permitted')) {
+        throw FileAccessDeniedError(
+          'Permission denied relocating $sourcePath to $destinationPath',
+        );
+      }
+
+      throw errorBuilder(sourcePath, destinationPath, 'operation_failed');
+    });
+  }
+
+  Future<String> _resolveUniqueDestination(
+    String directoryPath,
+    String fileName,
+  ) async {
+    await ensureDirectoryExists(directoryPath);
+
+    var candidate = path.join(directoryPath, fileName);
+    if (!await exists(candidate)) {
+      return candidate;
+    }
+
+    final extension = path.extension(fileName);
+    final baseName = extension.isEmpty
+        ? fileName
+        : fileName.substring(0, fileName.length - extension.length);
+
+    var counter = 1;
+    while (true) {
+      final suffix = '($counter)';
+      final candidateName = extension.isEmpty
+          ? '$baseName$suffix'
+          : '$baseName$suffix$extension';
+      candidate = path.join(directoryPath, candidateName);
+      if (!await exists(candidate)) {
+        return candidate;
+      }
+      counter++;
+    }
   }
 }

--- a/lib/core/services/logging_service.dart
+++ b/lib/core/services/logging_service.dart
@@ -5,6 +5,20 @@ enum LogLevel {
   error,
 }
 
+class LogRecord {
+  const LogRecord({
+    required this.timestamp,
+    required this.level,
+    required this.message,
+    this.context,
+  });
+
+  final DateTime timestamp;
+  final LogLevel level;
+  final String message;
+  final Map<String, dynamic>? context;
+}
+
 abstract class LogOutput {
   void write(LogLevel level, String message, Map<String, dynamic>? context);
 }
@@ -32,21 +46,58 @@ class LoggingService implements Logger {
 
   final List<LogOutput> _outputs;
   final LogLevel _minLevel;
+  final int _maxHistory;
+  final List<LogRecord> _history = [];
 
   LoggingService._({
     List<LogOutput>? outputs,
     LogLevel minLevel = LogLevel.debug,
-  }) : _outputs = outputs ?? [ConsoleLogOutput()], _minLevel = minLevel;
+    int maxHistory = 2000,
+  })  : _outputs = outputs ?? [ConsoleLogOutput()],
+        _minLevel = minLevel,
+        _maxHistory = maxHistory;
 
   factory LoggingService({
     List<LogOutput>? outputs,
     LogLevel minLevel = LogLevel.debug,
+    int maxHistory = 2000,
   }) {
-    return LoggingService._(outputs: outputs, minLevel: minLevel);
+    return LoggingService._(
+      outputs: outputs,
+      minLevel: minLevel,
+      maxHistory: maxHistory,
+    );
   }
+
+  List<LogRecord> get history => List.unmodifiable(_history);
+
+  Iterable<LogRecord> getHistory({LogLevel? minLevel, DateTime? since}) {
+    return _history.where((record) {
+      final levelMatches =
+          minLevel == null || record.level.index >= minLevel.index;
+      final timestampMatches = since == null ||
+          record.timestamp.isAfter(since) ||
+          record.timestamp.isAtSameMomentAs(since);
+      return levelMatches && timestampMatches;
+    });
+  }
+
+  void clearHistory() => _history.clear();
 
   @override
   void log(LogLevel level, String message, [Map<String, dynamic>? context]) {
+    final record = LogRecord(
+      timestamp: DateTime.now(),
+      level: level,
+      message: message,
+      context: context == null ? null : Map.unmodifiable(context),
+    );
+
+    _history.add(record);
+    if (_history.length > _maxHistory) {
+      _history.removeRange(0, _history.length - _maxHistory);
+    }
+
     if (level.index >= _minLevel.index) {
       for (final output in _outputs) {
         output.write(level, message, context);

--- a/lib/features/media_library/data/repositories/file_operations_repository_impl.dart
+++ b/lib/features/media_library/data/repositories/file_operations_repository_impl.dart
@@ -1,39 +1,476 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:uuid/uuid.dart';
+
+import '../../../../core/error/app_error.dart';
 import '../../../../core/services/file_service.dart';
+import '../../../../core/services/logging_service.dart';
 import '../../../../core/services/permission_service.dart';
+import '../../domain/entities/file_rename_request.dart';
+import '../../domain/entities/trashed_item_entity.dart';
 import '../../domain/repositories/file_operations_repository.dart';
 
 /// Implementation of FileOperationsRepository
 class FileOperationsRepositoryImpl implements FileOperationsRepository {
-  const FileOperationsRepositoryImpl(
+  FileOperationsRepositoryImpl(
     this._fileService,
-    this._permissionService,
-  );
+    this._permissionService, [
+    LoggingService? logger,
+  ])  : _logger = logger ?? LoggingService.instance,
+        _uuid = const Uuid();
 
   final FileService _fileService;
   final PermissionService _permissionService;
+  final LoggingService _logger;
+  final Uuid _uuid;
+
+  static const _trashFolderName = '.mediafastview_trash';
+  static const _trashManifestName = '.manifest.json';
 
   @override
-  Future<void> deleteFile(String filePath) async {
-    await _permissionService.ensureStoragePermission();
-    await _permissionService.ensurePathAccessible(filePath);
-    await _fileService.deleteFile(filePath);
+  Future<void> deleteFile(String filePath, {String? bookmarkData}) async {
+    _logger.info('file_operation_delete_file_start', {
+      'path': filePath,
+    });
+
+    try {
+      await _permissionService.runWithBookmarkAccess<void>(
+        path: filePath,
+        bookmarkData: bookmarkData,
+        operation: 'delete_file',
+        action: (effectivePath) async {
+          await _permissionService.ensurePathAccessible(effectivePath);
+          await _fileService.deleteFile(effectivePath);
+        },
+      );
+
+      _logger.info('file_operation_delete_file_success', {
+        'path': filePath,
+      });
+    } catch (error, stackTrace) {
+      _logger.error('file_operation_delete_file_error', {
+        'path': filePath,
+        'error': error.toString(),
+        'stackTrace': stackTrace.toString(),
+      });
+      rethrow;
+    }
   }
 
   @override
-  Future<void> deleteDirectory(String directoryPath) async {
-    await _permissionService.ensureStoragePermission();
-    await _permissionService.ensurePathAccessible(directoryPath);
-    await _fileService.deleteDirectory(directoryPath);
+  Future<void> deleteDirectory(
+    String directoryPath, {
+    String? bookmarkData,
+  }) async {
+    _logger.info('file_operation_delete_directory_start', {
+      'path': directoryPath,
+    });
+
+    try {
+      await _permissionService.runWithBookmarkAccess<void>(
+        path: directoryPath,
+        bookmarkData: bookmarkData,
+        operation: 'delete_directory',
+        action: (effectivePath) async {
+          await _permissionService.ensurePathAccessible(effectivePath);
+          await _fileService.deleteDirectory(effectivePath);
+        },
+      );
+
+      _logger.info('file_operation_delete_directory_success', {
+        'path': directoryPath,
+      });
+    } catch (error, stackTrace) {
+      _logger.error('file_operation_delete_directory_error', {
+        'path': directoryPath,
+        'error': error.toString(),
+        'stackTrace': stackTrace.toString(),
+      });
+      rethrow;
+    }
   }
 
   @override
   Future<bool> validatePath(String path) async {
+    _logger.debug('file_operation_validate_path_start', {
+      'path': path,
+    });
+
     await _permissionService.ensureStoragePermission();
-    return await _permissionService.canAccessPath(path);
+    final isAccessible = await _permissionService.canAccessPath(path);
+
+    _logger.debug('file_operation_validate_path_result', {
+      'path': path,
+      'accessible': isAccessible,
+    });
+
+    return isAccessible;
   }
 
   @override
   String getFileType(String filePath) {
-    return _fileService.getMediaTypeFromExtension(filePath);
+    final type = _fileService.getMediaTypeFromExtension(filePath);
+    _logger.debug('file_operation_detect_type', {
+      'path': filePath,
+      'type': type,
+    });
+    return type;
+  }
+
+  @override
+  Future<List<String>> bulkRename(
+    List<FileRenameRequest> renameRequests, {
+    Map<String, String?>? bookmarkDataMap,
+  }) async {
+    if (renameRequests.isEmpty) {
+      return const [];
+    }
+
+    _logger.info('file_operation_bulk_rename_start', {
+      'count': renameRequests.length,
+    });
+
+    final renamedPaths = <String>[];
+
+    for (final request in renameRequests) {
+      final bookmark = bookmarkDataMap?[request.originalPath];
+      try {
+        final newPath = await _permissionService.runWithBookmarkAccess<String>(
+          path: request.originalPath,
+          bookmarkData: bookmark,
+          operation: 'bulk_rename',
+          action: (effectivePath) async {
+            final directoryPath = p.dirname(effectivePath);
+            await _permissionService.ensurePathAccessible(effectivePath);
+            await _permissionService.ensurePathWritable(directoryPath);
+
+            final currentExtension = p.extension(effectivePath);
+            final normalizedNewName =
+                _resolveNewName(request, currentExtension);
+            final destinationPath =
+                p.join(directoryPath, normalizedNewName);
+
+            _logger.debug('file_operation_rename_attempt', {
+              'source': effectivePath,
+              'destination': destinationPath,
+            });
+
+            return _fileService.renameEntity(effectivePath, destinationPath);
+          },
+        );
+
+        renamedPaths.add(newPath);
+        _logger.info('file_operation_rename_success', {
+          'originalPath': request.originalPath,
+          'newPath': newPath,
+        });
+      } catch (error, stackTrace) {
+        _logger.error('file_operation_rename_error', {
+          'originalPath': request.originalPath,
+          'error': error.toString(),
+          'stackTrace': stackTrace.toString(),
+        });
+        rethrow;
+      }
+    }
+
+    return renamedPaths;
+  }
+
+  @override
+  Future<List<String>> moveToFolder(
+    List<String> paths,
+    String destinationDirectory, {
+    Map<String, String?>? bookmarkDataMap,
+    bool createIfMissing = true,
+  }) async {
+    if (paths.isEmpty) {
+      return const [];
+    }
+
+    _logger.info('file_operation_move_start', {
+      'count': paths.length,
+      'destination': destinationDirectory,
+    });
+
+    final destinationBookmark = bookmarkDataMap?[destinationDirectory];
+    final resolvedDestination = await _permissionService
+        .runWithBookmarkAccess<String>(
+      path: destinationDirectory,
+      bookmarkData: destinationBookmark,
+      operation: 'move_to_folder_destination',
+      action: (effectiveDestination) async {
+        final exists = await _fileService.exists(effectiveDestination);
+        if (!exists) {
+          if (!createIfMissing) {
+            throw DirectoryNotFoundError(
+              'Destination directory does not exist: $effectiveDestination',
+            );
+          }
+          await _fileService.ensureDirectoryExists(effectiveDestination);
+        } else {
+          await _permissionService.ensurePathAccessible(effectiveDestination);
+        }
+
+        await _permissionService.ensurePathWritable(effectiveDestination);
+        return effectiveDestination;
+      },
+    );
+
+    final movedPaths = <String>[];
+
+    for (final path in paths) {
+      final bookmark = bookmarkDataMap?[path];
+      try {
+        final movedPath = await _permissionService.runWithBookmarkAccess<String>(
+          path: path,
+          bookmarkData: bookmark,
+          operation: 'move_to_folder',
+          action: (effectivePath) async {
+            await _permissionService.ensurePathAccessible(effectivePath);
+            final targetPath = await _fileService.moveEntityToDirectory(
+              effectivePath,
+              resolvedDestination,
+            );
+            return targetPath;
+          },
+        );
+
+        movedPaths.add(movedPath);
+        _logger.info('file_operation_move_success', {
+          'source': path,
+          'destination': movedPath,
+        });
+      } catch (error, stackTrace) {
+        _logger.error('file_operation_move_error', {
+          'source': path,
+          'destinationDirectory': destinationDirectory,
+          'error': error.toString(),
+          'stackTrace': stackTrace.toString(),
+        });
+        rethrow;
+      }
+    }
+
+    return movedPaths;
+  }
+
+  @override
+  Future<List<TrashedItemEntity>> moveToTrash(
+    List<String> paths, {
+    Map<String, String?>? bookmarkDataMap,
+    String? trashDirectory,
+  }) async {
+    if (paths.isEmpty) {
+      return const [];
+    }
+
+    _logger.info('file_operation_trash_start', {
+      'count': paths.length,
+      'customTrash': trashDirectory,
+    });
+
+    final trashedItems = <TrashedItemEntity>[];
+    final manifestUpdates = <String, List<TrashedItemEntity>>{};
+
+    for (final path in paths) {
+      final bookmark = bookmarkDataMap?[path];
+      try {
+        final trashedItem = await _permissionService
+            .runWithBookmarkAccess<TrashedItemEntity>(
+          path: path,
+          bookmarkData: bookmark,
+          operation: 'move_to_trash',
+          action: (effectivePath) async {
+            final parentDirectory = p.dirname(effectivePath);
+            await _permissionService.ensurePathAccessible(effectivePath);
+            await _permissionService.ensurePathWritable(parentDirectory);
+
+            final resolvedTrashDirectory = trashDirectory ??
+                p.join(parentDirectory, _trashFolderName);
+
+            await _fileService.ensureDirectoryExists(resolvedTrashDirectory);
+            await _permissionService.ensurePathWritable(resolvedTrashDirectory);
+            final trashedPath = await _fileService.moveToTrash(
+              effectivePath,
+              resolvedTrashDirectory,
+            );
+
+            final item = TrashedItemEntity(
+              id: _uuid.v4(),
+              originalPath: effectivePath,
+              trashedPath: trashedPath,
+              trashedAt: DateTime.now(),
+              bookmarkData: bookmark,
+            );
+
+            manifestUpdates
+                .putIfAbsent(resolvedTrashDirectory, () => [])
+                .add(item);
+
+            return item;
+          },
+        );
+
+        trashedItems.add(trashedItem);
+        _logger.info('file_operation_trash_success', {
+          'originalPath': path,
+          'trashedPath': trashedItem.trashedPath,
+        });
+      } catch (error, stackTrace) {
+        _logger.error('file_operation_trash_error', {
+          'path': path,
+          'error': error.toString(),
+          'stackTrace': stackTrace.toString(),
+        });
+        rethrow;
+      }
+    }
+
+    for (final entry in manifestUpdates.entries) {
+      final existing = await _readTrashManifest(entry.key);
+      final updated = [...existing, ...entry.value];
+      await _writeTrashManifest(entry.key, updated);
+    }
+
+    return trashedItems;
+  }
+
+  @override
+  Future<void> restoreFromTrash(
+    List<TrashedItemEntity> items, {
+    Map<String, String?>? bookmarkDataMap,
+  }) async {
+    if (items.isEmpty) {
+      return;
+    }
+
+    _logger.info('file_operation_restore_start', {
+      'count': items.length,
+    });
+
+    final manifestRemovals = <String, Set<String>>{};
+
+    for (final item in items) {
+      final bookmark =
+          bookmarkDataMap?[item.originalPath] ?? item.bookmarkData;
+      try {
+        await _permissionService.runWithBookmarkAccess<void>(
+          path: item.originalPath,
+          bookmarkData: bookmark,
+          operation: 'restore_from_trash',
+          action: (resolvedOriginalPath) async {
+            final parentDirectory = p.dirname(resolvedOriginalPath);
+            await _fileService.ensureDirectoryExists(parentDirectory);
+            await _permissionService.ensurePathWritable(parentDirectory);
+
+            final existsInTrash = await _fileService.exists(item.trashedPath);
+            if (!existsInTrash) {
+              throw TrashItemNotFoundError(
+                'Trashed item missing: ${item.trashedPath}',
+              );
+            }
+
+            await _permissionService.ensurePathAccessible(item.trashedPath);
+
+            await _fileService.moveEntity(
+              item.trashedPath,
+              resolvedOriginalPath,
+            );
+
+            manifestRemovals
+                .putIfAbsent(p.dirname(item.trashedPath), () => <String>{})
+                .add(item.id);
+          },
+        );
+
+        _logger.info('file_operation_restore_success', {
+          'originalPath': item.originalPath,
+        });
+      } catch (error, stackTrace) {
+        _logger.error('file_operation_restore_error', {
+          'originalPath': item.originalPath,
+          'error': error.toString(),
+          'stackTrace': stackTrace.toString(),
+        });
+        rethrow;
+      }
+    }
+
+    for (final entry in manifestRemovals.entries) {
+      final existing = await _readTrashManifest(entry.key);
+      final remaining = existing
+          .where((item) => !entry.value.contains(item.id))
+          .toList();
+      await _writeTrashManifest(entry.key, remaining);
+    }
+  }
+
+  String _resolveNewName(
+    FileRenameRequest request,
+    String currentExtension,
+  ) {
+    if (!request.preserveExtension || currentExtension.isEmpty) {
+      return request.newName;
+    }
+
+    if (request.newName.toLowerCase().endsWith(
+          currentExtension.toLowerCase(),
+        )) {
+      return request.newName;
+    }
+
+    return '${request.newName}$currentExtension';
+  }
+
+  Future<List<TrashedItemEntity>> _readTrashManifest(String trashDirectory) async {
+    final manifestFile = File(_manifestPath(trashDirectory));
+    if (!await manifestFile.exists()) {
+      return [];
+    }
+
+    try {
+      final raw = await manifestFile.readAsString();
+      if (raw.trim().isEmpty) {
+        return [];
+      }
+
+      final decoded = jsonDecode(raw) as List<dynamic>;
+      return decoded
+          .map((item) => TrashedItemEntity.fromJson(
+                Map<String, dynamic>.from(item as Map<dynamic, dynamic>),
+              ))
+          .toList();
+    } catch (error) {
+      _logger.warning('file_operation_trash_manifest_read_error', {
+        'trashDirectory': trashDirectory,
+        'error': error.toString(),
+      });
+      return [];
+    }
+  }
+
+  Future<void> _writeTrashManifest(
+    String trashDirectory,
+    List<TrashedItemEntity> items,
+  ) async {
+    await _fileService.ensureDirectoryExists(trashDirectory);
+    final manifestFile = File(_manifestPath(trashDirectory));
+    final payload = jsonEncode(
+      items.map((item) => item.toJson()).toList(),
+    );
+
+    await manifestFile.writeAsString(payload, flush: true);
+
+    _logger.debug('file_operation_trash_manifest_written', {
+      'trashDirectory': trashDirectory,
+      'entries': items.length,
+    });
+  }
+
+  String _manifestPath(String trashDirectory) {
+    return p.join(trashDirectory, _trashManifestName);
   }
 }

--- a/lib/features/media_library/domain/entities/file_rename_request.dart
+++ b/lib/features/media_library/domain/entities/file_rename_request.dart
@@ -1,0 +1,11 @@
+class FileRenameRequest {
+  const FileRenameRequest({
+    required this.originalPath,
+    required this.newName,
+    this.preserveExtension = true,
+  });
+
+  final String originalPath;
+  final String newName;
+  final bool preserveExtension;
+}

--- a/lib/features/media_library/domain/entities/trashed_item_entity.dart
+++ b/lib/features/media_library/domain/entities/trashed_item_entity.dart
@@ -1,0 +1,51 @@
+class TrashedItemEntity {
+  const TrashedItemEntity({
+    required this.id,
+    required this.originalPath,
+    required this.trashedPath,
+    required this.trashedAt,
+    this.bookmarkData,
+  });
+
+  final String id;
+  final String originalPath;
+  final String trashedPath;
+  final DateTime trashedAt;
+  final String? bookmarkData;
+
+  TrashedItemEntity copyWith({
+    String? id,
+    String? originalPath,
+    String? trashedPath,
+    DateTime? trashedAt,
+    String? bookmarkData,
+  }) {
+    return TrashedItemEntity(
+      id: id ?? this.id,
+      originalPath: originalPath ?? this.originalPath,
+      trashedPath: trashedPath ?? this.trashedPath,
+      trashedAt: trashedAt ?? this.trashedAt,
+      bookmarkData: bookmarkData ?? this.bookmarkData,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'originalPath': originalPath,
+      'trashedPath': trashedPath,
+      'trashedAt': trashedAt.toIso8601String(),
+      'bookmarkData': bookmarkData,
+    };
+  }
+
+  factory TrashedItemEntity.fromJson(Map<String, dynamic> json) {
+    return TrashedItemEntity(
+      id: json['id'] as String,
+      originalPath: json['originalPath'] as String,
+      trashedPath: json['trashedPath'] as String,
+      trashedAt: DateTime.parse(json['trashedAt'] as String),
+      bookmarkData: json['bookmarkData'] as String?,
+    );
+  }
+}

--- a/lib/features/media_library/domain/repositories/file_operations_repository.dart
+++ b/lib/features/media_library/domain/repositories/file_operations_repository.dart
@@ -1,14 +1,44 @@
+import '../entities/file_rename_request.dart';
+import '../entities/trashed_item_entity.dart';
+
 /// Repository interface for file operations
 abstract class FileOperationsRepository {
   /// Deletes a file from the filesystem
-  Future<void> deleteFile(String filePath);
+  Future<void> deleteFile(String filePath, {String? bookmarkData});
 
   /// Deletes a directory and all its contents from the filesystem
-  Future<void> deleteDirectory(String directoryPath);
+  Future<void> deleteDirectory(String directoryPath, {String? bookmarkData});
 
   /// Validates if a path is accessible
   Future<bool> validatePath(String path);
 
   /// Gets file type from extension
   String getFileType(String filePath);
+
+  /// Renames multiple files or directories in bulk.
+  Future<List<String>> bulkRename(
+    List<FileRenameRequest> renameRequests, {
+    Map<String, String?>? bookmarkDataMap,
+  });
+
+  /// Moves multiple items to a destination directory.
+  Future<List<String>> moveToFolder(
+    List<String> paths,
+    String destinationDirectory, {
+    Map<String, String?>? bookmarkDataMap,
+    bool createIfMissing = true,
+  });
+
+  /// Moves multiple items to a reversible trash location.
+  Future<List<TrashedItemEntity>> moveToTrash(
+    List<String> paths, {
+    Map<String, String?>? bookmarkDataMap,
+    String? trashDirectory,
+  });
+
+  /// Restores trashed items back to their original locations.
+  Future<void> restoreFromTrash(
+    List<TrashedItemEntity> items, {
+    Map<String, String?>? bookmarkDataMap,
+  });
 }

--- a/lib/features/media_library/domain/use_cases/bulk_rename_use_case.dart
+++ b/lib/features/media_library/domain/use_cases/bulk_rename_use_case.dart
@@ -1,0 +1,19 @@
+import '../entities/file_rename_request.dart';
+import '../repositories/file_operations_repository.dart';
+
+/// Use case for renaming multiple files or directories at once.
+class BulkRenameUseCase {
+  const BulkRenameUseCase(this._repository);
+
+  final FileOperationsRepository _repository;
+
+  Future<List<String>> call(
+    List<FileRenameRequest> requests, {
+    Map<String, String?>? bookmarkDataMap,
+  }) {
+    return _repository.bulkRename(
+      requests,
+      bookmarkDataMap: bookmarkDataMap,
+    );
+  }
+}

--- a/lib/features/media_library/domain/use_cases/delete_directory_use_case.dart
+++ b/lib/features/media_library/domain/use_cases/delete_directory_use_case.dart
@@ -7,6 +7,9 @@ class DeleteDirectoryUseCase {
   final FileOperationsRepository _repository;
 
   /// Executes the use case to delete a directory recursively
-  Future<void> call(String directoryPath) =>
-      _repository.deleteDirectory(directoryPath);
+  Future<void> call(String directoryPath, {String? bookmarkData}) =>
+      _repository.deleteDirectory(
+        directoryPath,
+        bookmarkData: bookmarkData,
+      );
 }

--- a/lib/features/media_library/domain/use_cases/delete_file_use_case.dart
+++ b/lib/features/media_library/domain/use_cases/delete_file_use_case.dart
@@ -7,5 +7,6 @@ class DeleteFileUseCase {
   final FileOperationsRepository _repository;
 
   /// Executes the use case to delete a file
-  Future<void> call(String filePath) => _repository.deleteFile(filePath);
+  Future<void> call(String filePath, {String? bookmarkData}) =>
+      _repository.deleteFile(filePath, bookmarkData: bookmarkData);
 }

--- a/lib/features/media_library/domain/use_cases/move_to_folder_use_case.dart
+++ b/lib/features/media_library/domain/use_cases/move_to_folder_use_case.dart
@@ -1,0 +1,22 @@
+import '../repositories/file_operations_repository.dart';
+
+/// Use case for moving multiple items to a destination folder.
+class MoveToFolderUseCase {
+  const MoveToFolderUseCase(this._repository);
+
+  final FileOperationsRepository _repository;
+
+  Future<List<String>> call(
+    List<String> paths,
+    String destinationDirectory, {
+    Map<String, String?>? bookmarkDataMap,
+    bool createIfMissing = true,
+  }) {
+    return _repository.moveToFolder(
+      paths,
+      destinationDirectory,
+      bookmarkDataMap: bookmarkDataMap,
+      createIfMissing: createIfMissing,
+    );
+  }
+}

--- a/lib/features/media_library/domain/use_cases/move_to_trash_use_case.dart
+++ b/lib/features/media_library/domain/use_cases/move_to_trash_use_case.dart
@@ -1,0 +1,21 @@
+import '../entities/trashed_item_entity.dart';
+import '../repositories/file_operations_repository.dart';
+
+/// Use case for moving items to the reversible trash.
+class MoveToTrashUseCase {
+  const MoveToTrashUseCase(this._repository);
+
+  final FileOperationsRepository _repository;
+
+  Future<List<TrashedItemEntity>> call(
+    List<String> paths, {
+    Map<String, String?>? bookmarkDataMap,
+    String? trashDirectory,
+  }) {
+    return _repository.moveToTrash(
+      paths,
+      bookmarkDataMap: bookmarkDataMap,
+      trashDirectory: trashDirectory,
+    );
+  }
+}

--- a/lib/features/media_library/domain/use_cases/restore_from_trash_use_case.dart
+++ b/lib/features/media_library/domain/use_cases/restore_from_trash_use_case.dart
@@ -1,0 +1,19 @@
+import '../entities/trashed_item_entity.dart';
+import '../repositories/file_operations_repository.dart';
+
+/// Use case for restoring items from the reversible trash.
+class RestoreFromTrashUseCase {
+  const RestoreFromTrashUseCase(this._repository);
+
+  final FileOperationsRepository _repository;
+
+  Future<void> call(
+    List<TrashedItemEntity> items, {
+    Map<String, String?>? bookmarkDataMap,
+  }) {
+    return _repository.restoreFromTrash(
+      items,
+      bookmarkDataMap: bookmarkDataMap,
+    );
+  }
+}

--- a/lib/features/media_library/presentation/view_models/file_operations_view_model.dart
+++ b/lib/features/media_library/presentation/view_models/file_operations_view_model.dart
@@ -1,8 +1,14 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../shared/providers/repository_providers.dart';
+import '../../domain/entities/file_rename_request.dart';
+import '../../domain/entities/trashed_item_entity.dart';
+import '../../domain/use_cases/bulk_rename_use_case.dart';
 import '../../domain/use_cases/delete_directory_use_case.dart';
 import '../../domain/use_cases/delete_file_use_case.dart';
+import '../../domain/use_cases/move_to_folder_use_case.dart';
+import '../../domain/use_cases/move_to_trash_use_case.dart';
+import '../../domain/use_cases/restore_from_trash_use_case.dart';
 import '../../domain/use_cases/validate_path_use_case.dart';
 
 /// State for file operations
@@ -36,17 +42,25 @@ class FileOperationsViewModel extends StateNotifier<FileOperationsState> {
     this._deleteFileUseCase,
     this._deleteDirectoryUseCase,
     this._validatePathUseCase,
+    this._bulkRenameUseCase,
+    this._moveToFolderUseCase,
+    this._moveToTrashUseCase,
+    this._restoreFromTrashUseCase,
   ) : super(const FileOperationsInitial());
 
   final DeleteFileUseCase _deleteFileUseCase;
   final DeleteDirectoryUseCase _deleteDirectoryUseCase;
   final ValidatePathUseCase _validatePathUseCase;
+  final BulkRenameUseCase _bulkRenameUseCase;
+  final MoveToFolderUseCase _moveToFolderUseCase;
+  final MoveToTrashUseCase _moveToTrashUseCase;
+  final RestoreFromTrashUseCase _restoreFromTrashUseCase;
 
   /// Deletes a file
-  Future<void> deleteFile(String filePath) async {
+  Future<void> deleteFile(String filePath, {String? bookmarkData}) async {
     state = const FileOperationsLoading();
     try {
-      await _deleteFileUseCase(filePath);
+      await _deleteFileUseCase(filePath, bookmarkData: bookmarkData);
       state = FileOperationsSuccess('File deleted successfully');
     } catch (e) {
       state = FileOperationsError(e.toString());
@@ -54,10 +68,16 @@ class FileOperationsViewModel extends StateNotifier<FileOperationsState> {
   }
 
   /// Deletes a directory recursively
-  Future<void> deleteDirectory(String directoryPath) async {
+  Future<void> deleteDirectory(
+    String directoryPath, {
+    String? bookmarkData,
+  }) async {
     state = const FileOperationsLoading();
     try {
-      await _deleteDirectoryUseCase(directoryPath);
+      await _deleteDirectoryUseCase(
+        directoryPath,
+        bookmarkData: bookmarkData,
+      );
       state = FileOperationsSuccess('Directory deleted successfully');
     } catch (e) {
       state = FileOperationsError(e.toString());
@@ -70,6 +90,99 @@ class FileOperationsViewModel extends StateNotifier<FileOperationsState> {
       return await _validatePathUseCase(path);
     } catch (e) {
       return false;
+    }
+  }
+
+  /// Renames multiple files or directories.
+  Future<List<String>> bulkRename(
+    List<FileRenameRequest> requests, {
+    Map<String, String?>? bookmarkDataMap,
+  }) async {
+    if (requests.isEmpty) {
+      return const [];
+    }
+    state = const FileOperationsLoading();
+    try {
+      final result = await _bulkRenameUseCase(
+        requests,
+        bookmarkDataMap: bookmarkDataMap,
+      );
+      state = FileOperationsSuccess('Renamed ${result.length} item(s)');
+      return result;
+    } catch (e) {
+      state = FileOperationsError(e.toString());
+      rethrow;
+    }
+  }
+
+  /// Moves items to a destination folder.
+  Future<List<String>> moveToFolder(
+    List<String> paths,
+    String destinationDirectory, {
+    Map<String, String?>? bookmarkDataMap,
+    bool createIfMissing = true,
+  }) async {
+    if (paths.isEmpty) {
+      return const [];
+    }
+    state = const FileOperationsLoading();
+    try {
+      final result = await _moveToFolderUseCase(
+        paths,
+        destinationDirectory,
+        bookmarkDataMap: bookmarkDataMap,
+        createIfMissing: createIfMissing,
+      );
+      state = FileOperationsSuccess('Moved ${result.length} item(s)');
+      return result;
+    } catch (e) {
+      state = FileOperationsError(e.toString());
+      rethrow;
+    }
+  }
+
+  /// Moves items to the reversible trash.
+  Future<List<TrashedItemEntity>> moveToTrash(
+    List<String> paths, {
+    Map<String, String?>? bookmarkDataMap,
+    String? trashDirectory,
+  }) async {
+    if (paths.isEmpty) {
+      return const [];
+    }
+    state = const FileOperationsLoading();
+    try {
+      final result = await _moveToTrashUseCase(
+        paths,
+        bookmarkDataMap: bookmarkDataMap,
+        trashDirectory: trashDirectory,
+      );
+      state = FileOperationsSuccess('Trashed ${result.length} item(s)');
+      return result;
+    } catch (e) {
+      state = FileOperationsError(e.toString());
+      rethrow;
+    }
+  }
+
+  /// Restores items from the reversible trash.
+  Future<void> restoreFromTrash(
+    List<TrashedItemEntity> items, {
+    Map<String, String?>? bookmarkDataMap,
+  }) async {
+    if (items.isEmpty) {
+      return;
+    }
+    state = const FileOperationsLoading();
+    try {
+      await _restoreFromTrashUseCase(
+        items,
+        bookmarkDataMap: bookmarkDataMap,
+      );
+      state = FileOperationsSuccess('Restored ${items.length} item(s)');
+    } catch (e) {
+      state = FileOperationsError(e.toString());
+      rethrow;
     }
   }
 
@@ -89,5 +202,9 @@ final fileOperationsViewModelProvider =
         ref.watch(deleteFileUseCaseProvider),
         ref.watch(deleteDirectoryUseCaseProvider),
         ref.watch(validatePathUseCaseProvider),
+        ref.watch(bulkRenameUseCaseProvider),
+        ref.watch(moveToFolderUseCaseProvider),
+        ref.watch(moveToTrashUseCaseProvider),
+        ref.watch(restoreFromTrashUseCaseProvider),
       ),
     );

--- a/lib/shared/providers/repository_providers.dart
+++ b/lib/shared/providers/repository_providers.dart
@@ -20,11 +20,15 @@ import '../../features/media_library/domain/repositories/directory_repository.da
 import '../../features/media_library/domain/repositories/file_operations_repository.dart';
 import '../../features/media_library/domain/repositories/media_repository.dart';
 import '../../features/media_library/domain/use_cases/add_directory_use_case.dart';
+import '../../features/media_library/domain/use_cases/bulk_rename_use_case.dart';
 import '../../features/media_library/domain/use_cases/clear_directories_use_case.dart';
 import '../../features/media_library/domain/use_cases/delete_directory_use_case.dart';
 import '../../features/media_library/domain/use_cases/delete_file_use_case.dart';
 import '../../features/media_library/domain/use_cases/get_directories_use_case.dart';
+import '../../features/media_library/domain/use_cases/move_to_folder_use_case.dart';
+import '../../features/media_library/domain/use_cases/move_to_trash_use_case.dart';
 import '../../features/media_library/domain/use_cases/remove_directory_use_case.dart';
+import '../../features/media_library/domain/use_cases/restore_from_trash_use_case.dart';
 import '../../features/media_library/domain/use_cases/search_directories_use_case.dart';
 import '../../features/media_library/domain/use_cases/validate_path_use_case.dart';
 import '../../features/tagging/domain/use_cases/get_tags_use_case.dart';
@@ -202,6 +206,23 @@ final deleteDirectoryUseCaseProvider = Provider<DeleteDirectoryUseCase>((ref) {
 
 final validatePathUseCaseProvider = Provider<ValidatePathUseCase>((ref) {
   return ValidatePathUseCase(ref.watch(fileOperationsRepositoryProvider));
+});
+
+final bulkRenameUseCaseProvider = Provider<BulkRenameUseCase>((ref) {
+  return BulkRenameUseCase(ref.watch(fileOperationsRepositoryProvider));
+});
+
+final moveToFolderUseCaseProvider = Provider<MoveToFolderUseCase>((ref) {
+  return MoveToFolderUseCase(ref.watch(fileOperationsRepositoryProvider));
+});
+
+final moveToTrashUseCaseProvider = Provider<MoveToTrashUseCase>((ref) {
+  return MoveToTrashUseCase(ref.watch(fileOperationsRepositoryProvider));
+});
+
+final restoreFromTrashUseCaseProvider =
+    Provider<RestoreFromTrashUseCase>((ref) {
+  return RestoreFromTrashUseCase(ref.watch(fileOperationsRepositoryProvider));
 });
 // Tag use case providers
 final getTagsUseCaseProvider = Provider<GetTagsUseCase>((ref) {


### PR DESCRIPTION
## Summary
- add bulk rename, move to folder, and reversible trash flows with security-scoped bookmark handling
- persist trash metadata and expose new domain entities/use cases for advanced file operations
- extend logging and permission services to retain audit history and wrap bookmark access for every action

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e6b7c6dc108320ac72463e755651d4