### PR TITLE
Add shuffle mode and duration controls to favorites slideshow

### DIFF
--- a/lib/features/favorites/presentation/screens/slideshow_screen.dart
+++ b/lib/features/favorites/presentation/screens/slideshow_screen.dart
@@ -151,6 +151,8 @@ class _SlideshowScreenState extends ConsumerState<SlideshowScreen> {
                 onPrevious: viewModel.previousItem,
                 onToggleLoop: viewModel.toggleLoop,
                 onToggleMute: viewModel.toggleMute,
+                onToggleShuffle: viewModel.toggleShuffle,
+                onDurationChanged: _handleDurationChange,
               ),
 
               const SizedBox(height: 16),
@@ -221,6 +223,14 @@ class _SlideshowScreenState extends ConsumerState<SlideshowScreen> {
     }
   }
 
+  void _handleDurationChange(double seconds) {
+    final viewModel = ref.read(
+      slideshowViewModelProvider(widget.mediaList).notifier,
+    );
+    final duration = Duration(milliseconds: (seconds * 1000).round());
+    viewModel.updateDisplayDuration(duration);
+  }
+
   KeyEventResult _handleKeyEvent(FocusNode node, KeyEvent event) {
     if (event is! KeyDownEvent) return KeyEventResult.ignored;
 
@@ -252,6 +262,10 @@ class _SlideshowScreenState extends ConsumerState<SlideshowScreen> {
 
       case LogicalKeyboardKey.keyM:
         viewModel.toggleMute();
+        return KeyEventResult.handled;
+
+      case LogicalKeyboardKey.keyS:
+        viewModel.toggleShuffle();
         return KeyEventResult.handled;
 
       default:


### PR DESCRIPTION
## Summary
- add shuffle and slide duration controls to the slideshow overlay
- extend the slideshow view model with shuffle ordering and configurable image timing
- expose the new controls through the fullscreen slideshow screen and keyboard shortcut

## Testing
- not run (environment lacks Flutter/Dart tooling)

------
https://chatgpt.com/codex/tasks/task_e_68e9164c977c8320bd8767554eee35c5