### PR TITLE
Persist macOS directory bookmarks across sessions

### DIFF
--- a/test/features/media_library/data/repositories/directory_repository_impl_test.dart
+++ b/test/features/media_library/data/repositories/directory_repository_impl_test.dart
@@ -26,6 +26,10 @@ void main() {
       permissionService = MockPermissionService();
       mediaDataSource = MockSharedPreferencesMediaDataSource();
 
+      when(bookmarkService.ensurePersistentAccess(any)).thenAnswer((_) async => null);
+      when(bookmarkService.releasePersistentAccess(any)).thenAnswer((_) async {});
+      when(bookmarkService.releaseAllPersistentAccesses()).thenAnswer((_) async {});
+
       repository = DirectoryRepositoryImpl(
         directoryDataSource,
         localDirectoryDataSource,

--- a/test/mocks.mocks.dart
+++ b/test/mocks.mocks.dart
@@ -1131,6 +1131,32 @@ class MockBookmarkService extends _i1.Mock implements _i22.BookmarkService {
             ),
           )
           as _i6.Future<String>);
+
+  @override
+  _i6.Future<String?> ensurePersistentAccess(String? bookmarkData) =>
+      (super.noSuchMethod(
+            Invocation.method(#ensurePersistentAccess, [bookmarkData]),
+            returnValue: _i6.Future<String?>.value(),
+            returnValueForMissingStub: _i6.Future<String?>.value(),
+          )
+          as _i6.Future<String?>);
+
+  @override
+  _i6.Future<void> releasePersistentAccess(String? bookmarkData) =>
+      (super.noSuchMethod(
+            Invocation.method(#releasePersistentAccess, [bookmarkData]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> releaseAllPersistentAccesses() => (super.noSuchMethod(
+            Invocation.method(#releaseAllPersistentAccesses, []),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
 }
 
 /// A class which mocks [SharedPreferences].


### PR DESCRIPTION
## Summary
- keep macOS security-scoped bookmarks active across app launches
- update directory repository logic to reuse and release persistent bookmark sessions
- adjust mocks and tests to accommodate the new bookmark persistence APIs

## Testing
- not run (flutter/dart tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e92602e8cc8320a5c3d073ced586d6