### PR TITLE
Persist grid column selection across screens

### DIFF
--- a/lib/core/config/app_config.dart
+++ b/lib/core/config/app_config.dart
@@ -45,8 +45,8 @@ class AppConfig {
 
   /// Initialize the configuration system with SharedPreferences.
   /// Must be called before accessing any configuration values.
-  static Future<void> init() async {
-    _prefs = await SharedPreferences.getInstance();
+  static Future<void> init({SharedPreferences? sharedPreferences}) async {
+    _prefs = sharedPreferences ?? await SharedPreferences.getInstance();
   }
 
   /// Get the number of grid columns.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'core/config/app_config.dart';
 import 'shared/providers/repository_providers.dart';
 import 'shared/providers/theme_provider.dart';
 import 'shared/widgets/error_boundary.dart';
@@ -10,6 +11,7 @@ import 'shared/widgets/main_navigation.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   final sharedPreferences = await SharedPreferences.getInstance();
+  await AppConfig.init(sharedPreferences: sharedPreferences);
 
   runApp(ProviderScope(
     overrides: [

--- a/lib/shared/providers/grid_columns_provider.dart
+++ b/lib/shared/providers/grid_columns_provider.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/config/app_config.dart';
+
+/// Manages the grid column count across the application and persists changes.
+class GridColumnsNotifier extends StateNotifier<int> {
+  GridColumnsNotifier() : super(AppConfig.gridColumns);
+
+  /// Updates the column count and persists the new value.
+  void setColumns(int columns) {
+    final clampedColumns = columns.clamp(2, 12).toInt();
+    if (state == clampedColumns) {
+      return;
+    }
+
+    state = clampedColumns;
+    AppConfig.gridColumns = clampedColumns;
+  }
+}
+
+/// Provider exposing the shared grid column count.
+final gridColumnsProvider =
+    StateNotifierProvider<GridColumnsNotifier, int>((ref) {
+  return GridColumnsNotifier();
+});


### PR DESCRIPTION
## Summary
- add a shared grid column notifier backed by AppConfig persistence
- update directory and media grid view models to listen to the shared column count
- expose column switching in the Tags tab and initialize AppConfig during app startup

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e92a8312288320b02dcc7621e751ca