### PR TITLE
Add sorting controls for media library grids

### DIFF
--- a/lib/features/media_library/presentation/screens/directory_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/directory_grid_screen.dart
@@ -34,6 +34,12 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
   Widget build(BuildContext context) {
     final state = ref.watch(directoryViewModelProvider);
     final viewModel = ref.read(directoryViewModelProvider.notifier);
+    final currentSortOption = switch (state) {
+      DirectoryLoaded(:final sortOption) => sortOption,
+      DirectoryPermissionRevoked(:final sortOption) => sortOption,
+      DirectoryBookmarkInvalid(:final sortOption) => sortOption,
+      _ => viewModel.currentSortOption,
+    };
 
     return Scaffold(
       appBar: AppBar(
@@ -46,6 +52,19 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
           IconButton(
             icon: const Icon(Icons.tag),
             onPressed: () => TagCreationDialog.show(context),
+          ),
+          PopupMenuButton<DirectorySortOption>(
+            icon: const Icon(Icons.sort),
+            tooltip: 'Sort',
+            onSelected: viewModel.changeSortOption,
+            itemBuilder: (context) => [
+              for (final option in DirectorySortOption.values)
+                CheckedPopupMenuItem<DirectorySortOption>(
+                  value: option,
+                  checked: option == currentSortOption,
+                  child: Text(option.label),
+                ),
+            ],
           ),
           IconButton(
             icon: const Icon(Icons.view_module),

--- a/lib/features/media_library/presentation/screens/media_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/media_grid_screen.dart
@@ -59,6 +59,9 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
     );
     final state = ref.watch(mediaViewModelProvider(_params!));
     _viewModel = ref.read(mediaViewModelProvider(_params!).notifier);
+    final sortOption = state is MediaLoaded
+        ? state.sortOption
+        : _viewModel?.currentSortOption ?? MediaSortOption.nameAscending;
 
     return Scaffold(
       appBar: AppBar(
@@ -68,6 +71,19 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
                icon: const Icon(Icons.tag),
                tooltip: 'Manage Tags',
                onPressed: () => TagManagementDialog.show(context),
+             ),
+             PopupMenuButton<MediaSortOption>(
+               icon: const Icon(Icons.sort),
+               tooltip: 'Sort',
+               onSelected: _viewModel!.changeSortOption,
+               itemBuilder: (context) => [
+                 for (final option in MediaSortOption.values)
+                   CheckedPopupMenuItem<MediaSortOption>(
+                     value: option,
+                     checked: option == sortOption,
+                     child: Text(option.label),
+                   ),
+               ],
              ),
              IconButton(
                icon: const Icon(Icons.view_module),

--- a/lib/features/media_library/presentation/view_models/directory_grid_view_model.dart
+++ b/lib/features/media_library/presentation/view_models/directory_grid_view_model.dart
@@ -14,6 +14,21 @@ import '../../domain/use_cases/get_directories_use_case.dart';
 import '../../domain/use_cases/remove_directory_use_case.dart';
 import '../../domain/use_cases/search_directories_use_case.dart';
 
+/// Defines the available sort options for directory listings.
+enum DirectorySortOption {
+  nameAscending,
+  nameDescending,
+  lastModifiedDescending,
+}
+
+extension DirectorySortOptionX on DirectorySortOption {
+  String get label => switch (this) {
+        DirectorySortOption.nameAscending => 'Name (A-Z)',
+        DirectorySortOption.nameDescending => 'Name (Z-A)',
+        DirectorySortOption.lastModifiedDescending => 'Last Modified',
+      };
+}
+
 /// Sealed class representing the state of the directory grid.
 sealed class DirectoryState {
   const DirectoryState();
@@ -31,24 +46,28 @@ class DirectoryLoaded extends DirectoryState {
     required this.searchQuery,
     required this.selectedTagIds,
     required this.columns,
+    required this.sortOption,
   });
 
   final List<DirectoryEntity> directories;
   final String searchQuery;
   final List<String> selectedTagIds;
   final int columns;
+  final DirectorySortOption sortOption;
 
   DirectoryLoaded copyWith({
     List<DirectoryEntity>? directories,
     String? searchQuery,
     List<String>? selectedTagIds,
     int? columns,
+    DirectorySortOption? sortOption,
   }) {
     return DirectoryLoaded(
       directories: directories ?? this.directories,
       searchQuery: searchQuery ?? this.searchQuery,
       selectedTagIds: selectedTagIds ?? this.selectedTagIds,
       columns: columns ?? this.columns,
+      sortOption: sortOption ?? this.sortOption,
     );
   }
 }
@@ -73,6 +92,7 @@ class DirectoryPermissionRevoked extends DirectoryState {
     required this.searchQuery,
     required this.selectedTagIds,
     required this.columns,
+    required this.sortOption,
   });
 
   final List<DirectoryEntity> inaccessibleDirectories;
@@ -80,6 +100,7 @@ class DirectoryPermissionRevoked extends DirectoryState {
   final String searchQuery;
   final List<String> selectedTagIds;
   final int columns;
+  final DirectorySortOption sortOption;
 
   DirectoryPermissionRevoked copyWith({
     List<DirectoryEntity>? inaccessibleDirectories,
@@ -87,6 +108,7 @@ class DirectoryPermissionRevoked extends DirectoryState {
     String? searchQuery,
     List<String>? selectedTagIds,
     int? columns,
+    DirectorySortOption? sortOption,
   }) {
     return DirectoryPermissionRevoked(
       inaccessibleDirectories: inaccessibleDirectories ?? this.inaccessibleDirectories,
@@ -94,6 +116,7 @@ class DirectoryPermissionRevoked extends DirectoryState {
       searchQuery: searchQuery ?? this.searchQuery,
       selectedTagIds: selectedTagIds ?? this.selectedTagIds,
       columns: columns ?? this.columns,
+      sortOption: sortOption ?? this.sortOption,
     );
   }
 }
@@ -106,6 +129,7 @@ class DirectoryBookmarkInvalid extends DirectoryState {
     required this.searchQuery,
     required this.selectedTagIds,
     required this.columns,
+    required this.sortOption,
   });
 
   final List<DirectoryEntity> invalidDirectories;
@@ -113,6 +137,7 @@ class DirectoryBookmarkInvalid extends DirectoryState {
   final String searchQuery;
   final List<String> selectedTagIds;
   final int columns;
+  final DirectorySortOption sortOption;
 
   DirectoryBookmarkInvalid copyWith({
     List<DirectoryEntity>? invalidDirectories,
@@ -120,6 +145,7 @@ class DirectoryBookmarkInvalid extends DirectoryState {
     String? searchQuery,
     List<String>? selectedTagIds,
     int? columns,
+    DirectorySortOption? sortOption,
   }) {
     return DirectoryBookmarkInvalid(
       invalidDirectories: invalidDirectories ?? this.invalidDirectories,
@@ -127,6 +153,7 @@ class DirectoryBookmarkInvalid extends DirectoryState {
       searchQuery: searchQuery ?? this.searchQuery,
       selectedTagIds: selectedTagIds ?? this.selectedTagIds,
       columns: columns ?? this.columns,
+      sortOption: sortOption ?? this.sortOption,
     );
   }
 }
@@ -174,6 +201,9 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
   String _currentSearchQuery = '';
   List<String> _currentSelectedTagIds = const <String>[];
   late int _currentColumns;
+  DirectorySortOption _currentSortOption = DirectorySortOption.nameAscending;
+
+  DirectorySortOption get currentSortOption => _currentSortOption;
 
   @override
   void dispose() {
@@ -349,6 +379,10 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
       _currentSearchQuery,
     );
 
+    final sortedAccessible = _sortDirectories(filteredAccessible);
+    final sortedInaccessible = _sortDirectories(filteredInaccessible);
+    final sortedInvalid = _sortDirectories(filteredInvalid);
+
     if (_cachedAccessibleDirectories.isEmpty &&
         _cachedInaccessibleDirectories.isEmpty &&
         _cachedInvalidDirectories.isEmpty) {
@@ -358,31 +392,34 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
 
     if (_cachedInvalidDirectories.isNotEmpty) {
       state = DirectoryBookmarkInvalid(
-        invalidDirectories: filteredInvalid,
-        accessibleDirectories: filteredAccessible,
+        invalidDirectories: sortedInvalid,
+        accessibleDirectories: sortedAccessible,
         searchQuery: _currentSearchQuery,
         selectedTagIds: _currentSelectedTagIds,
         columns: _currentColumns,
+        sortOption: _currentSortOption,
       );
       return;
     }
 
     if (_cachedInaccessibleDirectories.isNotEmpty) {
       state = DirectoryPermissionRevoked(
-        inaccessibleDirectories: filteredInaccessible,
-        accessibleDirectories: filteredAccessible,
+        inaccessibleDirectories: sortedInaccessible,
+        accessibleDirectories: sortedAccessible,
         searchQuery: _currentSearchQuery,
         selectedTagIds: _currentSelectedTagIds,
         columns: _currentColumns,
+        sortOption: _currentSortOption,
       );
       return;
     }
 
     state = DirectoryLoaded(
-      directories: filteredAccessible,
+      directories: sortedAccessible,
       searchQuery: _currentSearchQuery,
       selectedTagIds: _currentSelectedTagIds,
       columns: _currentColumns,
+      sortOption: _currentSortOption,
     );
   }
 
@@ -509,6 +546,35 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
       LoggingService.instance.error('Error validating directory ${directory.path}: $e');
       rethrow;
     }
+  }
+
+  /// Updates the sort option and reapplies sorting to the current state.
+  void changeSortOption(DirectorySortOption option) {
+    if (_currentSortOption == option) {
+      return;
+    }
+    _currentSortOption = option;
+    _emitFilteredState();
+  }
+
+  List<DirectoryEntity> _sortDirectories(List<DirectoryEntity> directories) {
+    final sorted = List<DirectoryEntity>.from(directories);
+    switch (_currentSortOption) {
+      case DirectorySortOption.nameAscending:
+        sorted.sort(
+          (a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()),
+        );
+        break;
+      case DirectorySortOption.nameDescending:
+        sorted.sort(
+          (a, b) => b.name.toLowerCase().compareTo(a.name.toLowerCase()),
+        );
+        break;
+      case DirectorySortOption.lastModifiedDescending:
+        sorted.sort((a, b) => b.lastModified.compareTo(a.lastModified));
+        break;
+    }
+    return sorted;
   }
 }
 

--- a/lib/features/media_library/presentation/view_models/directory_grid_view_model.dart
+++ b/lib/features/media_library/presentation/view_models/directory_grid_view_model.dart
@@ -19,13 +19,15 @@ enum DirectorySortOption {
   nameAscending,
   nameDescending,
   lastModifiedDescending,
+  lastModifiedAscending,
 }
 
 extension DirectorySortOptionX on DirectorySortOption {
   String get label => switch (this) {
         DirectorySortOption.nameAscending => 'Name (A-Z)',
         DirectorySortOption.nameDescending => 'Name (Z-A)',
-        DirectorySortOption.lastModifiedDescending => 'Last Modified',
+        DirectorySortOption.lastModifiedDescending => 'Last Modified (Newest)',
+        DirectorySortOption.lastModifiedAscending => 'Last Modified (Oldest)',
       };
 }
 
@@ -572,6 +574,9 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
         break;
       case DirectorySortOption.lastModifiedDescending:
         sorted.sort((a, b) => b.lastModified.compareTo(a.lastModified));
+        break;
+      case DirectorySortOption.lastModifiedAscending:
+        sorted.sort((a, b) => a.lastModified.compareTo(b.lastModified));
         break;
     }
     return sorted;

--- a/lib/features/media_library/presentation/view_models/media_grid_view_model.dart
+++ b/lib/features/media_library/presentation/view_models/media_grid_view_model.dart
@@ -18,6 +18,7 @@ enum MediaSortOption {
   nameAscending,
   nameDescending,
   lastModifiedDescending,
+  lastModifiedAscending,
   sizeDescending,
 }
 
@@ -25,7 +26,8 @@ extension MediaSortOptionX on MediaSortOption {
   String get label => switch (this) {
         MediaSortOption.nameAscending => 'Name (A-Z)',
         MediaSortOption.nameDescending => 'Name (Z-A)',
-        MediaSortOption.lastModifiedDescending => 'Last Modified',
+        MediaSortOption.lastModifiedDescending => 'Last Modified (Newest)',
+        MediaSortOption.lastModifiedAscending => 'Last Modified (Oldest)',
         MediaSortOption.sizeDescending => 'Size',
       };
 }
@@ -508,6 +510,9 @@ class MediaViewModel extends StateNotifier<MediaState> {
         break;
       case MediaSortOption.lastModifiedDescending:
         sorted.sort((a, b) => b.lastModified.compareTo(a.lastModified));
+        break;
+      case MediaSortOption.lastModifiedAscending:
+        sorted.sort((a, b) => a.lastModified.compareTo(b.lastModified));
         break;
       case MediaSortOption.sizeDescending:
         sorted.sort((a, b) => b.size.compareTo(a.size));

--- a/lib/features/media_library/presentation/widgets/directory_search_bar.dart
+++ b/lib/features/media_library/presentation/widgets/directory_search_bar.dart
@@ -12,7 +12,12 @@ class DirectorySearchBar extends ConsumerWidget {
     final state = ref.watch(directoryViewModelProvider);
     final viewModel = ref.read(directoryViewModelProvider.notifier);
 
-    final searchQuery = state is DirectoryLoaded ? state.searchQuery : '';
+    final searchQuery = switch (state) {
+      DirectoryLoaded(:final searchQuery) => searchQuery,
+      DirectoryPermissionRevoked(:final searchQuery) => searchQuery,
+      DirectoryBookmarkInvalid(:final searchQuery) => searchQuery,
+      _ => '',
+    };
 
     return Padding(
       padding: const EdgeInsets.all(16),


### PR DESCRIPTION
## Summary
- add reusable sorting options to the directory view model and expose the current selection in UI
- provide popup menu sort controls for directories and media along with state updates to reflect the chosen order
- introduce media sorting (name, date, size) with cached lists so search and tag filters respect the selected ordering

## Testing
- Unable to run tests locally (Flutter tooling is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e96af7640c8320beff9417875fcfa4