### PR TITLE
Add sorting controls for media and directory grids

### DIFF
--- a/lib/features/media_library/presentation/screens/directory_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/directory_grid_screen.dart
@@ -34,6 +34,12 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
   Widget build(BuildContext context) {
     final state = ref.watch(directoryViewModelProvider);
     final viewModel = ref.read(directoryViewModelProvider.notifier);
+    final currentSortOption = switch (state) {
+      DirectoryLoaded(:final sortOption) => sortOption,
+      DirectoryPermissionRevoked(:final sortOption) => sortOption,
+      DirectoryBookmarkInvalid(:final sortOption) => sortOption,
+      _ => DirectorySortOption.nameAscending,
+    };
 
     return Scaffold(
       appBar: AppBar(
@@ -46,6 +52,34 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
           IconButton(
             icon: const Icon(Icons.tag),
             onPressed: () => TagCreationDialog.show(context),
+          ),
+          PopupMenuButton<DirectorySortOption>(
+            icon: const Icon(Icons.sort),
+            tooltip: 'Sort directories',
+            initialValue: currentSortOption,
+            onSelected: viewModel.sortDirectories,
+            itemBuilder: (context) {
+              return DirectorySortOption.values.map((option) {
+                final isSelected = option == currentSortOption;
+                return PopupMenuItem<DirectorySortOption>(
+                  value: option,
+                  child: Row(
+                    children: [
+                      if (isSelected)
+                        Icon(
+                          Icons.check,
+                          size: UiSizing.iconSmall,
+                          color: Theme.of(context).colorScheme.primary,
+                        )
+                      else
+                        const SizedBox(width: UiSizing.iconSmall),
+                      SizedBox(width: UiSpacing.smallGap),
+                      Text(option.label),
+                    ],
+                  ),
+                );
+              }).toList();
+            },
           ),
           IconButton(
             icon: const Icon(Icons.view_module),

--- a/lib/features/media_library/presentation/screens/media_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/media_grid_screen.dart
@@ -59,6 +59,9 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
     );
     final state = ref.watch(mediaViewModelProvider(_params!));
     _viewModel = ref.read(mediaViewModelProvider(_params!).notifier);
+    final currentSortOption = state is MediaLoaded
+        ? state.sortOption
+        : MediaSortOption.nameAscending;
 
     return Scaffold(
       appBar: AppBar(
@@ -68,6 +71,34 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
                icon: const Icon(Icons.tag),
                tooltip: 'Manage Tags',
                onPressed: () => TagManagementDialog.show(context),
+             ),
+             PopupMenuButton<MediaSortOption>(
+               icon: const Icon(Icons.sort),
+               tooltip: 'Sort media',
+               initialValue: currentSortOption,
+               onSelected: _viewModel!.sortMedia,
+               itemBuilder: (context) {
+                 return MediaSortOption.values.map((option) {
+                   final isSelected = option == currentSortOption;
+                   return PopupMenuItem<MediaSortOption>(
+                     value: option,
+                     child: Row(
+                       children: [
+                         if (isSelected)
+                           Icon(
+                             Icons.check,
+                             size: UiSizing.iconSmall,
+                             color: Theme.of(context).colorScheme.primary,
+                           )
+                         else
+                           const SizedBox(width: UiSizing.iconSmall),
+                         SizedBox(width: UiSpacing.smallGap),
+                         Text(option.label),
+                       ],
+                     ),
+                   );
+                 }).toList();
+               },
              ),
              IconButton(
                icon: const Icon(Icons.view_module),

--- a/lib/features/media_library/presentation/widgets/directory_search_bar.dart
+++ b/lib/features/media_library/presentation/widgets/directory_search_bar.dart
@@ -12,7 +12,12 @@ class DirectorySearchBar extends ConsumerWidget {
     final state = ref.watch(directoryViewModelProvider);
     final viewModel = ref.read(directoryViewModelProvider.notifier);
 
-    final searchQuery = state is DirectoryLoaded ? state.searchQuery : '';
+    final searchQuery = switch (state) {
+      DirectoryLoaded(:final searchQuery) => searchQuery,
+      DirectoryPermissionRevoked(:final searchQuery) => searchQuery,
+      DirectoryBookmarkInvalid(:final searchQuery) => searchQuery,
+      _ => '',
+    };
 
     return Padding(
       padding: const EdgeInsets.all(16),


### PR DESCRIPTION
## Summary
- add directory sort options and ensure grid state applies sorting alongside search/tag filters
- cache media results, expose sort options, and update media grid UI with sort controls
- keep directory search text when permissions/bookmark dialogs are active for a smoother UX

## Testing
- not run (flutter tooling not available in execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e96af7640c8320beff9417875fcfa4