### PR TITLE
Add sorting controls for media library views

### DIFF
--- a/lib/features/media_library/domain/use_cases/sort_directories_use_case.dart
+++ b/lib/features/media_library/domain/use_cases/sort_directories_use_case.dart
@@ -1,0 +1,29 @@
+import '../entities/directory_entity.dart';
+import '../value_objects/sort_option.dart';
+
+/// Use case responsible for sorting directories using the provided option.
+class SortDirectoriesUseCase {
+  const SortDirectoriesUseCase();
+
+  /// Returns a new list of directories sorted according to [option].
+  List<DirectoryEntity> call(
+    List<DirectoryEntity> directories,
+    DirectorySortOption option,
+  ) {
+    final sortedDirectories = List<DirectoryEntity>.from(directories);
+    sortedDirectories.sort((a, b) {
+      final comparison = switch (option.field) {
+        DirectorySortField.name => a.name.toLowerCase().compareTo(
+              b.name.toLowerCase(),
+            ),
+        DirectorySortField.lastModified => a.lastModified.compareTo(
+              b.lastModified,
+            ),
+      };
+
+      return option.order == SortOrder.ascending ? comparison : -comparison;
+    });
+
+    return sortedDirectories;
+  }
+}

--- a/lib/features/media_library/domain/use_cases/sort_media_use_case.dart
+++ b/lib/features/media_library/domain/use_cases/sort_media_use_case.dart
@@ -1,0 +1,30 @@
+import '../entities/media_entity.dart';
+import '../value_objects/sort_option.dart';
+
+/// Use case responsible for sorting media items using the provided option.
+class SortMediaUseCase {
+  const SortMediaUseCase();
+
+  /// Returns a new list of media items sorted according to [option].
+  List<MediaEntity> call(
+    List<MediaEntity> media,
+    MediaSortOption option,
+  ) {
+    final sortedMedia = List<MediaEntity>.from(media);
+    sortedMedia.sort((a, b) {
+      final comparison = switch (option.field) {
+        MediaSortField.name => a.name.toLowerCase().compareTo(
+              b.name.toLowerCase(),
+            ),
+        MediaSortField.lastModified => a.lastModified.compareTo(
+              b.lastModified,
+            ),
+        MediaSortField.size => a.size.compareTo(b.size),
+      };
+
+      return option.order == SortOrder.ascending ? comparison : -comparison;
+    });
+
+    return sortedMedia;
+  }
+}

--- a/lib/features/media_library/domain/value_objects/sort_option.dart
+++ b/lib/features/media_library/domain/value_objects/sort_option.dart
@@ -1,0 +1,138 @@
+/// Represents the order a collection should be sorted in.
+enum SortOrder { ascending, descending }
+
+/// Available fields for sorting directories.
+enum DirectorySortField { name, lastModified }
+
+/// Available fields for sorting media items.
+enum MediaSortField { name, lastModified, size }
+
+/// Defines how directories should be sorted.
+class DirectorySortOption {
+  const DirectorySortOption({
+    required this.field,
+    required this.order,
+  });
+
+  final DirectorySortField field;
+  final SortOrder order;
+
+  DirectorySortOption copyWith({
+    DirectorySortField? field,
+    SortOrder? order,
+  }) {
+    return DirectorySortOption(
+      field: field ?? this.field,
+      order: order ?? this.order,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is DirectorySortOption &&
+        other.field == field &&
+        other.order == order;
+  }
+
+  @override
+  int get hashCode => Object.hash(field, order);
+
+  static const DirectorySortOption nameAscending = DirectorySortOption(
+    field: DirectorySortField.name,
+    order: SortOrder.ascending,
+  );
+
+  static const DirectorySortOption nameDescending = DirectorySortOption(
+    field: DirectorySortField.name,
+    order: SortOrder.descending,
+  );
+
+  static const DirectorySortOption lastModifiedNewestFirst =
+      DirectorySortOption(
+    field: DirectorySortField.lastModified,
+    order: SortOrder.descending,
+  );
+
+  static const DirectorySortOption lastModifiedOldestFirst =
+      DirectorySortOption(
+    field: DirectorySortField.lastModified,
+    order: SortOrder.ascending,
+  );
+
+  static const List<DirectorySortOption> values = <DirectorySortOption>[
+    nameAscending,
+    nameDescending,
+    lastModifiedNewestFirst,
+    lastModifiedOldestFirst,
+  ];
+}
+
+/// Defines how media should be sorted.
+class MediaSortOption {
+  const MediaSortOption({
+    required this.field,
+    required this.order,
+  });
+
+  final MediaSortField field;
+  final SortOrder order;
+
+  MediaSortOption copyWith({
+    MediaSortField? field,
+    SortOrder? order,
+  }) {
+    return MediaSortOption(
+      field: field ?? this.field,
+      order: order ?? this.order,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is MediaSortOption &&
+        other.field == field &&
+        other.order == order;
+  }
+
+  @override
+  int get hashCode => Object.hash(field, order);
+
+  static const MediaSortOption nameAscending = MediaSortOption(
+    field: MediaSortField.name,
+    order: SortOrder.ascending,
+  );
+
+  static const MediaSortOption nameDescending = MediaSortOption(
+    field: MediaSortField.name,
+    order: SortOrder.descending,
+  );
+
+  static const MediaSortOption lastModifiedNewestFirst = MediaSortOption(
+    field: MediaSortField.lastModified,
+    order: SortOrder.descending,
+  );
+
+  static const MediaSortOption lastModifiedOldestFirst = MediaSortOption(
+    field: MediaSortField.lastModified,
+    order: SortOrder.ascending,
+  );
+
+  static const MediaSortOption sizeLargestFirst = MediaSortOption(
+    field: MediaSortField.size,
+    order: SortOrder.descending,
+  );
+
+  static const MediaSortOption sizeSmallestFirst = MediaSortOption(
+    field: MediaSortField.size,
+    order: SortOrder.ascending,
+  );
+
+  static const List<MediaSortOption> values = <MediaSortOption>[
+    nameAscending,
+    nameDescending,
+    lastModifiedNewestFirst,
+    lastModifiedOldestFirst,
+    sizeLargestFirst,
+    sizeSmallestFirst,
+  ];
+}

--- a/lib/features/media_library/presentation/screens/directory_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/directory_grid_screen.dart
@@ -17,6 +17,7 @@ import '../widgets/directory_grid_item.dart';
 import '../widgets/directory_search_bar.dart';
 import '../widgets/column_selector_popup.dart';
 import 'media_grid_screen.dart';
+import '../../domain/value_objects/sort_option.dart';
 
 /// Screen for displaying directories in a customizable grid layout.
 class DirectoryGridScreen extends ConsumerStatefulWidget {
@@ -46,6 +47,37 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
           IconButton(
             icon: const Icon(Icons.tag),
             onPressed: () => TagCreationDialog.show(context),
+          ),
+          PopupMenuButton<DirectorySortOption>(
+            icon: const Icon(Icons.sort),
+            tooltip: 'Sort directories',
+            initialValue: viewModel.sortOption,
+            onSelected: viewModel.setSortOption,
+            itemBuilder: (context) {
+              final current = viewModel.sortOption;
+              return DirectorySortOption.values
+                  .map(
+                    (option) => PopupMenuItem<DirectorySortOption>(
+                      value: option,
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          if (option == current)
+                            Icon(
+                              Icons.check,
+                              size: 18,
+                              color: Theme.of(context).colorScheme.primary,
+                            )
+                          else
+                            const SizedBox(width: 18),
+                          const SizedBox(width: 8),
+                          Text(_describeDirectorySortOption(option)),
+                        ],
+                      ),
+                    ),
+                  )
+                  .toList();
+            },
           ),
           IconButton(
             icon: const Icon(Icons.view_module),
@@ -133,6 +165,17 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
         ),
       ),
     );
+  }
+
+  String _describeDirectorySortOption(DirectorySortOption option) {
+    return switch (option.field) {
+      DirectorySortField.name => option.order == SortOrder.ascending
+          ? 'Name (A-Z)'
+          : 'Name (Z-A)',
+      DirectorySortField.lastModified => option.order == SortOrder.descending
+          ? 'Last Modified (Newest)'
+          : 'Last Modified (Oldest)',
+    };
   }
 
   void _onDragDone(DropDoneDetails details, DirectoryViewModel viewModel) {

--- a/lib/features/media_library/presentation/screens/media_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/media_grid_screen.dart
@@ -13,6 +13,7 @@ import '../../domain/entities/media_entity.dart';
 import '../view_models/media_grid_view_model.dart';
 import '../widgets/media_grid_item.dart';
 import '../widgets/column_selector_popup.dart';
+import '../../domain/value_objects/sort_option.dart';
 
 /// Screen for displaying media in a customizable grid layout.
 class MediaGridScreen extends ConsumerStatefulWidget {
@@ -69,6 +70,37 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
                tooltip: 'Manage Tags',
                onPressed: () => TagManagementDialog.show(context),
              ),
+             PopupMenuButton<MediaSortOption>(
+               icon: const Icon(Icons.sort),
+               tooltip: 'Sort media',
+               initialValue: _viewModel?.sortOption,
+               onSelected: _viewModel!.setSortOption,
+               itemBuilder: (context) {
+                 final current = _viewModel?.sortOption ?? MediaSortOption.nameAscending;
+                 return MediaSortOption.values
+                     .map(
+                       (option) => PopupMenuItem<MediaSortOption>(
+                         value: option,
+                         child: Row(
+                           mainAxisSize: MainAxisSize.min,
+                           children: [
+                             if (option == current)
+                               Icon(
+                                 Icons.check,
+                                 size: 18,
+                                 color: Theme.of(context).colorScheme.primary,
+                               )
+                             else
+                               const SizedBox(width: 18),
+                             const SizedBox(width: 8),
+                             Text(_describeMediaSortOption(option)),
+                           ],
+                         ),
+                       ),
+                     )
+                     .toList();
+               },
+             ),
              IconButton(
                icon: const Icon(Icons.view_module),
                onPressed: () => _showColumnSelector(context),
@@ -112,6 +144,20 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
         maxChipsToShow: UiGrid.maxFilterChips, // Limit to prevent overflow
       ),
     );
+  }
+
+  String _describeMediaSortOption(MediaSortOption option) {
+    return switch (option.field) {
+      MediaSortField.name => option.order == SortOrder.ascending
+          ? 'Name (A-Z)'
+          : 'Name (Z-A)',
+      MediaSortField.lastModified => option.order == SortOrder.descending
+          ? 'Last Modified (Newest)'
+          : 'Last Modified (Oldest)',
+      MediaSortField.size => option.order == SortOrder.descending
+          ? 'Size (Largest)'
+          : 'Size (Smallest)',
+    };
   }
 
   Widget _buildGrid(

--- a/lib/shared/providers/repository_providers.dart
+++ b/lib/shared/providers/repository_providers.dart
@@ -26,6 +26,8 @@ import '../../features/media_library/domain/use_cases/delete_file_use_case.dart'
 import '../../features/media_library/domain/use_cases/get_directories_use_case.dart';
 import '../../features/media_library/domain/use_cases/remove_directory_use_case.dart';
 import '../../features/media_library/domain/use_cases/search_directories_use_case.dart';
+import '../../features/media_library/domain/use_cases/sort_directories_use_case.dart';
+import '../../features/media_library/domain/use_cases/sort_media_use_case.dart';
 import '../../features/media_library/domain/use_cases/validate_path_use_case.dart';
 import '../../features/tagging/domain/use_cases/get_tags_use_case.dart';
 import '../../features/tagging/domain/use_cases/assign_tag_use_case.dart';
@@ -176,6 +178,10 @@ final searchDirectoriesUseCaseProvider = Provider<SearchDirectoriesUseCase>((
   return const SearchDirectoriesUseCase();
 });
 
+final sortDirectoriesUseCaseProvider = Provider<SortDirectoriesUseCase>((ref) {
+  return const SortDirectoriesUseCase();
+});
+
 final addDirectoryUseCaseProvider = Provider<AddDirectoryUseCase>((ref) {
   return AddDirectoryUseCase(ref.watch(directoryRepositoryProvider));
 });
@@ -198,6 +204,10 @@ final deleteFileUseCaseProvider = Provider<DeleteFileUseCase>((ref) {
 
 final deleteDirectoryUseCaseProvider = Provider<DeleteDirectoryUseCase>((ref) {
   return DeleteDirectoryUseCase(ref.watch(fileOperationsRepositoryProvider));
+});
+
+final sortMediaUseCaseProvider = Provider<SortMediaUseCase>((ref) {
+  return const SortMediaUseCase();
 });
 
 final validatePathUseCaseProvider = Provider<ValidatePathUseCase>((ref) {


### PR DESCRIPTION
## Summary
- add shared sort option value objects and domain use cases for directories and media
- integrate sorting state into directory and media view models with Riverpod providers
- expose sort controls in the directory and media grid screens with name, last-modified, and size presets

## Testing
- No automated tests were run (not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e96af7640c8320beff9417875fcfa4