### PR TITLE
Add sorting controls to media and directory grids

### DIFF
--- a/lib/features/media_library/presentation/screens/directory_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/directory_grid_screen.dart
@@ -13,9 +13,11 @@ import '../../../tagging/presentation/view_models/tag_management_view_model.dart
 import '../../../tagging/presentation/widgets/tag_creation_dialog.dart';
 import '../../domain/entities/directory_entity.dart';
 import '../view_models/directory_grid_view_model.dart';
+import '../view_models/library_sort_option.dart';
 import '../widgets/directory_grid_item.dart';
 import '../widgets/directory_search_bar.dart';
 import '../widgets/column_selector_popup.dart';
+import '../widgets/library_sort_menu_button.dart';
 import 'media_grid_screen.dart';
 
 /// Screen for displaying directories in a customizable grid layout.
@@ -34,11 +36,28 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
   Widget build(BuildContext context) {
     final state = ref.watch(directoryViewModelProvider);
     final viewModel = ref.read(directoryViewModelProvider.notifier);
+    final sortOption = switch (state) {
+      DirectoryLoaded(:final sortOption) => sortOption,
+      DirectoryPermissionRevoked(:final sortOption) => sortOption,
+      DirectoryBookmarkInvalid(:final sortOption) => sortOption,
+      _ => LibrarySortOption.nameAscending,
+    };
+    final isSortEnabled = switch (state) {
+      DirectoryLoaded() => true,
+      DirectoryPermissionRevoked() => true,
+      DirectoryBookmarkInvalid() => true,
+      _ => false,
+    };
 
     return Scaffold(
       appBar: AppBar(
         title: const Text('Directories'),
         actions: [
+          LibrarySortMenuButton(
+            selectedOption: sortOption,
+            onSelected: viewModel.changeSortOption,
+            enabled: isSortEnabled,
+          ),
           IconButton(
             icon: const Icon(Icons.add),
             onPressed: () => _showAddDirectoryDialog(context, ref),

--- a/lib/features/media_library/presentation/screens/media_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/media_grid_screen.dart
@@ -11,8 +11,10 @@ import '../../../tagging/presentation/widgets/tag_filter_chips.dart';
 import '../../../tagging/presentation/widgets/tag_management_dialog.dart';
 import '../../domain/entities/media_entity.dart';
 import '../view_models/media_grid_view_model.dart';
+import '../view_models/library_sort_option.dart';
 import '../widgets/media_grid_item.dart';
 import '../widgets/column_selector_popup.dart';
+import '../widgets/library_sort_menu_button.dart';
 
 /// Screen for displaying media in a customizable grid layout.
 class MediaGridScreen extends ConsumerStatefulWidget {
@@ -59,11 +61,20 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
     );
     final state = ref.watch(mediaViewModelProvider(_params!));
     _viewModel = ref.read(mediaViewModelProvider(_params!).notifier);
+    final sortOption = state is MediaLoaded
+        ? state.sortOption
+        : LibrarySortOption.nameAscending;
+    final isSortEnabled = state is MediaLoaded;
 
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.directoryName),
         actions: [
+             LibrarySortMenuButton(
+               selectedOption: sortOption,
+               onSelected: _viewModel!.changeSortOption,
+               enabled: isSortEnabled,
+             ),
              IconButton(
                icon: const Icon(Icons.tag),
                tooltip: 'Manage Tags',

--- a/lib/features/media_library/presentation/view_models/library_sort_option.dart
+++ b/lib/features/media_library/presentation/view_models/library_sort_option.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+/// Available sort options for library listings.
+enum LibrarySortOption {
+  nameAscending,
+  nameDescending,
+  lastModified,
+}
+
+extension LibrarySortOptionX on LibrarySortOption {
+  /// Display label for the sort option.
+  String get label => switch (this) {
+        LibrarySortOption.nameAscending => 'Name (A-Z)',
+        LibrarySortOption.nameDescending => 'Name (Z-A)',
+        LibrarySortOption.lastModified => 'Last Modified',
+      };
+
+  /// Icon associated with the sort option.
+  IconData get icon => switch (this) {
+        LibrarySortOption.nameAscending => Icons.sort_by_alpha,
+        LibrarySortOption.nameDescending => Icons.sort_by_alpha,
+        LibrarySortOption.lastModified => Icons.access_time,
+      };
+}

--- a/lib/features/media_library/presentation/widgets/library_sort_menu_button.dart
+++ b/lib/features/media_library/presentation/widgets/library_sort_menu_button.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+import '../view_models/library_sort_option.dart';
+
+/// Popup menu button for selecting library sort options.
+class LibrarySortMenuButton extends StatelessWidget {
+  const LibrarySortMenuButton({
+    super.key,
+    required this.selectedOption,
+    required this.onSelected,
+    this.enabled = true,
+  });
+
+  final LibrarySortOption selectedOption;
+  final ValueChanged<LibrarySortOption> onSelected;
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    return PopupMenuButton<LibrarySortOption>(
+      enabled: enabled,
+      tooltip: 'Sort',
+      initialValue: selectedOption,
+      icon: const Icon(Icons.sort),
+      onSelected: onSelected,
+      itemBuilder: (context) {
+        return LibrarySortOption.values
+            .map(
+              (option) => PopupMenuItem<LibrarySortOption>(
+                value: option,
+                child: Row(
+                  children: [
+                    Icon(option.icon),
+                    const SizedBox(width: 8),
+                    Text(option.label),
+                  ],
+                ),
+              ),
+            )
+            .toList();
+      },
+    );
+  }
+}

--- a/test/features/media_library/presentation/view_models/directory_grid_view_model_test.dart
+++ b/test/features/media_library/presentation/view_models/directory_grid_view_model_test.dart
@@ -8,6 +8,7 @@ import '../../../../../lib/features/media_library/domain/use_cases/get_directori
 import '../../../../../lib/features/media_library/domain/use_cases/remove_directory_use_case.dart';
 import '../../../../../lib/features/media_library/domain/use_cases/search_directories_use_case.dart';
 import '../../../../../lib/features/media_library/presentation/view_models/directory_grid_view_model.dart';
+import '../../../../../lib/features/media_library/presentation/view_models/library_sort_option.dart';
 import '../../../../../lib/features/media_library/data/data_sources/local_directory_data_source.dart';
 import '../../../../../lib/core/services/permission_service.dart';
 
@@ -159,6 +160,7 @@ void main() {
       expect(loadedState.directories.length, 1);
       expect(loadedState.directories.first.id, '1');
       expect(loadedState.selectedTagIds, ['tag1']);
+      expect(loadedState.sortOption, LibrarySortOption.nameAscending);
     });
   });
 }

--- a/test/providers/media_grid_view_model_test.dart
+++ b/test/providers/media_grid_view_model_test.dart
@@ -6,6 +6,7 @@ import 'package:mockito/mockito.dart';
 
 import 'package:media_fast_view/features/media_library/domain/entities/media_entity.dart';
 import 'package:media_fast_view/features/media_library/presentation/view_models/media_grid_view_model.dart';
+import 'package:media_fast_view/features/media_library/presentation/view_models/library_sort_option.dart';
 import '../mocks.mocks.dart';
 
 void main() {
@@ -95,6 +96,7 @@ void main() {
       expect(loadedState.columns, 3);
       expect(loadedState.currentDirectoryPath, testDirectoryPath);
       expect(loadedState.currentDirectoryName, testDirectoryName);
+      expect(loadedState.sortOption, LibrarySortOption.nameAscending);
 
       // Verify interactions
       verify(mockMediaRepository.getMediaForDirectoryPath(testDirectoryPath, bookmarkData: null)).called(1);
@@ -155,6 +157,7 @@ void main() {
       expect(loadedState.media.length, 1);
       expect(loadedState.media.first.name, 'image1.jpg');
       expect(loadedState.searchQuery, 'image');
+      expect(loadedState.sortOption, LibrarySortOption.nameAscending);
     });
 
     test('searchMedia with empty query returns all media', () async {
@@ -165,6 +168,7 @@ void main() {
       final loadedState = viewModel.state as MediaLoaded;
       expect(loadedState.media.length, 0);
       expect(loadedState.searchQuery, 'nonexistent');
+      expect(loadedState.sortOption, LibrarySortOption.nameAscending);
     });
 
     test('setColumns updates columns in state', () async {
@@ -207,10 +211,27 @@ void main() {
       expect(loadedState.media.length, 1);
       expect(loadedState.selectedTagIds, ['tag1']);
       expect(loadedState.searchQuery, ''); // Reset on filter
+      expect(loadedState.sortOption, LibrarySortOption.nameAscending);
 
       // Verify interactions
       verify(mockMediaRepository.filterMediaByTagsForDirectory(['tag1'], testDirectoryPath, bookmarkData: null)).called(1);
       // Note: saveMedia is not called when using mock repository
+    });
+
+    test('changeSortOption sorts media correctly', () async {
+      await viewModel.loadMedia();
+
+      viewModel.changeSortOption(LibrarySortOption.nameDescending);
+      expect(viewModel.state, isA<MediaLoaded>());
+      var loadedState = viewModel.state as MediaLoaded;
+      expect(loadedState.media.first.name, 'video1.mp4');
+      expect(loadedState.sortOption, LibrarySortOption.nameDescending);
+
+      viewModel.changeSortOption(LibrarySortOption.lastModified);
+      expect(viewModel.state, isA<MediaLoaded>());
+      loadedState = viewModel.state as MediaLoaded;
+      expect(loadedState.media.first.name, 'video1.mp4');
+      expect(loadedState.sortOption, LibrarySortOption.lastModified);
     });
 
     test('filterByTags with error transitions to MediaError', () async {


### PR DESCRIPTION
## Summary
- add reusable sort option definitions and popup menu for the media library
- enable sorting controls and state management for directories and media, including name and last modified ordering
- extend unit tests to cover new sorting behaviour and default sort selections

## Testing
- Not Run (environment lacks Flutter tooling)


------
https://chatgpt.com/codex/tasks/task_e_68e98460ea988320ae7834a7425d8234