### PR TITLE
feat: add sorting options for library media and directories

### DIFF
--- a/lib/features/media_library/presentation/screens/directory_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/directory_grid_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/constants/ui_constants.dart';
 
+import '../../../../shared/models/library_sort_option.dart';
 import '../../../../shared/providers/grid_columns_provider.dart';
 import '../../../../shared/providers/repository_providers.dart';
 import '../../../tagging/domain/entities/tag_entity.dart';
@@ -46,6 +47,30 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
           IconButton(
             icon: const Icon(Icons.tag),
             onPressed: () => TagCreationDialog.show(context),
+          ),
+          PopupMenuButton<LibrarySortOption>(
+            icon: const Icon(Icons.sort),
+            tooltip: 'Sort',
+            initialValue: viewModel.sortOption,
+            onSelected: viewModel.setSortOption,
+            itemBuilder: (context) {
+              return LibrarySortOption.values
+                  .map(
+                    (option) => PopupMenuItem<LibrarySortOption>(
+                      value: option,
+                      child: Row(
+                        children: [
+                          if (option == viewModel.sortOption)
+                            const Icon(Icons.check, size: 18),
+                          if (option == viewModel.sortOption)
+                            const SizedBox(width: 8),
+                          Text(option.label),
+                        ],
+                      ),
+                    ),
+                  )
+                  .toList();
+            },
           ),
           IconButton(
             icon: const Icon(Icons.view_module),

--- a/lib/features/media_library/presentation/screens/media_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/media_grid_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/config/app_config.dart';
 import '../../../../core/constants/ui_constants.dart';
+import '../../../../shared/models/library_sort_option.dart';
 import '../../../../shared/providers/grid_columns_provider.dart';
 
 import '../../../full_screen/presentation/screens/full_screen_viewer_screen.dart';
@@ -68,6 +69,31 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
                icon: const Icon(Icons.tag),
                tooltip: 'Manage Tags',
                onPressed: () => TagManagementDialog.show(context),
+             ),
+             PopupMenuButton<LibrarySortOption>(
+               icon: const Icon(Icons.sort),
+               tooltip: 'Sort',
+               initialValue: _viewModel?.sortOption ?? LibrarySortOption.nameAscending,
+               onSelected: _viewModel?.setSortOption,
+               itemBuilder: (context) {
+                 final current = _viewModel?.sortOption ?? LibrarySortOption.nameAscending;
+                 return LibrarySortOption.values
+                     .map(
+                       (option) => PopupMenuItem<LibrarySortOption>(
+                         value: option,
+                         child: Row(
+                           children: [
+                             if (option == current)
+                               const Icon(Icons.check, size: 18),
+                             if (option == current)
+                               const SizedBox(width: 8),
+                             Text(option.label),
+                           ],
+                         ),
+                       ),
+                     )
+                     .toList();
+               },
              ),
              IconButton(
                icon: const Icon(Icons.view_module),

--- a/lib/shared/models/library_sort_option.dart
+++ b/lib/shared/models/library_sort_option.dart
@@ -1,0 +1,20 @@
+/// Sorting options available for media library listings.
+enum LibrarySortOption {
+  nameAscending,
+  nameDescending,
+  lastModifiedDescending,
+}
+
+extension LibrarySortOptionX on LibrarySortOption {
+  /// Human-readable label for display in menus.
+  String get label {
+    switch (this) {
+      case LibrarySortOption.nameAscending:
+        return 'Name (A-Z)';
+      case LibrarySortOption.nameDescending:
+        return 'Name (Z-A)';
+      case LibrarySortOption.lastModifiedDescending:
+        return 'Last Modified';
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared library sort option enum for reuse across directory and media listings
- enhance directory and media grid view models to apply sorting and expose selection controls
- surface sort menus in both directory and media grid screens and extend tests for the new behaviour

## Testing
- flutter test *(fails: flutter executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e98460ea988320ae7834a7425d8234