### PR TITLE
Add sorting controls to library directories and media

### DIFF
--- a/lib/features/media_library/presentation/screens/media_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/media_grid_screen.dart
@@ -59,6 +59,9 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
     );
     final state = ref.watch(mediaViewModelProvider(_params!));
     _viewModel = ref.read(mediaViewModelProvider(_params!).notifier);
+    final sortOption = state is MediaLoaded
+        ? state.sortOption
+        : _viewModel!.currentSortOption;
 
     return Scaffold(
       appBar: AppBar(
@@ -68,6 +71,23 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
                icon: const Icon(Icons.tag),
                tooltip: 'Manage Tags',
                onPressed: () => TagManagementDialog.show(context),
+             ),
+             PopupMenuButton<MediaSortOption>(
+               tooltip: 'Sort',
+               initialValue: sortOption,
+               icon: const Icon(Icons.sort),
+               onSelected: _viewModel!.sortMedia,
+               itemBuilder: (context) {
+                 return MediaSortOption.values
+                     .map(
+                       (option) => CheckedPopupMenuItem<MediaSortOption>(
+                         value: option,
+                         checked: option == sortOption,
+                         child: Text(_mediaSortLabel(option)),
+                       ),
+                     )
+                     .toList();
+               },
              ),
              IconButton(
                icon: const Icon(Icons.view_module),
@@ -97,6 +117,19 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
         ],
       ),
     );
+  }
+
+  String _mediaSortLabel(MediaSortOption option) {
+    switch (option) {
+      case MediaSortOption.nameAscending:
+        return 'Name (A-Z)';
+      case MediaSortOption.nameDescending:
+        return 'Name (Z-A)';
+      case MediaSortOption.lastModifiedNewest:
+        return 'Last Modified (Newest)';
+      case MediaSortOption.lastModifiedOldest:
+        return 'Last Modified (Oldest)';
+    }
   }
 
   Widget _buildTagFilter(MediaViewModel viewModel, MediaState state) {


### PR DESCRIPTION
## Summary
- add sorting enums and state handling so directories and media can be ordered by name or last modified metadata
- expose sort pop-up menus on the directory and media grids to let users switch between the supported orders

## Testing
- not run (flutter command is not available in the container)

------
https://chatgpt.com/codex/tasks/task_e_68e98460ea988320ae7834a7425d8234