### PR TITLE
Add multi-selection state to media and directory view models

### DIFF
--- a/lib/features/media_library/presentation/view_models/directory_grid_view_model.dart
+++ b/lib/features/media_library/presentation/view_models/directory_grid_view_model.dart
@@ -24,11 +24,11 @@ enum DirectorySortOption {
 
 extension DirectorySortOptionX on DirectorySortOption {
   String get label => switch (this) {
-        DirectorySortOption.nameAscending => 'Name (A-Z)',
-        DirectorySortOption.nameDescending => 'Name (Z-A)',
-        DirectorySortOption.lastModifiedDescending => 'Last Modified (Newest)',
-        DirectorySortOption.lastModifiedAscending => 'Last Modified (Oldest)',
-      };
+    DirectorySortOption.nameAscending => 'Name (A-Z)',
+    DirectorySortOption.nameDescending => 'Name (Z-A)',
+    DirectorySortOption.lastModifiedDescending => 'Last Modified (Newest)',
+    DirectorySortOption.lastModifiedAscending => 'Last Modified (Oldest)',
+  };
 }
 
 /// Sealed class representing the state of the directory grid.
@@ -76,8 +76,7 @@ class DirectoryLoaded extends DirectoryState {
       selectedTagIds: selectedTagIds ?? this.selectedTagIds,
       columns: columns ?? this.columns,
       sortOption: sortOption ?? this.sortOption,
-      selectedDirectoryIds:
-          selectedDirectoryIds ?? this.selectedDirectoryIds,
+      selectedDirectoryIds: selectedDirectoryIds ?? this.selectedDirectoryIds,
       isSelectionMode: isSelectionMode ?? this.isSelectionMode,
     );
   }
@@ -136,8 +135,7 @@ class DirectoryPermissionRevoked extends DirectoryState {
       selectedTagIds: selectedTagIds ?? this.selectedTagIds,
       columns: columns ?? this.columns,
       sortOption: sortOption ?? this.sortOption,
-      selectedDirectoryIds:
-          selectedDirectoryIds ?? this.selectedDirectoryIds,
+      selectedDirectoryIds: selectedDirectoryIds ?? this.selectedDirectoryIds,
       isSelectionMode: isSelectionMode ?? this.isSelectionMode,
     );
   }
@@ -183,8 +181,7 @@ class DirectoryBookmarkInvalid extends DirectoryState {
       selectedTagIds: selectedTagIds ?? this.selectedTagIds,
       columns: columns ?? this.columns,
       sortOption: sortOption ?? this.sortOption,
-      selectedDirectoryIds:
-          selectedDirectoryIds ?? this.selectedDirectoryIds,
+      selectedDirectoryIds: selectedDirectoryIds ?? this.selectedDirectoryIds,
       isSelectionMode: isSelectionMode ?? this.isSelectionMode,
     );
   }
@@ -203,17 +200,15 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
     this._permissionService,
   ) : super(const DirectoryLoading()) {
     _currentColumns = _ref.read(gridColumnsProvider);
-    _gridColumnsSubscription = _ref.listen<int>(
-      gridColumnsProvider,
-      (_, next) {
-        _currentColumns = next;
-        if (state case DirectoryLoaded() ||
-            DirectoryPermissionRevoked() ||
-            DirectoryBookmarkInvalid()) {
-          _emitFilteredState();
-        }
-      },
-    );
+    _gridColumnsSubscription = _ref.listen<int>(gridColumnsProvider, (_, next) {
+      _currentColumns = next;
+      if (state
+          case DirectoryLoaded() ||
+              DirectoryPermissionRevoked() ||
+              DirectoryBookmarkInvalid()) {
+        _emitFilteredState();
+      }
+    });
     loadDirectories();
   }
 
@@ -238,7 +233,8 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
   bool _isSelectionMode = false;
 
   DirectorySortOption get currentSortOption => _currentSortOption;
-  Set<String> get selectedDirectoryIds => Set<String>.unmodifiable(_selectedDirectoryIds);
+  Set<String> get selectedDirectoryIds =>
+      Set<String>.unmodifiable(_selectedDirectoryIds);
   bool get isSelectionMode => _isSelectionMode;
   int get selectedDirectoryCount => _selectedDirectoryIds.length;
 
@@ -260,10 +256,16 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
   /// Selects a specific set of directory IDs. When [append] is true the IDs
   /// are merged with the existing selection, otherwise the selection is
   /// replaced entirely.
-  void selectDirectoryRange(Iterable<String> directoryIds, {bool append = false}) {
-    final updated = append
-        ? Set<String>.from(_selectedDirectoryIds)..addAll(directoryIds)
-        : Set<String>.from(directoryIds);
+  void selectDirectoryRange(
+    Iterable<String> directoryIds, {
+    bool append = false,
+  }) {
+    Set<String> updated = Set<String>.from(_selectedDirectoryIds);
+    if (append) {
+      updated.addAll(directoryIds);
+    } else {
+      Set<String>.from(directoryIds);
+    }
     _applySelectionUpdate(updated);
   }
 
@@ -318,29 +320,41 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
     try {
       LoggingService.instance.debug('Fetching directories from use case');
       final directories = await _getDirectoriesUseCase();
-      LoggingService.instance.debug('Retrieved ${directories.length} directories from use case');
+      LoggingService.instance.debug(
+        'Retrieved ${directories.length} directories from use case',
+      );
 
       // Separate accessible and inaccessible directories
       final accessibleDirectories = <DirectoryEntity>[];
       final inaccessibleDirectories = <DirectoryEntity>[];
 
-      LoggingService.instance.debug('Checking directory accessibility for ${directories.length} directories');
+      LoggingService.instance.debug(
+        'Checking directory accessibility for ${directories.length} directories',
+      );
       for (final directory in directories) {
         try {
           if (await _isDirectoryAccessible(directory)) {
             accessibleDirectories.add(directory);
-            LoggingService.instance.debug('Directory ${directory.path} is accessible');
+            LoggingService.instance.debug(
+              'Directory ${directory.path} is accessible',
+            );
           } else {
             inaccessibleDirectories.add(directory);
-            LoggingService.instance.debug('Directory ${directory.path} is not accessible');
+            LoggingService.instance.debug(
+              'Directory ${directory.path} is not accessible',
+            );
           }
         } catch (e) {
-          LoggingService.instance.warning('Error checking accessibility for directory ${directory.path}: $e');
+          LoggingService.instance.warning(
+            'Error checking accessibility for directory ${directory.path}: $e',
+          );
           inaccessibleDirectories.add(directory);
         }
       }
 
-      LoggingService.instance.debug('Accessibility check complete: ${accessibleDirectories.length} accessible, ${inaccessibleDirectories.length} inaccessible');
+      LoggingService.instance.debug(
+        'Accessibility check complete: ${accessibleDirectories.length} accessible, ${inaccessibleDirectories.length} inaccessible',
+      );
 
       if (accessibleDirectories.isEmpty && inaccessibleDirectories.isEmpty) {
         LoggingService.instance.info('Setting state to DirectoryEmpty');
@@ -353,22 +367,37 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
         _resetFilters();
         state = const DirectoryEmpty();
       } else {
-        if (accessibleDirectories.isNotEmpty && inaccessibleDirectories.isEmpty) {
-          LoggingService.instance.info('Setting state to DirectoryLoaded with ${accessibleDirectories.length} directories');
+        if (accessibleDirectories.isNotEmpty &&
+            inaccessibleDirectories.isEmpty) {
+          LoggingService.instance.info(
+            'Setting state to DirectoryLoaded with ${accessibleDirectories.length} directories',
+          );
           LoggingService.instance.debug('Directory details:');
           for (final dir in accessibleDirectories) {
-            LoggingService.instance.debug('  Directory: ${dir.name} (id: ${dir.id}), tagIds: ${dir.tagIds}');
+            LoggingService.instance.debug(
+              '  Directory: ${dir.name} (id: ${dir.id}), tagIds: ${dir.tagIds}',
+            );
           }
-          _updateDirectoryCaches(accessible: accessibleDirectories, inaccessible: const [], invalid: const []);
+          _updateDirectoryCaches(
+            accessible: accessibleDirectories,
+            inaccessible: const [],
+            invalid: const [],
+          );
         } else {
-          LoggingService.instance.info('Setting state to DirectoryPermissionRevoked: ${accessibleDirectories.length} accessible, ${inaccessibleDirectories.length} inaccessible');
+          LoggingService.instance.info(
+            'Setting state to DirectoryPermissionRevoked: ${accessibleDirectories.length} accessible, ${inaccessibleDirectories.length} inaccessible',
+          );
           LoggingService.instance.debug('Accessible directory details:');
           for (final dir in accessibleDirectories) {
-            LoggingService.instance.debug('  Directory: ${dir.name} (id: ${dir.id}), tagIds: ${dir.tagIds}');
+            LoggingService.instance.debug(
+              '  Directory: ${dir.name} (id: ${dir.id}), tagIds: ${dir.tagIds}',
+            );
           }
           LoggingService.instance.debug('Inaccessible directory details:');
           for (final dir in inaccessibleDirectories) {
-            LoggingService.instance.debug('  Directory: ${dir.name} (id: ${dir.id}), tagIds: ${dir.tagIds}');
+            LoggingService.instance.debug(
+              '  Directory: ${dir.name} (id: ${dir.id}), tagIds: ${dir.tagIds}',
+            );
           }
           _updateDirectoryCaches(
             accessible: accessibleDirectories,
@@ -383,7 +412,9 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
     } catch (e) {
       LoggingService.instance.error('Error in loadDirectories: $e');
       if (e is BookmarkInvalidError) {
-        LoggingService.instance.info('Handling BookmarkInvalidError for directory ${e.directoryPath}');
+        LoggingService.instance.info(
+          'Handling BookmarkInvalidError for directory ${e.directoryPath}',
+        );
         // Set to bookmark invalid state
         final invalidDirectory = DirectoryEntity(
           id: e.directoryId,
@@ -403,14 +434,18 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
         _resetFilters();
         _emitFilteredState();
       } else {
-        LoggingService.instance.error('Setting state to DirectoryError: ${ErrorHandler.getErrorMessage(ErrorHandler.toAppError(e))}');
+        LoggingService.instance.error(
+          'Setting state to DirectoryError: ${ErrorHandler.getErrorMessage(ErrorHandler.toAppError(e))}',
+        );
         _updateDirectoryCaches(
           accessible: const [],
           inaccessible: const [],
           invalid: const [],
         );
         _clearSelectionInternal();
-        state = DirectoryError(ErrorHandler.getErrorMessage(ErrorHandler.toAppError(e)));
+        state = DirectoryError(
+          ErrorHandler.getErrorMessage(ErrorHandler.toAppError(e)),
+        );
       }
     }
   }
@@ -425,7 +460,10 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
     };
     _currentColumns = previousColumns;
     _currentSearchQuery = query;
-    if (state case DirectoryLoaded() || DirectoryPermissionRevoked() || DirectoryBookmarkInvalid()) {
+    if (state
+        case DirectoryLoaded() ||
+            DirectoryPermissionRevoked() ||
+            DirectoryBookmarkInvalid()) {
       _emitFilteredState();
     }
   }
@@ -443,7 +481,9 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
     };
     _currentColumns = previousColumns;
     _currentSelectedTagIds = List<String>.unmodifiable(tagIds);
-    LoggingService.instance.info('filterByTags completed. New selectedTagIds: $tagIds');
+    LoggingService.instance.info(
+      'filterByTags completed. New selectedTagIds: $tagIds',
+    );
     _emitFilteredState();
   }
 
@@ -471,15 +511,24 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
 
   void _emitFilteredState() {
     final filteredAccessible = _applySearchIfNeeded(
-      _filterDirectoriesByTags(_cachedAccessibleDirectories, _currentSelectedTagIds),
+      _filterDirectoriesByTags(
+        _cachedAccessibleDirectories,
+        _currentSelectedTagIds,
+      ),
       _currentSearchQuery,
     );
     final filteredInaccessible = _applySearchIfNeeded(
-      _filterDirectoriesByTags(_cachedInaccessibleDirectories, _currentSelectedTagIds),
+      _filterDirectoriesByTags(
+        _cachedInaccessibleDirectories,
+        _currentSelectedTagIds,
+      ),
       _currentSearchQuery,
     );
     final filteredInvalid = _applySearchIfNeeded(
-      _filterDirectoriesByTags(_cachedInvalidDirectories, _currentSelectedTagIds),
+      _filterDirectoriesByTags(
+        _cachedInvalidDirectories,
+        _currentSelectedTagIds,
+      ),
       _currentSearchQuery,
     );
 
@@ -552,7 +601,9 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
   /// Sets the number of columns for the grid.
   void setColumns(int columns) {
     final clampedColumns = columns.clamp(2, 12);
-    final newColumns = clampedColumns is int ? clampedColumns : clampedColumns.toInt();
+    final newColumns = clampedColumns is int
+        ? clampedColumns
+        : clampedColumns.toInt();
     _ref.read(gridColumnsProvider.notifier).setColumns(newColumns);
   }
 
@@ -563,7 +614,9 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
       await _addDirectoryUseCase(path, silent: silent);
       await loadDirectories(); // Reload to show the new directory
     } catch (e) {
-      state = DirectoryError(ErrorHandler.getErrorMessage(ErrorHandler.toAppError(e)));
+      state = DirectoryError(
+        ErrorHandler.getErrorMessage(ErrorHandler.toAppError(e)),
+      );
     }
   }
 
@@ -584,14 +637,21 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
       await _addDirectoryUseCase(directoryPath);
       await loadDirectories(); // Reload to show the re-added directory
     } catch (e) {
-      state = DirectoryError('Failed to re-grant permissions: ${ErrorHandler.getErrorMessage(ErrorHandler.toAppError(e))}');
+      state = DirectoryError(
+        'Failed to re-grant permissions: ${ErrorHandler.getErrorMessage(ErrorHandler.toAppError(e))}',
+      );
     }
   }
 
   /// Recovers access to a directory with invalid bookmark by prompting user to re-select.
-  Future<void> recoverDirectoryBookmark(String directoryId, String directoryPath) async {
+  Future<void> recoverDirectoryBookmark(
+    String directoryId,
+    String directoryPath,
+  ) async {
     try {
-      final recoveryResult = await _permissionService.recoverDirectoryAccess(directoryPath);
+      final recoveryResult = await _permissionService.recoverDirectoryAccess(
+        directoryPath,
+      );
       if (recoveryResult != null) {
         // Remove the old directory entry
         await _removeDirectoryUseCase(directoryId);
@@ -600,7 +660,9 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
         await loadDirectories(); // Reload to reflect the changes
       }
     } catch (e) {
-      state = DirectoryError('Failed to recover directory access: ${ErrorHandler.getErrorMessage(ErrorHandler.toAppError(e))}');
+      state = DirectoryError(
+        'Failed to recover directory access: ${ErrorHandler.getErrorMessage(ErrorHandler.toAppError(e))}',
+      );
     }
   }
 
@@ -610,12 +672,18 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
     try {
       LoggingService.instance.debug('Calling clear directories use case');
       await _clearDirectoriesUseCase();
-      LoggingService.instance.debug('Clear directories use case completed, reloading directories');
+      LoggingService.instance.debug(
+        'Clear directories use case completed, reloading directories',
+      );
       await loadDirectories(); // Reload to show empty state
-      LoggingService.instance.info('Directory cache clear operation completed successfully');
+      LoggingService.instance.info(
+        'Directory cache clear operation completed successfully',
+      );
     } catch (e) {
       LoggingService.instance.error('Failed to clear directory cache: $e');
-      state = DirectoryError('Failed to clear directory cache: ${ErrorHandler.getErrorMessage(ErrorHandler.toAppError(e))}');
+      state = DirectoryError(
+        'Failed to clear directory cache: ${ErrorHandler.getErrorMessage(ErrorHandler.toAppError(e))}',
+      );
     }
   }
 
@@ -624,10 +692,14 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
     List<DirectoryEntity> directories,
     List<String> tagIds,
   ) {
-    LoggingService.instance.debug('_filterDirectoriesByTags called with ${directories.length} directories and tagIds: $tagIds');
+    LoggingService.instance.debug(
+      '_filterDirectoriesByTags called with ${directories.length} directories and tagIds: $tagIds',
+    );
 
     if (tagIds.isEmpty) {
-      LoggingService.instance.debug('tagIds is empty, returning all ${directories.length} directories (no filtering)');
+      LoggingService.instance.debug(
+        'tagIds is empty, returning all ${directories.length} directories (no filtering)',
+      );
       return directories;
     }
 
@@ -636,16 +708,24 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
         .where((dir) => dir.tagIds.any((tagId) => tagIds.contains(tagId)))
         .toList();
 
-    LoggingService.instance.debug('Filtering result: ${filtered.length} directories match out of ${directories.length}');
+    LoggingService.instance.debug(
+      'Filtering result: ${filtered.length} directories match out of ${directories.length}',
+    );
     LoggingService.instance.debug('Directories that passed filter:');
     for (final dir in filtered) {
-      LoggingService.instance.debug('  ${dir.name}: tagIds=${dir.tagIds}, matched tagIds=${tagIds.where((tagId) => dir.tagIds.contains(tagId)).toList()}');
+      LoggingService.instance.debug(
+        '  ${dir.name}: tagIds=${dir.tagIds}, matched tagIds=${tagIds.where((tagId) => dir.tagIds.contains(tagId)).toList()}',
+      );
     }
 
     LoggingService.instance.debug('Directories that were filtered out:');
-    final filteredOut = directories.where((dir) => !dir.tagIds.any((tagId) => tagIds.contains(tagId))).toList();
+    final filteredOut = directories
+        .where((dir) => !dir.tagIds.any((tagId) => tagIds.contains(tagId)))
+        .toList();
     for (final dir in filteredOut) {
-      LoggingService.instance.debug('  ${dir.name}: tagIds=${dir.tagIds}, no match with selected tagIds=$tagIds');
+      LoggingService.instance.debug(
+        '  ${dir.name}: tagIds=${dir.tagIds}, no match with selected tagIds=$tagIds',
+      );
     }
 
     return filtered;
@@ -655,11 +735,17 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
   Future<bool> _isDirectoryAccessible(DirectoryEntity directory) async {
     try {
       LoggingService.instance.debug('Validating directory: ${directory.path}');
-      final result = await _localDirectoryDataSource.validateDirectory(directory);
-      LoggingService.instance.debug('Directory validation result for ${directory.path}: $result');
+      final result = await _localDirectoryDataSource.validateDirectory(
+        directory,
+      );
+      LoggingService.instance.debug(
+        'Directory validation result for ${directory.path}: $result',
+      );
       return result;
     } catch (e) {
-      LoggingService.instance.error('Error validating directory ${directory.path}: $e');
+      LoggingService.instance.error(
+        'Error validating directory ${directory.path}: $e',
+      );
       rethrow;
     }
   }
@@ -713,18 +799,18 @@ final directoryViewModelProvider =
     );
 
 Set<String> _extractDirectorySelection(DirectoryState state) => switch (state) {
-      DirectoryLoaded(selectedDirectoryIds: final ids) => ids,
-      DirectoryPermissionRevoked(selectedDirectoryIds: final ids) => ids,
-      DirectoryBookmarkInvalid(selectedDirectoryIds: final ids) => ids,
-      _ => const <String>{},
-    };
+  DirectoryLoaded(selectedDirectoryIds: final ids) => ids,
+  DirectoryPermissionRevoked(selectedDirectoryIds: final ids) => ids,
+  DirectoryBookmarkInvalid(selectedDirectoryIds: final ids) => ids,
+  _ => const <String>{},
+};
 
 bool _extractDirectorySelectionMode(DirectoryState state) => switch (state) {
-      DirectoryLoaded(isSelectionMode: final mode) => mode,
-      DirectoryPermissionRevoked(isSelectionMode: final mode) => mode,
-      DirectoryBookmarkInvalid(isSelectionMode: final mode) => mode,
-      _ => false,
-    };
+  DirectoryLoaded(isSelectionMode: final mode) => mode,
+  DirectoryPermissionRevoked(isSelectionMode: final mode) => mode,
+  DirectoryBookmarkInvalid(isSelectionMode: final mode) => mode,
+  _ => false,
+};
 
 /// Provider exposing the current set of selected directory IDs.
 final selectedDirectoryIdsProvider = Provider.autoDispose<Set<String>>((ref) {

--- a/lib/features/media_library/presentation/view_models/media_grid_view_model.dart
+++ b/lib/features/media_library/presentation/view_models/media_grid_view_model.dart
@@ -177,9 +177,13 @@ class MediaViewModel extends StateNotifier<MediaState> {
   /// Selects a set of media IDs, optionally appending to the current
   /// selection when [append] is true.
   void selectMediaRange(Iterable<String> mediaIds, {bool append = false}) {
-    final updated = append
-        ? Set<String>.from(_selectedMediaIds)..addAll(mediaIds)
-        : Set<String>.from(mediaIds);
+    Set<String> updated = Set<String>.from(_selectedMediaIds);
+    if (append) {
+      updated.addAll(mediaIds);
+    }
+    else {
+      updated = Set<String>.from(mediaIds);
+    }
     _applySelectionUpdate(updated);
   }
 

--- a/test/features/media_library/presentation/view_models/directory_grid_view_model_test.dart
+++ b/test/features/media_library/presentation/view_models/directory_grid_view_model_test.dart
@@ -1,27 +1,16 @@
-import 'package:test/test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
-import '../../../../../lib/features/media_library/domain/entities/directory_entity.dart';
-import '../../../../../lib/features/media_library/domain/repositories/directory_repository.dart';
-import '../../../../../lib/features/media_library/domain/use_cases/add_directory_use_case.dart';
-import '../../../../../lib/features/media_library/domain/use_cases/clear_directories_use_case.dart';
-import '../../../../../lib/features/media_library/domain/use_cases/get_directories_use_case.dart';
-import '../../../../../lib/features/media_library/domain/use_cases/remove_directory_use_case.dart';
-import '../../../../../lib/features/media_library/domain/use_cases/search_directories_use_case.dart';
-import '../../../../../lib/features/media_library/presentation/view_models/directory_grid_view_model.dart';
-import '../../../../../lib/features/media_library/data/data_sources/local_directory_data_source.dart';
 import '../../../../../lib/core/services/permission_service.dart';
-
-DirectoryEntity? _firstWhereOrNull(
-  Iterable<DirectoryEntity> directories,
-  bool Function(DirectoryEntity) test,
-) {
-  for (final directory in directories) {
-    if (test(directory)) {
-      return directory;
-    }
-  }
-  return null;
-}
+import '../../../../../lib/features/favorites/domain/repositories/favorites_repository.dart';
+import '../../../../../lib/features/media_library/data/data_sources/local_directory_data_source.dart';
+import '../../../../../lib/features/media_library/domain/entities/directory_entity.dart';
+import '../../../../../lib/features/media_library/domain/entities/media_entity.dart';
+import '../../../../../lib/features/media_library/domain/repositories/directory_repository.dart';
+import '../../../../../lib/features/media_library/domain/repositories/media_repository.dart';
+import '../../../../../lib/features/media_library/presentation/view_models/directory_grid_view_model.dart';
+import '../../../../../lib/shared/providers/repository_providers.dart';
 
 class InMemoryDirectoryRepository implements DirectoryRepository {
   InMemoryDirectoryRepository(this._directories);
@@ -43,9 +32,7 @@ class InMemoryDirectoryRepository implements DirectoryRepository {
     if (tagIds.isEmpty) {
       return getDirectories();
     }
-    return _directories
-        .where((dir) => dir.tagIds.any(tagIds.contains))
-        .toList();
+    return _directories.where((dir) => dir.tagIds.any(tagIds.contains)).toList();
   }
 
   @override
@@ -55,7 +42,11 @@ class InMemoryDirectoryRepository implements DirectoryRepository {
 
   @override
   Future<DirectoryEntity?> getDirectoryById(String id) async {
-    return _firstWhereOrNull(_directories, (dir) => dir.id == id);
+    try {
+      return _directories.firstWhere((dir) => dir.id == id);
+    } catch (_) {
+      return null;
+    }
   }
 
   @override
@@ -91,6 +82,90 @@ class InMemoryDirectoryRepository implements DirectoryRepository {
   }
 }
 
+class InMemoryMediaRepository implements MediaRepository {
+  InMemoryMediaRepository(this._media);
+
+  final List<MediaEntity> _media;
+
+  @override
+  Future<List<MediaEntity>> filterMediaByTags(List<String> tagIds) async {
+    if (tagIds.isEmpty) {
+      return List<MediaEntity>.from(_media);
+    }
+    return _media.where((item) => item.tagIds.any(tagIds.contains)).toList();
+  }
+
+  @override
+  Future<List<MediaEntity>> filterMediaByTagsForDirectory(
+    List<String> tagIds,
+    String directoryPath, {
+    String? bookmarkData,
+  }) async {
+    return (await filterMediaByTags(tagIds))
+        .where((item) => item.directoryId == directoryPath)
+        .toList();
+  }
+
+  @override
+  Future<List<MediaEntity>> getMediaForDirectory(String directoryId) async {
+    return _media.where((item) => item.directoryId == directoryId).toList();
+  }
+
+  @override
+  Future<List<MediaEntity>> getMediaForDirectoryPath(
+    String directoryPath, {
+    String? bookmarkData,
+  }) async {
+    return getMediaForDirectory(directoryPath);
+  }
+
+  @override
+  Future<MediaEntity?> getMediaById(String id) async {
+    try {
+      return _media.firstWhere((item) => item.id == id);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  @override
+  Future<void> removeMediaForDirectory(String directoryId) async {
+    _media.removeWhere((item) => item.directoryId == directoryId);
+  }
+
+  @override
+  Future<void> updateMediaTags(String mediaId, List<String> tagIds) async {
+    final index = _media.indexWhere((item) => item.id == mediaId);
+    if (index != -1) {
+      _media[index] = _media[index].copyWith(tagIds: tagIds);
+    }
+  }
+}
+
+class InMemoryFavoritesRepository implements FavoritesRepository {
+  final Set<String> _favorites = <String>{};
+
+  @override
+  Future<void> addFavorite(String mediaId) async {
+    _favorites.add(mediaId);
+  }
+
+  @override
+  Future<List<String>> getFavoriteMediaIds() async {
+    return _favorites.toList();
+  }
+
+  @override
+  Future<bool> isFavorite(String mediaId) async {
+    return _favorites.contains(mediaId);
+  }
+
+  @override
+  Future<void> removeFavorite(String mediaId) async {
+    _favorites.remove(mediaId);
+  }
+}
+
 class FakeLocalDirectoryDataSource extends LocalDirectoryDataSource {
   const FakeLocalDirectoryDataSource() : super(bookmarkService: BookmarkService.instance);
 
@@ -102,63 +177,141 @@ class FakePermissionService extends PermissionService {
   FakePermissionService() : super();
 }
 
+Future<ProviderContainer> _createDirectoryTestContainer({
+  required InMemoryDirectoryRepository directoryRepository,
+  required InMemoryMediaRepository mediaRepository,
+  required InMemoryFavoritesRepository favoritesRepository,
+  required SharedPreferences sharedPreferences,
+}) async {
+  final container = ProviderContainer(
+    overrides: [
+      sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+      localDirectoryDataSourceProvider.overrideWithValue(const FakeLocalDirectoryDataSource()),
+      permissionServiceProvider.overrideWithValue(FakePermissionService()),
+      directoryRepositoryProvider.overrideWith((ref) {
+        return DirectoryRepositoryNotifier(directoryRepository);
+      }),
+      mediaRepositoryProvider.overrideWith((ref) {
+        return MediaRepositoryNotifier(mediaRepository);
+      }),
+      favoritesRepositoryProvider.overrideWith((ref) {
+        return FavoritesRepositoryNotifier(favoritesRepository);
+      }),
+    ],
+  );
+
+  return container;
+}
+
 void main() {
-  group('DirectoryViewModel tag filtering', () {
-    late DirectoryViewModel viewModel;
-    late InMemoryDirectoryRepository repository;
+  TestWidgetsFlutterBinding.ensureInitialized();
 
-    setUp(() async {
-      repository = InMemoryDirectoryRepository([
-        DirectoryEntity(
-          id: '1',
-          path: '/dir1',
-          name: 'Dir 1',
-          thumbnailPath: null,
-          tagIds: const ['tag1'],
-          lastModified: DateTime(2024, 1, 1),
-        ),
-        DirectoryEntity(
-          id: '2',
-          path: '/dir2',
-          name: 'Dir 2',
-          thumbnailPath: null,
-          tagIds: const ['tag2'],
-          lastModified: DateTime(2024, 1, 2),
-        ),
-        DirectoryEntity(
-          id: '3',
-          path: '/dir3',
-          name: 'Dir 3',
-          thumbnailPath: null,
-          tagIds: const [],
-          lastModified: DateTime(2024, 1, 3),
-        ),
-      ]);
+  late SharedPreferences sharedPreferences;
+  late InMemoryDirectoryRepository directoryRepository;
+  late InMemoryMediaRepository mediaRepository;
+  late InMemoryFavoritesRepository favoritesRepository;
 
-      viewModel = DirectoryViewModel(
-        GetDirectoriesUseCase(repository),
-        const SearchDirectoriesUseCase(),
-        AddDirectoryUseCase(repository),
-        RemoveDirectoryUseCase(repository),
-        ClearDirectoriesUseCase(repository),
-        const FakeLocalDirectoryDataSource(),
-        FakePermissionService(),
-      );
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    sharedPreferences = await SharedPreferences.getInstance();
+    directoryRepository = InMemoryDirectoryRepository([
+      DirectoryEntity(
+        id: '1',
+        path: '/dir1',
+        name: 'Directory 1',
+        thumbnailPath: null,
+        tagIds: const ['tag1'],
+        lastModified: DateTime(2024, 1, 1),
+      ),
+      DirectoryEntity(
+        id: '2',
+        path: '/dir2',
+        name: 'Directory 2',
+        thumbnailPath: null,
+        tagIds: const ['tag2'],
+        lastModified: DateTime(2024, 1, 2),
+      ),
+      DirectoryEntity(
+        id: '3',
+        path: '/dir3',
+        name: 'Directory 3',
+        thumbnailPath: null,
+        tagIds: const [],
+        lastModified: DateTime(2024, 1, 3),
+      ),
+    ]);
+    mediaRepository = InMemoryMediaRepository([]);
+    favoritesRepository = InMemoryFavoritesRepository();
+  });
 
-      await viewModel.loadDirectories();
-    });
+  test('toggleDirectorySelection toggles selection mode and IDs', () async {
+    final container = await _createDirectoryTestContainer(
+      directoryRepository: directoryRepository,
+      mediaRepository: mediaRepository,
+      favoritesRepository: favoritesRepository,
+      sharedPreferences: sharedPreferences,
+    );
+    addTearDown(container.dispose);
 
-    test('filters directories by selected tag ids', () async {
-      expect(viewModel.state, isA<DirectoryLoaded>());
+    final viewModel = container.read(directoryViewModelProvider.notifier);
+    await viewModel.loadDirectories();
 
-      viewModel.filterByTags(const ['tag1']);
+    viewModel.toggleDirectorySelection('1');
 
-      final state = viewModel.state;
-      expect(state, isA<DirectoryLoaded>());
-      final loadedState = state as DirectoryLoaded;
-      expect(loadedState.directories.length, 1);
-      expect(loadedState.directories.first.id, '1');
-      expect(loadedState.selectedTagIds, ['tag1']);
-    });
+    final state = container.read(directoryViewModelProvider);
+    expect(state, isA<DirectoryLoaded>());
+    final loaded = state as DirectoryLoaded;
+    expect(loaded.selectedDirectoryIds, {'1'});
+    expect(loaded.isSelectionMode, isTrue);
+
+    viewModel.toggleDirectorySelection('1');
+    final cleared = container.read(directoryViewModelProvider) as DirectoryLoaded;
+    expect(cleared.selectedDirectoryIds, isEmpty);
+    expect(cleared.isSelectionMode, isFalse);
+  });
+
+  test('selectDirectoryRange supports append mode', () async {
+    final container = await _createDirectoryTestContainer(
+      directoryRepository: directoryRepository,
+      mediaRepository: mediaRepository,
+      favoritesRepository: favoritesRepository,
+      sharedPreferences: sharedPreferences,
+    );
+    addTearDown(container.dispose);
+
+    final viewModel = container.read(directoryViewModelProvider.notifier);
+    await viewModel.loadDirectories();
+
+    viewModel.selectDirectoryRange(const ['1', '2']);
+    DirectoryLoaded state = container.read(directoryViewModelProvider) as DirectoryLoaded;
+    expect(state.selectedDirectoryIds, {'1', '2'});
+    expect(state.isSelectionMode, isTrue);
+
+    viewModel.selectDirectoryRange(const ['3'], append: true);
+    state = container.read(directoryViewModelProvider) as DirectoryLoaded;
+    expect(state.selectedDirectoryIds, {'1', '2', '3'});
+  });
+
+  test('clearDirectorySelection resets providers', () async {
+    final container = await _createDirectoryTestContainer(
+      directoryRepository: directoryRepository,
+      mediaRepository: mediaRepository,
+      favoritesRepository: favoritesRepository,
+      sharedPreferences: sharedPreferences,
+    );
+    addTearDown(container.dispose);
+
+    final viewModel = container.read(directoryViewModelProvider.notifier);
+    await viewModel.loadDirectories();
+    viewModel.selectDirectoryRange(const ['1', '2']);
+
+    viewModel.clearDirectorySelection();
+
+    final state = container.read(directoryViewModelProvider) as DirectoryLoaded;
+    expect(state.selectedDirectoryIds, isEmpty);
+    expect(state.isSelectionMode, isFalse);
+    expect(container.read(selectedDirectoryIdsProvider), isEmpty);
+    expect(container.read(directorySelectionModeProvider), isFalse);
+    expect(container.read(selectedDirectoryCountProvider), 0);
   });
 }


### PR DESCRIPTION
## Summary
- track selected IDs and selection mode inside the directory and media grid view models and surface helpers to toggle, range select, and clear selections
- expose new Riverpod providers that publish current selections and counts for directory and media grids
- replace the directory and media view model tests with Riverpod-backed suites that cover the new selection workflows

## Testing
- `flutter test` *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e98bbc04b08320a7ad020a2be125c9