### PR TITLE
Add batch tag assignment support for directories and media

### DIFF
--- a/lib/core/utils/batch_update_result.dart
+++ b/lib/core/utils/batch_update_result.dart
@@ -1,0 +1,45 @@
+import 'package:collection/collection.dart';
+
+/// Describes the outcome of a batch update operation, including the
+/// identifiers that were successfully updated and any failures.
+class BatchUpdateResult {
+  const BatchUpdateResult({
+    this.successfulIds = const <String>[],
+    this.failureReasons = const <String, String>{},
+  });
+
+  /// Identifiers that were updated successfully.
+  final List<String> successfulIds;
+
+  /// Mapping of identifiers that failed to update to the associated reason.
+  final Map<String, String> failureReasons;
+
+  /// Indicates whether any updates failed.
+  bool get hasFailures => failureReasons.isNotEmpty;
+
+  /// Indicates whether any updates succeeded.
+  bool get hasSuccesses => successfulIds.isNotEmpty;
+
+  /// Creates an empty result representing a no-op operation.
+  static const BatchUpdateResult empty = BatchUpdateResult();
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is! BatchUpdateResult) return false;
+    final listEquals = const ListEquality<String>().equals;
+    final mapEquals = const MapEquality<String, String>().equals;
+    return listEquals(successfulIds, other.successfulIds) &&
+        mapEquals(failureReasons, other.failureReasons);
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        const ListEquality<String>().hash(successfulIds),
+        const MapEquality<String, String>().hash(failureReasons),
+      );
+
+  @override
+  String toString() =>
+      'BatchUpdateResult(successfulIds: $successfulIds, failureReasons: $failureReasons)';
+}

--- a/lib/features/media_library/data/repositories/media_repository_impl.dart
+++ b/lib/features/media_library/data/repositories/media_repository_impl.dart
@@ -1,4 +1,5 @@
 import '../../../../core/services/logging_service.dart';
+import '../../../../core/utils/batch_update_result.dart';
 import '../../../../shared/utils/directory_id_utils.dart';
 import '../../domain/entities/media_entity.dart';
 import '../../domain/repositories/media_repository.dart';
@@ -75,6 +76,52 @@ class MediaRepositoryImpl implements MediaRepository {
   @override
   Future<void> updateMediaTags(String mediaId, List<String> tagIds) async {
     await _mediaDataSource.updateMediaTags(mediaId, tagIds);
+  }
+
+  @override
+  Future<BatchUpdateResult> updateMediaTagsBatch(
+    Map<String, List<String>> mediaTags,
+  ) async {
+    if (mediaTags.isEmpty) {
+      return BatchUpdateResult.empty;
+    }
+
+    final models = await _mediaDataSource.getMedia();
+    final indexById = {
+      for (var i = 0; i < models.length; i++) models[i].id: i,
+    };
+
+    final successes = <String>[];
+    final failures = <String, String>{};
+
+    for (final entry in mediaTags.entries) {
+      final index = indexById[entry.key];
+      if (index == null) {
+        failures[entry.key] = 'Media not found';
+        continue;
+      }
+
+      models[index] = models[index].copyWith(tagIds: entry.value);
+      successes.add(entry.key);
+    }
+
+    if (successes.isNotEmpty) {
+      await _mediaDataSource.saveMedia(models);
+      LoggingService.instance.info(
+        'Updated tags for ${successes.length} media items in a single batch.',
+      );
+    }
+
+    if (failures.isNotEmpty) {
+      LoggingService.instance.warning(
+        'Failed to update tags for media: ${failures.keys.join(', ')}',
+      );
+    }
+
+    return BatchUpdateResult(
+      successfulIds: successes,
+      failureReasons: failures,
+    );
   }
 
   @override

--- a/lib/features/media_library/domain/repositories/directory_repository.dart
+++ b/lib/features/media_library/domain/repositories/directory_repository.dart
@@ -1,3 +1,4 @@
+import '../../../../core/utils/batch_update_result.dart';
 import '../entities/directory_entity.dart';
 
 /// Repository interface for directory operations.
@@ -24,6 +25,13 @@ abstract class DirectoryRepository {
 
   /// Updates the tags for a directory.
   Future<void> updateDirectoryTags(String directoryId, List<String> tagIds);
+
+  /// Replaces the tag collections for multiple directories in a single
+  /// operation. Implementations should persist the updates atomically when
+  /// possible to avoid partial writes.
+  Future<BatchUpdateResult> updateDirectoryTagsBatch(
+    Map<String, List<String>> directoryTags,
+  );
 
   /// Updates the bookmark data for a directory.
   Future<void> updateDirectoryBookmark(String directoryId, String? bookmarkData);

--- a/lib/features/media_library/domain/repositories/media_repository.dart
+++ b/lib/features/media_library/domain/repositories/media_repository.dart
@@ -1,3 +1,4 @@
+import '../../../../core/utils/batch_update_result.dart';
 import '../entities/media_entity.dart';
 
 /// Repository interface for media operations.
@@ -29,6 +30,13 @@ abstract class MediaRepository {
 
   /// Updates the tags for a media item.
   Future<void> updateMediaTags(String mediaId, List<String> tagIds);
+
+  /// Replaces the tag collections for multiple media items in a single
+  /// operation. Implementations should persist the updates atomically when
+  /// possible to avoid partial writes.
+  Future<BatchUpdateResult> updateMediaTagsBatch(
+    Map<String, List<String>> mediaTags,
+  );
 
   /// Removes all cached media entries for a directory.
   Future<void> removeMediaForDirectory(String directoryId);

--- a/test/features/tagging/domain/use_cases/assign_tag_use_case_test.dart
+++ b/test/features/tagging/domain/use_cases/assign_tag_use_case_test.dart
@@ -1,3 +1,4 @@
+import 'package:media_fast_view/core/utils/batch_update_result.dart';
 import 'package:media_fast_view/features/media_library/domain/entities/directory_entity.dart';
 import 'package:media_fast_view/features/media_library/domain/repositories/directory_repository.dart';
 import 'package:media_fast_view/features/media_library/domain/repositories/media_repository.dart';
@@ -61,6 +62,108 @@ void main() {
 
       verify(directoryRepository.getDirectoryById('unknown')).called(1);
       verifyNever(directoryRepository.updateDirectoryTags(any, any));
+    });
+  });
+
+  group('setTagsForDirectories', () {
+    test('deduplicates ids and tags before forwarding to repository', () async {
+      when(directoryRepository.updateDirectoryTagsBatch(any))
+          .thenAnswer((_) async => BatchUpdateResult.empty);
+
+      await useCase.setTagsForDirectories(
+        ['dir-1', '', 'dir-1', 'dir-2'],
+        ['tag-a', 'tag-a', 'tag-b'],
+      );
+
+      final captured = verify(
+        directoryRepository.updateDirectoryTagsBatch(captureAny),
+      ).captured.single as Map<String, List<String>>;
+
+      expect(
+        captured,
+        equals({
+          'dir-1': ['tag-a', 'tag-b'],
+          'dir-2': ['tag-a', 'tag-b'],
+        }),
+      );
+    });
+
+    test('returns repository result allowing partial failures', () async {
+      const batchResult = BatchUpdateResult(
+        successfulIds: ['dir-1'],
+        failureReasons: {'dir-missing': 'Directory not found'},
+      );
+
+      when(directoryRepository.updateDirectoryTagsBatch(any))
+          .thenAnswer((_) async => batchResult);
+
+      final result = await useCase.setTagsForDirectories(
+        ['dir-1', 'dir-missing'],
+        ['tag-a'],
+      );
+
+      expect(result, equals(batchResult));
+    });
+
+    test('returns empty result when all ids are filtered out', () async {
+      final result = await useCase.setTagsForDirectories(
+        const [''],
+        const ['tag-a'],
+      );
+
+      expect(result, equals(BatchUpdateResult.empty));
+      verifyNever(directoryRepository.updateDirectoryTagsBatch(any));
+    });
+  });
+
+  group('setTagsForMedia', () {
+    test('deduplicates ids and tags before forwarding to repository', () async {
+      when(mediaRepository.updateMediaTagsBatch(any))
+          .thenAnswer((_) async => BatchUpdateResult.empty);
+
+      await useCase.setTagsForMedia(
+        ['media-1', '', 'media-2', 'media-2'],
+        ['tag-a', 'tag-b', 'tag-a'],
+      );
+
+      final captured = verify(
+        mediaRepository.updateMediaTagsBatch(captureAny),
+      ).captured.single as Map<String, List<String>>;
+
+      expect(
+        captured,
+        equals({
+          'media-1': ['tag-a', 'tag-b'],
+          'media-2': ['tag-a', 'tag-b'],
+        }),
+      );
+    });
+
+    test('returns repository result allowing partial failures', () async {
+      const batchResult = BatchUpdateResult(
+        successfulIds: ['media-1'],
+        failureReasons: {'media-missing': 'Media not found'},
+      );
+
+      when(mediaRepository.updateMediaTagsBatch(any))
+          .thenAnswer((_) async => batchResult);
+
+      final result = await useCase.setTagsForMedia(
+        ['media-1', 'media-missing'],
+        ['tag-a'],
+      );
+
+      expect(result, equals(batchResult));
+    });
+
+    test('returns empty result when ids are empty', () async {
+      final result = await useCase.setTagsForMedia(
+        const <String>[],
+        const ['tag-a'],
+      );
+
+      expect(result, equals(BatchUpdateResult.empty));
+      verifyNever(mediaRepository.updateMediaTagsBatch(any));
     });
   });
 }


### PR DESCRIPTION
## Summary
- add a reusable `BatchUpdateResult` to report batched tag update outcomes
- extend media and directory repositories plus the assign tag use case with batch APIs and update the selection view models to call them
- cover the new batch flows with unit tests that verify payloads and partial failure handling

## Testing
- Not run (flutter CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e9c01ce13083208897dcc2970ce8fb