### PR TITLE
Reduce bulk tag assignment dialog height

### DIFF
--- a/lib/features/tagging/presentation/widgets/bulk_tag_assignment_dialog.dart
+++ b/lib/features/tagging/presentation/widgets/bulk_tag_assignment_dialog.dart
@@ -129,6 +129,7 @@ class _BulkTagAssignmentDialogState
   }
 
   Widget _buildContent(BuildContext context, List<TagEntity> tags) {
+    final availableHeight = MediaQuery.of(context).size.height;
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -140,20 +141,26 @@ class _BulkTagAssignmentDialogState
               ),
         ),
         const SizedBox(height: 16),
-        Flexible(
-          child: SingleChildScrollView(
-            child: Wrap(
-              spacing: 8,
-              runSpacing: 8,
-              children: tags
-                  .map(
-                    (tag) => TagChip(
-                      tag: tag,
-                      selected: _tempSelectedTagIds.contains(tag.id),
-                      onTap: () => _toggleTagSelection(tag.id),
-                    ),
-                  )
-                  .toList(),
+        ConstrainedBox(
+          constraints: BoxConstraints(
+            maxHeight: availableHeight * 0.5,
+          ),
+          child: Scrollbar(
+            thumbVisibility: true,
+            child: SingleChildScrollView(
+              child: Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: tags
+                    .map(
+                      (tag) => TagChip(
+                        tag: tag,
+                        selected: _tempSelectedTagIds.contains(tag.id),
+                        onTap: () => _toggleTagSelection(tag.id),
+                      ),
+                    )
+                    .toList(),
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
## Summary
- limit the bulk tag assignment dialog tag list to half of the screen height so it no longer covers the full viewport
- wrap the tag list in a visible scrollbar to emphasize that it can scroll

## Testing
- Not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e9d1a3bf68832094ee3387a21f8495