### PR TITLE
Update bulk favorite selection behavior

### DIFF
--- a/lib/features/favorites/presentation/view_models/favorites_view_model.dart
+++ b/lib/features/favorites/presentation/view_models/favorites_view_model.dart
@@ -192,26 +192,37 @@ class FavoritesViewModel extends StateNotifier<FavoritesState> {
       final removals = <String>[];
       final mediaById = {for (final media in mediaItems) media.id: media};
 
+      final favoriteStatuses = <String, bool>{};
       for (final media in mediaItems) {
         final isFavorited = await _favoritesRepository.isFavorite(
           media.id,
           type: FavoriteItemType.media,
         );
-        if (isFavorited) {
-          removals.add(media.id);
-        } else {
-          additions.add(
-            FavoriteEntity(
-              itemId: media.id,
-              itemType: FavoriteItemType.media,
-              addedAt: DateTime.now(),
-              metadata: {
-                'name': media.name,
-                'path': media.path,
-                'type': media.type.name,
-              },
-            ),
-          );
+        favoriteStatuses[media.id] = isFavorited;
+      }
+
+      final allSelectedAreFavorites =
+          favoriteStatuses.values.every((isFavorite) => isFavorite);
+
+      if (allSelectedAreFavorites) {
+        removals.addAll(favoriteStatuses.keys);
+      } else {
+        for (final media in mediaItems) {
+          final isFavorited = favoriteStatuses[media.id] ?? false;
+          if (!isFavorited) {
+            additions.add(
+              FavoriteEntity(
+                itemId: media.id,
+                itemType: FavoriteItemType.media,
+                addedAt: DateTime.now(),
+                metadata: {
+                  'name': media.name,
+                  'path': media.path,
+                  'type': media.type.name,
+                },
+              ),
+            );
+          }
         }
       }
 

--- a/lib/features/media_library/presentation/screens/media_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/media_grid_screen.dart
@@ -199,6 +199,9 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
   ) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
+    final favoritesState = ref.watch(favoritesViewModelProvider);
+    final favoriteActionLabel =
+        _favoriteBulkActionLabel(favoritesState, selectedMediaIds);
 
     return AppBar(
       leading: IconButton(
@@ -231,7 +234,7 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
             _toggleSelectedMediaFavorites(state.media, selectedMediaIds),
           ),
           icon: const Icon(Icons.favorite),
-          label: const Text('Toggle Favorites'),
+          label: Text(favoriteActionLabel),
           style: FilledButton.styleFrom(
             backgroundColor: colorScheme.primary,
             foregroundColor: colorScheme.onPrimary,
@@ -242,6 +245,31 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
         const SizedBox(width: 8),
       ],
     );
+  }
+
+  String _favoriteBulkActionLabel(
+    FavoritesState favoritesState,
+    Set<String> selectedMediaIds,
+  ) {
+    if (selectedMediaIds.isEmpty) {
+      return 'Favorite All';
+    }
+
+    if (favoritesState is FavoritesLoaded) {
+      final favoritesSet = favoritesState.favorites.toSet();
+      final allSelectedAreFavorites =
+          selectedMediaIds.every((id) => favoritesSet.contains(id));
+      if (allSelectedAreFavorites) {
+        return 'Unfavorite All';
+      }
+      return 'Favorite All';
+    }
+
+    if (favoritesState is FavoritesEmpty) {
+      return 'Favorite All';
+    }
+
+    return 'Toggle Favorites';
   }
 
   Widget _buildTagFilter(MediaViewModel viewModel, MediaState state) {


### PR DESCRIPTION
## Summary
- adjust the favorites view model to perform bulk add or remove operations based on the current selection state
- update the media grid selection toolbar to show contextual favorite action labels

## Testing
- Not run (flutter command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e9fec417208320863146750e3b8ed4