### PR TITLE
Add marquee autoscroll and select all support

### DIFF
--- a/lib/features/media_library/presentation/view_models/media_grid_view_model.dart
+++ b/lib/features/media_library/presentation/view_models/media_grid_view_model.dart
@@ -203,11 +203,20 @@ class MediaViewModel extends StateNotifier<MediaState> {
     Set<String> updated = Set<String>.from(_selectedMediaIds);
     if (append) {
       updated.addAll(mediaIds);
-    } 
-    else {
+    } else {
       updated = Set<String>.from(mediaIds);
     }
     _applySelectionUpdate(updated);
+  }
+
+  /// Selects every media item currently loaded in the grid.
+  void selectAllMedia() {
+    if (_cachedMedia.isEmpty) {
+      _applySelectionUpdate(<String>{});
+      return;
+    }
+    final allIds = {for (final media in _cachedMedia) media.id};
+    _applySelectionUpdate(allIds);
   }
 
   /// Clears the current media selection and exits selection mode.


### PR DESCRIPTION
## Summary
- add marquee auto-scroll support so drag selections can include items revealed while scrolling
- keep marquee selections in sync during manual scrolls and expose select-all behavior in the media view model
- add a select-all shortcut and toolbar action when multi-select mode is active

## Testing
- Not run (Flutter CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ea0cd2c044832099348feb762908d0