### PR TITLE
Enable marquee auto-scroll and select all

### DIFF
--- a/lib/features/media_library/presentation/view_models/directory_grid_view_model.dart
+++ b/lib/features/media_library/presentation/view_models/directory_grid_view_model.dart
@@ -296,11 +296,47 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
     Set<String> updated = Set<String>.from(_selectedDirectoryIds);
     if (append) {
       updated.addAll(directoryIds);
-    } 
+    }
     else {
       updated = Set<String>.from(directoryIds);
     }
     _applySelectionUpdate(updated);
+  }
+
+  /// Selects every directory currently visible in the active state.
+  void selectAllVisibleDirectories() {
+    final stateSnapshot = state;
+    final allIds = <String>{};
+
+    switch (stateSnapshot) {
+      case DirectoryLoaded(:final directories):
+        allIds.addAll(directories.map((directory) => directory.id));
+        break;
+      case DirectoryPermissionRevoked(
+          :final accessibleDirectories,
+          :final inaccessibleDirectories,
+        ):
+        allIds
+          ..addAll(accessibleDirectories.map((directory) => directory.id))
+          ..addAll(inaccessibleDirectories.map((directory) => directory.id));
+        break;
+      case DirectoryBookmarkInvalid(
+          :final accessibleDirectories,
+          :final invalidDirectories,
+        ):
+        allIds
+          ..addAll(accessibleDirectories.map((directory) => directory.id))
+          ..addAll(invalidDirectories.map((directory) => directory.id));
+        break;
+      default:
+        break;
+    }
+
+    if (allIds.isEmpty) {
+      return;
+    }
+
+    _applySelectionUpdate(allIds);
   }
 
   /// Clears all selected directories and exits selection mode.

--- a/lib/features/media_library/presentation/view_models/media_grid_view_model.dart
+++ b/lib/features/media_library/presentation/view_models/media_grid_view_model.dart
@@ -203,11 +203,26 @@ class MediaViewModel extends StateNotifier<MediaState> {
     Set<String> updated = Set<String>.from(_selectedMediaIds);
     if (append) {
       updated.addAll(mediaIds);
-    } 
+    }
     else {
       updated = Set<String>.from(mediaIds);
     }
     _applySelectionUpdate(updated);
+  }
+
+  /// Selects every media item currently visible in the grid.
+  void selectAllVisibleMedia() {
+    final stateSnapshot = state;
+    if (stateSnapshot is! MediaLoaded) {
+      return;
+    }
+
+    final visibleIds = stateSnapshot.media.map((media) => media.id).toSet();
+    if (visibleIds.isEmpty) {
+      return;
+    }
+
+    _applySelectionUpdate(visibleIds);
   }
 
   /// Clears the current media selection and exits selection mode.


### PR DESCRIPTION
## Summary
- add auto-scroll support to directory and media marquee selection so drag-selecting can reach items beyond the viewport
- expose select-all actions via Cmd+A and toolbar buttons when multi-selection is active
- extend directory and media view models with helpers to select all visible items

## Testing
- not run (Flutter SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68ea0cd2c044832099348feb762908d0