### PR TITLE
Enable marquee selection across scroll and add select all

### DIFF
--- a/lib/features/media_library/presentation/view_models/directory_grid_view_model.dart
+++ b/lib/features/media_library/presentation/view_models/directory_grid_view_model.dart
@@ -296,11 +296,27 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
     Set<String> updated = Set<String>.from(_selectedDirectoryIds);
     if (append) {
       updated.addAll(directoryIds);
-    } 
+    }
     else {
       updated = Set<String>.from(directoryIds);
     }
     _applySelectionUpdate(updated);
+  }
+
+  /// Selects all directories currently cached in the view model.
+  void selectAllDirectories() {
+    final allIds = <String>{
+      for (final directory in _cachedAccessibleDirectories) directory.id,
+      for (final directory in _cachedInaccessibleDirectories) directory.id,
+      for (final directory in _cachedInvalidDirectories) directory.id,
+    };
+
+    if (allIds.isEmpty) {
+      _applySelectionUpdate(<String>{});
+      return;
+    }
+
+    _applySelectionUpdate(allIds);
   }
 
   /// Clears all selected directories and exits selection mode.

--- a/lib/features/media_library/presentation/view_models/media_grid_view_model.dart
+++ b/lib/features/media_library/presentation/view_models/media_grid_view_model.dart
@@ -203,11 +203,22 @@ class MediaViewModel extends StateNotifier<MediaState> {
     Set<String> updated = Set<String>.from(_selectedMediaIds);
     if (append) {
       updated.addAll(mediaIds);
-    } 
+    }
     else {
       updated = Set<String>.from(mediaIds);
     }
     _applySelectionUpdate(updated);
+  }
+
+  /// Selects every media item currently available in the grid.
+  void selectAllMedia() {
+    if (_cachedMedia.isEmpty) {
+      _applySelectionUpdate(<String>{});
+      return;
+    }
+
+    final allIds = {for (final media in _cachedMedia) media.id};
+    _applySelectionUpdate(allIds);
   }
 
   /// Clears the current media selection and exits selection mode.


### PR DESCRIPTION
## Summary
- update media and directory marquee selection to refresh when scrolling so offscreen items are captured
- add Command+A shortcut and toolbar select-all control when multi-selection is active
- expose select-all helpers on the media and directory view models to back the new UI

## Testing
- not run (Flutter/Dart SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ea0cd2c044832099348feb762908d0