### PR TITLE
Improve directory search bar usability

### DIFF
--- a/lib/features/media_library/presentation/widgets/directory_search_bar.dart
+++ b/lib/features/media_library/presentation/widgets/directory_search_bar.dart
@@ -4,34 +4,89 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../view_models/directory_grid_view_model.dart';
 
 /// Search bar widget for filtering directories.
-class DirectorySearchBar extends ConsumerWidget {
+class DirectorySearchBar extends ConsumerStatefulWidget {
   const DirectorySearchBar({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final state = ref.watch(directoryViewModelProvider);
-    final viewModel = ref.read(directoryViewModelProvider.notifier);
+  ConsumerState<DirectorySearchBar> createState() => _DirectorySearchBarState();
+}
 
-    final searchQuery = switch (state) {
+class _DirectorySearchBarState extends ConsumerState<DirectorySearchBar> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(
+      text: _extractSearchQuery(ref.read(directoryViewModelProvider)),
+    );
+    _controller.selection =
+        TextSelection.collapsed(offset: _controller.text.length);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  String _extractSearchQuery(DirectoryState state) {
+    return switch (state) {
       DirectoryLoaded(:final searchQuery) => searchQuery,
       DirectoryPermissionRevoked(:final searchQuery) => searchQuery,
       DirectoryBookmarkInvalid(:final searchQuery) => searchQuery,
       _ => '',
     };
+  }
+
+  void _refocusGrid(BuildContext context) {
+    final parentScope = FocusScope.of(context).parent;
+    parentScope?.requestFocus();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(directoryViewModelProvider);
+    final viewModel = ref.read(directoryViewModelProvider.notifier);
+
+    final searchQuery = _extractSearchQuery(state);
+    if (_controller.text != searchQuery) {
+      _controller.value = TextEditingValue(
+        text: searchQuery,
+        selection: TextSelection.collapsed(offset: searchQuery.length),
+      );
+    }
 
     return Padding(
       padding: const EdgeInsets.all(16),
-      child: TextField(
-        decoration: InputDecoration(
-          hintText: 'Search directories...',
-          prefixIcon: const Icon(Icons.search),
-          border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
-          filled: true,
-          fillColor: Theme.of(context).colorScheme.surface,
-        ),
-        onChanged: viewModel.searchDirectories,
-        controller: TextEditingController(text: searchQuery)
-          ..selection = TextSelection.collapsed(offset: searchQuery.length),
+      child: ValueListenableBuilder<TextEditingValue>(
+        valueListenable: _controller,
+        builder: (context, value, _) {
+          final hasQuery = value.text.isNotEmpty;
+          return TextField(
+            controller: _controller,
+            decoration: InputDecoration(
+              hintText: 'Search directories...',
+              prefixIcon: const Icon(Icons.search),
+              suffixIcon: hasQuery
+                  ? IconButton(
+                      icon: const Icon(Icons.clear),
+                      onPressed: () {
+                        _controller.clear();
+                        viewModel.searchDirectories('');
+                        _refocusGrid(context);
+                      },
+                    )
+                  : null,
+              border:
+                  OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
+              filled: true,
+              fillColor: Theme.of(context).colorScheme.surface,
+            ),
+            onChanged: viewModel.searchDirectories,
+            onSubmitted: (_) => _refocusGrid(context),
+          );
+        },
       ),
     );
   }


### PR DESCRIPTION
## Summary
- keep the directory search bar's text editing controller persistent and synced with state
- add a clear suffix action to quickly reset the current search query
- refocus the directory grid when a search is submitted to speed up repeated filtering

## Testing
- flutter test *(not run: Flutter SDK unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68eefe6fcf408320a68f1561d216fd42