### PR TITLE
Improve directory search bar usability

### DIFF
--- a/lib/features/media_library/presentation/view_models/directory_grid_view_model.dart
+++ b/lib/features/media_library/presentation/view_models/directory_grid_view_model.dart
@@ -546,6 +546,9 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
 
   /// Searches directories by query.
   void searchDirectories(String query) {
+    if (query == _currentSearchQuery) {
+      return;
+    }
     final previousColumns = switch (state) {
       DirectoryLoaded(columns: final columns) => columns,
       DirectoryPermissionRevoked(columns: final columns) => columns,

--- a/lib/features/media_library/presentation/widgets/directory_search_bar.dart
+++ b/lib/features/media_library/presentation/widgets/directory_search_bar.dart
@@ -4,11 +4,30 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../view_models/directory_grid_view_model.dart';
 
 /// Search bar widget for filtering directories.
-class DirectorySearchBar extends ConsumerWidget {
+class DirectorySearchBar extends ConsumerStatefulWidget {
   const DirectorySearchBar({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<DirectorySearchBar> createState() => _DirectorySearchBarState();
+}
+
+class _DirectorySearchBarState extends ConsumerState<DirectorySearchBar> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final state = ref.watch(directoryViewModelProvider);
     final viewModel = ref.read(directoryViewModelProvider.notifier);
 
@@ -19,20 +38,58 @@ class DirectorySearchBar extends ConsumerWidget {
       _ => '',
     };
 
+    if (_controller.text != searchQuery) {
+      _controller.value = TextEditingValue(
+        text: searchQuery,
+        selection: TextSelection.collapsed(offset: searchQuery.length),
+      );
+    }
+
     return Padding(
       padding: const EdgeInsets.all(16),
-      child: TextField(
-        decoration: InputDecoration(
-          hintText: 'Search directories...',
-          prefixIcon: const Icon(Icons.search),
-          border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
-          filled: true,
-          fillColor: Theme.of(context).colorScheme.surface,
-        ),
-        onChanged: viewModel.searchDirectories,
-        controller: TextEditingController(text: searchQuery)
-          ..selection = TextSelection.collapsed(offset: searchQuery.length),
+      child: ValueListenableBuilder<TextEditingValue>(
+        valueListenable: _controller,
+        builder: (context, value, _) {
+          final hasQuery = value.text.isNotEmpty;
+
+          return TextField(
+            controller: _controller,
+            decoration: InputDecoration(
+              hintText: 'Search directories...',
+              prefixIcon: const Icon(Icons.search),
+              suffixIcon: hasQuery
+                  ? IconButton(
+                      icon: const Icon(Icons.clear),
+                      tooltip: 'Clear search',
+                      onPressed: () {
+                        if (_controller.text.isEmpty) {
+                          return;
+                        }
+                        _controller.clear();
+                        viewModel.searchDirectories('');
+                        _refocusGrid();
+                      },
+                    )
+                  : null,
+              border:
+                  OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
+              filled: true,
+              fillColor: Theme.of(context).colorScheme.surface,
+            ),
+            onChanged: viewModel.searchDirectories,
+            onSubmitted: (_) {
+              viewModel.searchDirectories(_controller.text);
+              _refocusGrid();
+            },
+          );
+        },
       ),
     );
+  }
+
+  void _refocusGrid() {
+    final focusScope = FocusScope.of(context);
+    focusScope.unfocus();
+    focusScope.parent?.requestFocus();
   }
 }


### PR DESCRIPTION
## Summary
- convert the directory search bar to a stateful widget backed by a persistent text controller
- add a clear button and submission shortcut that clears focus back to the grid for faster navigation
- skip redundant search operations in the directory grid view model

## Testing
- flutter analyze *(fails: Flutter SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eefe6fcf408320a68f1561d216fd42