### PR TITLE
Improve directory search bar usability

### DIFF
--- a/lib/features/media_library/presentation/view_models/directory_grid_view_model.dart
+++ b/lib/features/media_library/presentation/view_models/directory_grid_view_model.dart
@@ -546,6 +546,9 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
 
   /// Searches directories by query.
   void searchDirectories(String query) {
+    if (query == _currentSearchQuery) {
+      return;
+    }
     final previousColumns = switch (state) {
       DirectoryLoaded(columns: final columns) => columns,
       DirectoryPermissionRevoked(columns: final columns) => columns,

--- a/lib/features/media_library/presentation/widgets/directory_search_bar.dart
+++ b/lib/features/media_library/presentation/widgets/directory_search_bar.dart
@@ -4,11 +4,68 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../view_models/directory_grid_view_model.dart';
 
 /// Search bar widget for filtering directories.
-class DirectorySearchBar extends ConsumerWidget {
+class DirectorySearchBar extends ConsumerStatefulWidget {
   const DirectorySearchBar({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<DirectorySearchBar> createState() => _DirectorySearchBarState();
+}
+
+class _DirectorySearchBarState extends ConsumerState<DirectorySearchBar> {
+  late final TextEditingController _controller;
+  bool _isUpdatingText = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController();
+    _controller.addListener(_handleControllerChanged);
+  }
+
+  @override
+  void dispose() {
+    _controller.removeListener(_handleControllerChanged);
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _handleControllerChanged() {
+    // Rebuild to reflect suffix icon visibility changes.
+    setState(() {});
+  }
+
+  void _updateControllerText(String text) {
+    if (_controller.text == text) {
+      return;
+    }
+    _isUpdatingText = true;
+    _controller.value = TextEditingValue(
+      text: text,
+      selection: TextSelection.collapsed(offset: text.length),
+    );
+  }
+
+  void _handleSubmitted(String value, DirectoryViewModel viewModel) {
+    viewModel.searchDirectories(value);
+    final parentFocus = Focus.of(context).parent;
+    if (parentFocus != null) {
+      parentFocus.requestFocus();
+    } else {
+      FocusScope.of(context).unfocus();
+    }
+  }
+
+  void _clearSearch(DirectoryViewModel viewModel) {
+    if (_controller.text.isEmpty) {
+      return;
+    }
+    _isUpdatingText = true;
+    _controller.clear();
+    viewModel.searchDirectories('');
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final state = ref.watch(directoryViewModelProvider);
     final viewModel = ref.read(directoryViewModelProvider.notifier);
 
@@ -19,19 +76,35 @@ class DirectorySearchBar extends ConsumerWidget {
       _ => '',
     };
 
+    _updateControllerText(searchQuery);
+
     return Padding(
       padding: const EdgeInsets.all(16),
       child: TextField(
+        controller: _controller,
         decoration: InputDecoration(
           hintText: 'Search directories...',
           prefixIcon: const Icon(Icons.search),
+          suffixIcon: _controller.text.isEmpty
+              ? null
+              : IconButton(
+                  tooltip: 'Clear search',
+                  icon: const Icon(Icons.clear),
+                  onPressed: () => _clearSearch(viewModel),
+                ),
           border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
           filled: true,
           fillColor: Theme.of(context).colorScheme.surface,
         ),
-        onChanged: viewModel.searchDirectories,
-        controller: TextEditingController(text: searchQuery)
-          ..selection = TextSelection.collapsed(offset: searchQuery.length),
+        textInputAction: TextInputAction.search,
+        onChanged: (value) {
+          if (_isUpdatingText) {
+            _isUpdatingText = false;
+            return;
+          }
+          viewModel.searchDirectories(value);
+        },
+        onSubmitted: (value) => _handleSubmitted(value, viewModel),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- convert the directory search bar to maintain a persistent controller, expose a clear suffix icon, and refocus the grid when submitting
- guard the directory search view model entry point against redundant queries to avoid unnecessary work

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68eefe6fcf408320a68f1561d216fd42