### PR TITLE
Enable video playback in the tag slideshow

### DIFF
--- a/lib/features/favorites/presentation/screens/slideshow_screen.dart
+++ b/lib/features/favorites/presentation/screens/slideshow_screen.dart
@@ -99,7 +99,7 @@ class _SlideshowScreenState extends ConsumerState<SlideshowScreen> {
         media: media,
         isPlaying: viewModel.isPlaying,
         isMuted: viewModel.isMuted,
-        isLooping: viewModel.isLooping,
+        isVideoLooping: viewModel.isVideoLooping,
         onProgress: viewModel.updateProgress,
         onCompleted: viewModel.nextItem,
       );
@@ -161,10 +161,13 @@ class _SlideshowScreenState extends ConsumerState<SlideshowScreen> {
                 onNext: viewModel.nextItem,
                 onPrevious: viewModel.previousItem,
                 onToggleLoop: viewModel.toggleLoop,
+                onToggleVideoLoop: viewModel.toggleVideoLoop,
                 onToggleMute: viewModel.toggleMute,
                 onToggleShuffle: viewModel.toggleShuffle,
                 onDurationSelected: viewModel.setImageDisplayDuration,
                 showProgressBar:
+                    viewModel.currentMedia?.type == MediaType.video,
+                showVideoLoopButton:
                     viewModel.currentMedia?.type == MediaType.video,
               ),
 

--- a/lib/features/favorites/presentation/screens/slideshow_screen.dart
+++ b/lib/features/favorites/presentation/screens/slideshow_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../media_library/domain/entities/media_entity.dart';
 import '../view_models/slideshow_view_model.dart';
 import '../widgets/slideshow_controls.dart';
+import '../widgets/slideshow_video_player.dart';
 
 /// Full-screen slideshow screen for viewing favorite media items.
 class SlideshowScreen extends ConsumerStatefulWidget {
@@ -58,7 +59,8 @@ class _SlideshowScreenState extends ConsumerState<SlideshowScreen> {
             _buildSlideshowContent(viewModel, slideshowViewModel),
 
             // Controls overlay
-            if (_areControlsVisible) _buildControlsOverlay(viewModel, slideshowViewModel),
+            if (_areControlsVisible)
+              _buildControlsOverlay(viewModel, slideshowViewModel),
           ],
         ),
       ),
@@ -84,12 +86,25 @@ class _SlideshowScreenState extends ConsumerState<SlideshowScreen> {
       onTap: _toggleControlsVisibility,
       child: Container(
         color: Colors.black,
-        child: Center(child: _buildMediaContent(currentMedia)),
+        child: Center(
+          child: _buildMediaContent(currentMedia, viewModel),
+        ),
       ),
     );
   }
 
-  Widget _buildMediaContent(MediaEntity media) {
+  Widget _buildMediaContent(MediaEntity media, SlideshowViewModel viewModel) {
+    if (media.type == MediaType.video) {
+      return SlideshowVideoPlayer(
+        media: media,
+        isPlaying: viewModel.isPlaying,
+        isMuted: viewModel.isMuted,
+        isLooping: viewModel.isLooping,
+        onProgress: viewModel.updateProgress,
+        onCompleted: viewModel.nextItem,
+      );
+    }
+
     return SizedBox.expand(
       child: Image.file(
         File(media.path),
@@ -149,6 +164,8 @@ class _SlideshowScreenState extends ConsumerState<SlideshowScreen> {
                 onToggleMute: viewModel.toggleMute,
                 onToggleShuffle: viewModel.toggleShuffle,
                 onDurationSelected: viewModel.setImageDisplayDuration,
+                showProgressBar:
+                    viewModel.currentMedia?.type == MediaType.video,
               ),
 
               const SizedBox(height: 16),

--- a/lib/features/favorites/presentation/view_models/slideshow_view_model.dart
+++ b/lib/features/favorites/presentation/view_models/slideshow_view_model.dart
@@ -486,6 +486,7 @@ class SlideshowViewModel extends StateNotifier<SlideshowState> {
 
   /// Updates progress (for video playback).
   void updateProgress(double progress) {
+    final clampedProgress = progress.clamp(0.0, 1.0).toDouble();
     state = switch (state) {
       SlideshowPlaying(
         :final currentIndex,
@@ -500,7 +501,7 @@ class SlideshowViewModel extends StateNotifier<SlideshowState> {
           isPlaying: isPlaying,
           isLooping: isLooping,
           isMuted: isMuted,
-          progress: progress,
+          progress: clampedProgress,
           isShuffleEnabled: isShuffleEnabled,
           imageDisplayDuration: imageDisplayDuration,
         ),
@@ -515,7 +516,7 @@ class SlideshowViewModel extends StateNotifier<SlideshowState> {
           currentIndex: currentIndex,
           isLooping: isLooping,
           isMuted: isMuted,
-          progress: progress,
+          progress: clampedProgress,
           isShuffleEnabled: isShuffleEnabled,
           imageDisplayDuration: imageDisplayDuration,
         ),

--- a/lib/features/favorites/presentation/view_models/slideshow_view_model.dart
+++ b/lib/features/favorites/presentation/view_models/slideshow_view_model.dart
@@ -21,6 +21,7 @@ class SlideshowPlaying extends SlideshowState {
     required this.currentIndex,
     required this.isPlaying,
     required this.isLooping,
+    required this.isVideoLooping,
     required this.isMuted,
     required this.progress,
     required this.isShuffleEnabled,
@@ -30,6 +31,7 @@ class SlideshowPlaying extends SlideshowState {
   final int currentIndex;
   final bool isPlaying;
   final bool isLooping;
+  final bool isVideoLooping;
   final bool isMuted;
   final double progress;
   final bool isShuffleEnabled;
@@ -39,6 +41,7 @@ class SlideshowPlaying extends SlideshowState {
     int? currentIndex,
     bool? isPlaying,
     bool? isLooping,
+    bool? isVideoLooping,
     bool? isMuted,
     double? progress,
     bool? isShuffleEnabled,
@@ -48,6 +51,7 @@ class SlideshowPlaying extends SlideshowState {
       currentIndex: currentIndex ?? this.currentIndex,
       isPlaying: isPlaying ?? this.isPlaying,
       isLooping: isLooping ?? this.isLooping,
+      isVideoLooping: isVideoLooping ?? this.isVideoLooping,
       isMuted: isMuted ?? this.isMuted,
       progress: progress ?? this.progress,
       isShuffleEnabled: isShuffleEnabled ?? this.isShuffleEnabled,
@@ -62,6 +66,7 @@ class SlideshowPaused extends SlideshowState {
   const SlideshowPaused({
     required this.currentIndex,
     required this.isLooping,
+    required this.isVideoLooping,
     required this.isMuted,
     required this.progress,
     required this.isShuffleEnabled,
@@ -70,6 +75,7 @@ class SlideshowPaused extends SlideshowState {
 
   final int currentIndex;
   final bool isLooping;
+  final bool isVideoLooping;
   final bool isMuted;
   final double progress;
   final bool isShuffleEnabled;
@@ -134,6 +140,11 @@ class SlideshowViewModel extends StateNotifier<SlideshowState> {
     SlideshowPaused(:final isLooping) => isLooping,
     _ => false,
   };
+  bool get isVideoLooping => switch (state) {
+    SlideshowPlaying(:final isVideoLooping) => isVideoLooping,
+    SlideshowPaused(:final isVideoLooping) => isVideoLooping,
+    _ => false,
+  };
   bool get isMuted => switch (state) {
     SlideshowPlaying(:final isMuted) => isMuted,
     SlideshowPaused(:final isMuted) => isMuted,
@@ -162,6 +173,7 @@ class SlideshowViewModel extends StateNotifier<SlideshowState> {
     state = SlideshowPaused(
       currentIndex: 0,
       isLooping: false,
+      isVideoLooping: false,
       isMuted: false,
       progress: 0.0,
       isShuffleEnabled: _isShuffleEnabled,
@@ -181,6 +193,7 @@ class SlideshowViewModel extends StateNotifier<SlideshowState> {
       currentIndex: currentIndex,
       isPlaying: true,
       isLooping: isLooping,
+      isVideoLooping: isVideoLooping,
       isMuted: isMuted,
       progress: 0.0,
       isShuffleEnabled: _isShuffleEnabled,
@@ -197,12 +210,14 @@ class SlideshowViewModel extends StateNotifier<SlideshowState> {
       SlideshowPlaying(
         :final currentIndex,
         :final isLooping,
+        :final isVideoLooping,
         :final isMuted,
         :final progress,
       ) =>
         SlideshowPaused(
           currentIndex: currentIndex,
           isLooping: isLooping,
+          isVideoLooping: isVideoLooping,
           isMuted: isMuted,
           progress: progress,
           isShuffleEnabled: _isShuffleEnabled,
@@ -220,6 +235,7 @@ class SlideshowViewModel extends StateNotifier<SlideshowState> {
       SlideshowPaused(
         :final currentIndex,
         :final isLooping,
+        :final isVideoLooping,
         :final isMuted,
         :final progress,
       ) =>
@@ -227,6 +243,7 @@ class SlideshowViewModel extends StateNotifier<SlideshowState> {
           currentIndex: currentIndex,
           isPlaying: true,
           isLooping: isLooping,
+          isVideoLooping: isVideoLooping,
           isMuted: isMuted,
           progress: progress,
           isShuffleEnabled: _isShuffleEnabled,
@@ -280,20 +297,22 @@ class SlideshowViewModel extends StateNotifier<SlideshowState> {
     _timer?.cancel();
 
     state = switch (state) {
-      SlideshowPlaying(:final isLooping, :final isMuted) =>
+      SlideshowPlaying(:final isLooping, :final isVideoLooping, :final isMuted) =>
         SlideshowPlaying(
           currentIndex: index,
           isPlaying: wasPlaying,
           isLooping: isLooping,
+          isVideoLooping: isVideoLooping,
           isMuted: isMuted,
           progress: 0.0,
           isShuffleEnabled: _isShuffleEnabled,
           imageDisplayDuration: _imageDisplayDuration,
         ),
-      SlideshowPaused(:final isLooping, :final isMuted) =>
+      SlideshowPaused(:final isLooping, :final isVideoLooping, :final isMuted) =>
         SlideshowPaused(
           currentIndex: index,
           isLooping: isLooping,
+          isVideoLooping: isVideoLooping,
           isMuted: isMuted,
           progress: 0.0,
           isShuffleEnabled: _isShuffleEnabled,
@@ -304,6 +323,7 @@ class SlideshowViewModel extends StateNotifier<SlideshowState> {
               currentIndex: index,
               isPlaying: wasPlaying,
               isLooping: false,
+              isVideoLooping: isVideoLooping,
               isMuted: false,
               progress: 0.0,
               isShuffleEnabled: _isShuffleEnabled,
@@ -312,6 +332,7 @@ class SlideshowViewModel extends StateNotifier<SlideshowState> {
           : SlideshowPaused(
               currentIndex: index,
               isLooping: false,
+              isVideoLooping: isVideoLooping,
               isMuted: false,
               progress: 0.0,
               isShuffleEnabled: _isShuffleEnabled,
@@ -331,6 +352,7 @@ class SlideshowViewModel extends StateNotifier<SlideshowState> {
         :final currentIndex,
         :final isPlaying,
         :final isLooping,
+        :final isVideoLooping,
         :final isMuted,
         :final progress,
         :final isShuffleEnabled,
@@ -340,6 +362,7 @@ class SlideshowViewModel extends StateNotifier<SlideshowState> {
           currentIndex: currentIndex,
           isPlaying: isPlaying,
           isLooping: !isLooping,
+          isVideoLooping: isVideoLooping,
           isMuted: isMuted,
           progress: progress,
           isShuffleEnabled: isShuffleEnabled,
@@ -348,6 +371,7 @@ class SlideshowViewModel extends StateNotifier<SlideshowState> {
       SlideshowPaused(
         :final currentIndex,
         :final isLooping,
+        :final isVideoLooping,
         :final isMuted,
         :final progress,
         :final isShuffleEnabled,
@@ -356,6 +380,52 @@ class SlideshowViewModel extends StateNotifier<SlideshowState> {
         SlideshowPaused(
           currentIndex: currentIndex,
           isLooping: !isLooping,
+          isVideoLooping: isVideoLooping,
+          isMuted: isMuted,
+          progress: progress,
+          isShuffleEnabled: isShuffleEnabled,
+          imageDisplayDuration: imageDisplayDuration,
+        ),
+      _ => state,
+    };
+  }
+
+  /// Toggles looping for the current video item without advancing the slideshow.
+  void toggleVideoLoop() {
+    state = switch (state) {
+      SlideshowPlaying(
+        :final currentIndex,
+        :final isPlaying,
+        :final isLooping,
+        :final isVideoLooping,
+        :final isMuted,
+        :final progress,
+        :final isShuffleEnabled,
+        :final imageDisplayDuration,
+      ) =>
+        SlideshowPlaying(
+          currentIndex: currentIndex,
+          isPlaying: isPlaying,
+          isLooping: isLooping,
+          isVideoLooping: !isVideoLooping,
+          isMuted: isMuted,
+          progress: progress,
+          isShuffleEnabled: isShuffleEnabled,
+          imageDisplayDuration: imageDisplayDuration,
+        ),
+      SlideshowPaused(
+        :final currentIndex,
+        :final isLooping,
+        :final isVideoLooping,
+        :final isMuted,
+        :final progress,
+        :final isShuffleEnabled,
+        :final imageDisplayDuration,
+      ) =>
+        SlideshowPaused(
+          currentIndex: currentIndex,
+          isLooping: isLooping,
+          isVideoLooping: !isVideoLooping,
           isMuted: isMuted,
           progress: progress,
           isShuffleEnabled: isShuffleEnabled,
@@ -372,6 +442,7 @@ class SlideshowViewModel extends StateNotifier<SlideshowState> {
         :final currentIndex,
         :final isPlaying,
         :final isLooping,
+        :final isVideoLooping,
         :final isMuted,
         :final progress,
         :final isShuffleEnabled,
@@ -381,6 +452,7 @@ class SlideshowViewModel extends StateNotifier<SlideshowState> {
           currentIndex: currentIndex,
           isPlaying: isPlaying,
           isLooping: isLooping,
+          isVideoLooping: isVideoLooping,
           isMuted: !isMuted,
           progress: progress,
           isShuffleEnabled: isShuffleEnabled,
@@ -389,6 +461,7 @@ class SlideshowViewModel extends StateNotifier<SlideshowState> {
       SlideshowPaused(
         :final currentIndex,
         :final isLooping,
+        :final isVideoLooping,
         :final isMuted,
         :final progress,
         :final isShuffleEnabled,
@@ -397,6 +470,7 @@ class SlideshowViewModel extends StateNotifier<SlideshowState> {
         SlideshowPaused(
           currentIndex: currentIndex,
           isLooping: isLooping,
+          isVideoLooping: isVideoLooping,
           isMuted: !isMuted,
           progress: progress,
           isShuffleEnabled: isShuffleEnabled,
@@ -441,12 +515,14 @@ class SlideshowViewModel extends StateNotifier<SlideshowState> {
       SlideshowPlaying(
         :final currentIndex,
         :final isLooping,
+        :final isVideoLooping,
         :final isMuted,
       ) =>
         SlideshowPlaying(
           currentIndex: currentIndex,
           isPlaying: true,
           isLooping: isLooping,
+          isVideoLooping: isVideoLooping,
           isMuted: isMuted,
           progress: 0.0,
           isShuffleEnabled: _isShuffleEnabled,
@@ -455,11 +531,13 @@ class SlideshowViewModel extends StateNotifier<SlideshowState> {
       SlideshowPaused(
         :final currentIndex,
         :final isLooping,
+        :final isVideoLooping,
         :final isMuted,
       ) =>
         SlideshowPaused(
           currentIndex: currentIndex,
           isLooping: isLooping,
+          isVideoLooping: isVideoLooping,
           isMuted: isMuted,
           progress: 0.0,
           isShuffleEnabled: _isShuffleEnabled,
@@ -471,6 +549,7 @@ class SlideshowViewModel extends StateNotifier<SlideshowState> {
             : SlideshowPaused(
                 currentIndex: 0,
                 isLooping: false,
+                isVideoLooping: false,
                 isMuted: false,
                 progress: 0.0,
                 isShuffleEnabled: _isShuffleEnabled,
@@ -492,6 +571,7 @@ class SlideshowViewModel extends StateNotifier<SlideshowState> {
         :final currentIndex,
         :final isPlaying,
         :final isLooping,
+        :final isVideoLooping,
         :final isMuted,
         :final isShuffleEnabled,
         :final imageDisplayDuration,
@@ -500,6 +580,7 @@ class SlideshowViewModel extends StateNotifier<SlideshowState> {
           currentIndex: currentIndex,
           isPlaying: isPlaying,
           isLooping: isLooping,
+          isVideoLooping: isVideoLooping,
           isMuted: isMuted,
           progress: clampedProgress,
           isShuffleEnabled: isShuffleEnabled,
@@ -508,6 +589,7 @@ class SlideshowViewModel extends StateNotifier<SlideshowState> {
       SlideshowPaused(
         :final currentIndex,
         :final isLooping,
+        :final isVideoLooping,
         :final isMuted,
         :final isShuffleEnabled,
         :final imageDisplayDuration,
@@ -515,6 +597,7 @@ class SlideshowViewModel extends StateNotifier<SlideshowState> {
         SlideshowPaused(
           currentIndex: currentIndex,
           isLooping: isLooping,
+          isVideoLooping: isVideoLooping,
           isMuted: isMuted,
           progress: clampedProgress,
           isShuffleEnabled: isShuffleEnabled,

--- a/lib/features/favorites/presentation/widgets/slideshow_controls.dart
+++ b/lib/features/favorites/presentation/widgets/slideshow_controls.dart
@@ -15,6 +15,7 @@ class SlideshowControls extends StatelessWidget {
     required this.onToggleMute,
     required this.onToggleShuffle,
     required this.onDurationSelected,
+    required this.showProgressBar,
   });
 
   final SlideshowState state;
@@ -25,6 +26,7 @@ class SlideshowControls extends StatelessWidget {
   final VoidCallback onToggleMute;
   final VoidCallback onToggleShuffle;
   final ValueChanged<Duration> onDurationSelected;
+  final bool showProgressBar;
 
   static const Duration _defaultDuration = Duration(seconds: 5);
 
@@ -56,8 +58,12 @@ class SlideshowControls extends StatelessWidget {
         _buildMuteButton(),
         const SizedBox(width: 32),
         _buildDurationSlider(context),
-        const SizedBox(width: 32),
-        if (_isVideoState()) _buildProgressBar(),
+        if (showProgressBar) ...[
+          const SizedBox(width: 32),
+          Expanded(
+            child: _buildProgressBar(),
+          ),
+        ],
       ],
     );
   }
@@ -204,22 +210,14 @@ class SlideshowControls extends StatelessWidget {
       _ => 0.0,
     };
 
-    return Expanded(
-      child: Container(
-        height: 4,
-        margin: const EdgeInsets.symmetric(horizontal: 16),
-        child: LinearProgressIndicator(
-          value: progress,
-          backgroundColor: Colors.white.withValues(alpha: 0.3),
-          valueColor: const AlwaysStoppedAnimation<Color>(Colors.white),
-        ),
+    return Container(
+      height: 4,
+      margin: const EdgeInsets.symmetric(horizontal: 16),
+      child: LinearProgressIndicator(
+        value: progress,
+        backgroundColor: Colors.white.withValues(alpha: 0.3),
+        valueColor: const AlwaysStoppedAnimation<Color>(Colors.white),
       ),
     );
-  }
-
-  bool _isVideoState() {
-    // This would check if the current media is a video
-    // For now, return false as we don't have video detection
-    return false;
   }
 }

--- a/lib/features/favorites/presentation/widgets/slideshow_controls.dart
+++ b/lib/features/favorites/presentation/widgets/slideshow_controls.dart
@@ -12,10 +12,12 @@ class SlideshowControls extends StatelessWidget {
     required this.onNext,
     required this.onPrevious,
     required this.onToggleLoop,
+    required this.onToggleVideoLoop,
     required this.onToggleMute,
     required this.onToggleShuffle,
     required this.onDurationSelected,
     required this.showProgressBar,
+    required this.showVideoLoopButton,
   });
 
   final SlideshowState state;
@@ -23,10 +25,12 @@ class SlideshowControls extends StatelessWidget {
   final VoidCallback onNext;
   final VoidCallback onPrevious;
   final VoidCallback onToggleLoop;
+  final VoidCallback onToggleVideoLoop;
   final VoidCallback onToggleMute;
   final VoidCallback onToggleShuffle;
   final ValueChanged<Duration> onDurationSelected;
   final bool showProgressBar;
+  final bool showVideoLoopButton;
 
   static const Duration _defaultDuration = Duration(seconds: 5);
 
@@ -63,6 +67,10 @@ class SlideshowControls extends StatelessWidget {
           Expanded(
             child: _buildProgressBar(),
           ),
+          if (showVideoLoopButton) ...[
+            const SizedBox(width: 16),
+            _buildVideoLoopButton(),
+          ],
         ],
       ],
     );
@@ -218,6 +226,23 @@ class SlideshowControls extends StatelessWidget {
         backgroundColor: Colors.white.withValues(alpha: 0.3),
         valueColor: const AlwaysStoppedAnimation<Color>(Colors.white),
       ),
+    );
+  }
+
+  Widget _buildVideoLoopButton() {
+    final isVideoLooping = switch (state) {
+      SlideshowPlaying(:final isVideoLooping) => isVideoLooping,
+      SlideshowPaused(:final isVideoLooping) => isVideoLooping,
+      _ => false,
+    };
+
+    return IconButton(
+      icon: Icon(
+        Icons.repeat_one,
+        color: isVideoLooping ? Colors.blue : Colors.white,
+      ),
+      onPressed: onToggleVideoLoop,
+      tooltip: isVideoLooping ? 'Disable video loop' : 'Loop current video',
     );
   }
 }

--- a/lib/features/favorites/presentation/widgets/slideshow_video_player.dart
+++ b/lib/features/favorites/presentation/widgets/slideshow_video_player.dart
@@ -16,7 +16,7 @@ class SlideshowVideoPlayer extends StatefulWidget {
     required this.media,
     required this.isPlaying,
     required this.isMuted,
-    required this.isLooping,
+    required this.isVideoLooping,
     required this.onProgress,
     required this.onCompleted,
   });
@@ -24,7 +24,7 @@ class SlideshowVideoPlayer extends StatefulWidget {
   final MediaEntity media;
   final bool isPlaying;
   final bool isMuted;
-  final bool isLooping;
+  final bool isVideoLooping;
   final ValueChanged<double> onProgress;
   final VoidCallback onCompleted;
 
@@ -61,8 +61,9 @@ class _SlideshowVideoPlayerState extends State<SlideshowVideoPlayer> {
     if (widget.isMuted != oldWidget.isMuted) {
       controller.setVolume(widget.isMuted ? 0.0 : 1.0);
     }
-    if (widget.isLooping != oldWidget.isLooping) {
-      controller.setLooping(widget.isLooping);
+    if (widget.isVideoLooping != oldWidget.isVideoLooping) {
+      _hasCompleted = false;
+      controller.setLooping(widget.isVideoLooping);
     }
     if (widget.isPlaying != oldWidget.isPlaying) {
       _hasCompleted = false;
@@ -86,7 +87,7 @@ class _SlideshowVideoPlayerState extends State<SlideshowVideoPlayer> {
     try {
       await controller.initialize();
       await controller.setVolume(widget.isMuted ? 0.0 : 1.0);
-      await controller.setLooping(widget.isLooping);
+      await controller.setLooping(widget.isVideoLooping);
       controller.addListener(_onVideoUpdate);
 
       if (widget.isPlaying) {
@@ -118,7 +119,7 @@ class _SlideshowVideoPlayerState extends State<SlideshowVideoPlayer> {
     }
 
     final hasFinished = duration > Duration.zero && position >= duration;
-    if (!widget.isLooping && widget.isPlaying && hasFinished && !_hasCompleted) {
+    if (!widget.isVideoLooping && widget.isPlaying && hasFinished && !_hasCompleted) {
       _hasCompleted = true;
       widget.onProgress(1.0);
       widget.onCompleted();

--- a/lib/features/favorites/presentation/widgets/slideshow_video_player.dart
+++ b/lib/features/favorites/presentation/widgets/slideshow_video_player.dart
@@ -1,0 +1,153 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:video_player/video_player.dart';
+
+import '../../../media_library/domain/entities/media_entity.dart';
+
+/// Video player dedicated to the slideshow experience.
+///
+/// It keeps the [`SlideshowViewModel`] informed about playback progress and
+/// notifies when the current video has finished so the carousel can advance to
+/// the following media item.
+class SlideshowVideoPlayer extends StatefulWidget {
+  const SlideshowVideoPlayer({
+    super.key,
+    required this.media,
+    required this.isPlaying,
+    required this.isMuted,
+    required this.isLooping,
+    required this.onProgress,
+    required this.onCompleted,
+  });
+
+  final MediaEntity media;
+  final bool isPlaying;
+  final bool isMuted;
+  final bool isLooping;
+  final ValueChanged<double> onProgress;
+  final VoidCallback onCompleted;
+
+  @override
+  State<SlideshowVideoPlayer> createState() => _SlideshowVideoPlayerState();
+}
+
+class _SlideshowVideoPlayerState extends State<SlideshowVideoPlayer> {
+  VideoPlayerController? _controller;
+  bool _hasCompleted = false;
+
+  VideoPlayerController? get _activeController => _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _initializeController();
+  }
+
+  @override
+  void didUpdateWidget(SlideshowVideoPlayer oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (widget.media.path != oldWidget.media.path) {
+      _initializeController();
+      return;
+    }
+
+    final controller = _activeController;
+    if (controller == null || !controller.value.isInitialized) {
+      return;
+    }
+
+    if (widget.isMuted != oldWidget.isMuted) {
+      controller.setVolume(widget.isMuted ? 0.0 : 1.0);
+    }
+    if (widget.isLooping != oldWidget.isLooping) {
+      controller.setLooping(widget.isLooping);
+    }
+    if (widget.isPlaying != oldWidget.isPlaying) {
+      _hasCompleted = false;
+      if (widget.isPlaying) {
+        controller.play();
+      } else {
+        controller.pause();
+      }
+    }
+  }
+
+  Future<void> _initializeController() async {
+    final previousController = _activeController;
+    previousController?.removeListener(_onVideoUpdate);
+    await previousController?.dispose();
+
+    _hasCompleted = false;
+    final controller = VideoPlayerController.file(File(widget.media.path));
+    _controller = controller;
+
+    try {
+      await controller.initialize();
+      await controller.setVolume(widget.isMuted ? 0.0 : 1.0);
+      await controller.setLooping(widget.isLooping);
+      controller.addListener(_onVideoUpdate);
+
+      if (widget.isPlaying) {
+        await controller.play();
+      }
+
+      widget.onProgress(0.0);
+
+      if (mounted) {
+        setState(() {});
+      }
+    } catch (error) {
+      debugPrint('Failed to initialize slideshow video: $error');
+    }
+  }
+
+  void _onVideoUpdate() {
+    final controller = _activeController;
+    if (controller == null || !mounted) return;
+
+    final value = controller.value;
+    final duration = value.duration;
+    final position = value.position;
+
+    if (duration > Duration.zero) {
+      final progress =
+          (position.inMilliseconds / duration.inMilliseconds).clamp(0.0, 1.0);
+      widget.onProgress(progress.toDouble());
+    }
+
+    final hasFinished = duration > Duration.zero && position >= duration;
+    if (!widget.isLooping && widget.isPlaying && hasFinished && !_hasCompleted) {
+      _hasCompleted = true;
+      widget.onProgress(1.0);
+      widget.onCompleted();
+    } else if (!hasFinished) {
+      _hasCompleted = false;
+    }
+  }
+
+  @override
+  void dispose() {
+    _activeController?.removeListener(_onVideoUpdate);
+    _activeController?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = _activeController;
+    if (controller == null || !controller.value.isInitialized) {
+      return const Center(
+        child: CircularProgressIndicator(color: Colors.white),
+      );
+    }
+
+    return Center(
+      child: AspectRatio(
+        aspectRatio: controller.value.aspectRatio,
+        child: VideoPlayer(controller),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated slideshow video player widget to handle progress reporting and completion callbacks for videos
- wire the slideshow screen and controls to use the video player, showing progress only for video items and clamping stored progress values

## Testing
- `flutter test` *(fails: Flutter is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f2fc5abe04832096cb901174097745