### PR TITLE
refactor: centralize permission issue panel

### DIFF
--- a/lib/features/full_screen/presentation/screens/full_screen_viewer_screen.dart
+++ b/lib/features/full_screen/presentation/screens/full_screen_viewer_screen.dart
@@ -13,6 +13,7 @@ import '../widgets/full_screen_favorite_toggle.dart';
 import '../widgets/full_screen_image_viewer.dart';
 import '../widgets/full_screen_video_controls.dart';
 import '../widgets/full_screen_video_player.dart';
+import '../../../../shared/widgets/permission_issue_panel.dart';
 
 /// Full-screen media viewer screen
 class FullScreenViewerScreen extends ConsumerStatefulWidget {
@@ -345,94 +346,40 @@ class _FullScreenViewerScreenState
   Widget _buildPermissionRevoked() {
     final colorScheme = Theme.of(context).colorScheme;
     return Center(
-      child: Container(
-        padding: const EdgeInsets.all(24),
-        margin: const EdgeInsets.symmetric(horizontal: 32),
-        decoration: BoxDecoration(
-          color: colorScheme.surface.withValues(alpha: 0.9),
-          borderRadius: BorderRadius.circular(12),
-          border: Border.all(color: colorScheme.error, width: 2),
-          boxShadow: [
-            BoxShadow(
-              color: colorScheme.shadow.withValues(alpha: 0.3),
-              blurRadius: 10,
-              offset: const Offset(0, 4),
-            ),
-          ],
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(
-              Icons.lock,
-              size: 64,
-              color: colorScheme.error,
-            ),
-            const SizedBox(height: 16),
-            Text(
-              'Access to this directory has been revoked',
-              style: TextStyle(
-                color: colorScheme.onSurface,
-                fontSize: 18,
-                fontWeight: FontWeight.bold,
-              ),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'The permissions for this directory are no longer available.',
-              style: TextStyle(color: colorScheme.onSurfaceVariant, fontSize: 16),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'This can happen when security-scoped bookmarks expire or when directory permissions change.',
-              style: TextStyle(color: colorScheme.onSurfaceVariant, fontSize: 14),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 24),
-            ElevatedButton.icon(
-              onPressed: () async {
-                // Try to recover permissions using the view model
-                final success = await _viewModel.attemptPermissionRecovery(
-                  widget.directoryPath,
-                  bookmarkData: widget.bookmarkData,
-                );
+      child: PermissionIssuePanel(
+        message: 'The permissions for this directory are no longer available.',
+        helpText:
+            'This can happen when security-scoped bookmarks expire or when directory permissions change.',
+        footerText:
+            'Return to the media grid and re-select the directory to restore full access.',
+        recoverLabel: 'Try to Recover',
+        recoverIcon: Icons.refresh,
+        backLabel: 'Back to Grid',
+        backIcon: Icons.arrow_back,
+        accentColor: colorScheme.error,
+        backgroundColor: colorScheme.surface.withValues(alpha: 0.9),
+        borderColor: colorScheme.error,
+        onRecover: () async {
+          final success = await _viewModel.attemptPermissionRecovery(
+            widget.directoryPath,
+            bookmarkData: widget.bookmarkData,
+          );
 
-                if (context.mounted) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: Text(success ? 'Access recovered successfully!' : 'Recovery failed. Please go back and re-select the directory.'),
-                      backgroundColor: success ? colorScheme.primary : colorScheme.error,
-                    ),
-                  );
-                }
-              },
-              icon: const Icon(Icons.refresh),
-              label: const Text('Try to Recover'),
-              style: ElevatedButton.styleFrom(
-                backgroundColor: colorScheme.primary,
-                foregroundColor: colorScheme.onPrimary,
+          if (context.mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(
+                  success
+                      ? 'Access recovered successfully!'
+                      : 'Recovery failed. Please go back and re-select the directory.',
+                ),
+                backgroundColor:
+                    success ? colorScheme.primary : colorScheme.error,
               ),
-            ),
-            const SizedBox(height: 12),
-            ElevatedButton.icon(
-              onPressed: () => Navigator.of(context).pop(),
-              icon: const Icon(Icons.arrow_back),
-              label: const Text('Back to Grid'),
-              style: ElevatedButton.styleFrom(
-                backgroundColor: colorScheme.secondary,
-                foregroundColor: colorScheme.onSecondary,
-              ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'Return to the media grid and re-select the directory to restore full access.',
-              style: TextStyle(color: colorScheme.onSurfaceVariant, fontSize: 12),
-              textAlign: TextAlign.center,
-            ),
-          ],
-        ),
+            );
+          }
+        },
+        onBack: () => Navigator.of(context).pop(),
       ),
     );
   }

--- a/lib/features/media_library/presentation/screens/directory_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/directory_grid_screen.dart
@@ -14,6 +14,7 @@ import '../../../../core/constants/ui_constants.dart';
 
 import '../../../../shared/providers/grid_columns_provider.dart';
 import '../../../../shared/providers/repository_providers.dart';
+import '../../../../shared/widgets/permission_issue_panel.dart';
 import '../../../tagging/domain/entities/tag_entity.dart';
 import '../../../tagging/presentation/states/tag_state.dart';
 import '../../../tagging/presentation/view_models/tag_management_view_model.dart';
@@ -501,29 +502,24 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
     return Column(
       children: [
         if (inaccessibleDirectories.isNotEmpty)
-          Container(
-            padding: UiSpacing.gridPadding,
-            color: Colors.orange.shade50,
-            child: Row(
-              children: [
-                Icon(Icons.warning, color: UiColors.orange),
-                SizedBox(width: UiSpacing.smallGap),
-                Expanded(
-                  child: Text(
-                    '${inaccessibleDirectories.length} directory(ies) are inaccessible due to permission changes. '
-                    'Click "Re-grant Permissions" to restore access.',
-                    style: TextStyle(color: UiColors.orange),
-                  ),
-                ),
-                ElevatedButton(
-                  onPressed: () => _showReGrantPermissionsDialog(
-                    context,
-                    inaccessibleDirectories,
-                    viewModel,
-                  ),
-                  child: const Text('Re-grant Permissions'),
-                ),
-              ],
+          PermissionIssuePanel(
+            title: 'Access to some directories has been revoked',
+            message:
+                '${inaccessibleDirectories.length} directory(ies) are inaccessible due to permission changes.',
+            helpText: 'Select "Re-grant Permissions" to restore access.',
+            recoverLabel: 'Re-grant Permissions',
+            recoverIcon: Icons.verified_user,
+            accentColor: Theme.of(context).colorScheme.error,
+            borderColor: Theme.of(context).colorScheme.error,
+            backgroundColor: Theme.of(context).colorScheme.surface,
+            margin: UiSpacing.gridPadding,
+            padding: const EdgeInsets.all(16),
+            fullWidth: true,
+            dense: true,
+            onRecover: () async => _showReGrantPermissionsDialog(
+              context,
+              inaccessibleDirectories,
+              viewModel,
             ),
           ),
         Expanded(

--- a/lib/features/media_library/presentation/screens/media_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/media_grid_screen.dart
@@ -12,6 +12,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../core/config/app_config.dart';
 import '../../../../core/constants/ui_constants.dart';
 import '../../../../shared/providers/grid_columns_provider.dart';
+import '../../../../shared/widgets/permission_issue_panel.dart';
 
 import '../../../favorites/presentation/view_models/favorites_view_model.dart';
 import '../../../full_screen/presentation/screens/full_screen_viewer_screen.dart';
@@ -663,88 +664,40 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
     MediaViewModel viewModel,
   ) {
     return Center(
-      child: Container(
-        padding: UiSpacing.dialogPadding,
-        margin: UiSpacing.dialogMargin,
-        decoration: BoxDecoration(
-          color: UiColors.white,
-          borderRadius: BorderRadius.circular(UiSizing.borderRadiusMedium),
-          border: Border.all(
-            color: UiColors.orange,
-            width: UiSizing.borderWidth,
-          ),
-          boxShadow: [UiShadows.standard],
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(Icons.lock, size: UiSizing.iconHuge, color: UiColors.orange),
-            SizedBox(height: UiSpacing.verticalGap),
-            const Text(
-              'Access to this directory has been revoked',
-              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-              textAlign: TextAlign.center,
-            ),
-            SizedBox(height: UiSpacing.smallGap),
-            Text(
-              'The permissions for "$directoryName" are no longer available.',
-              textAlign: TextAlign.center,
-              style: const TextStyle(fontSize: 16),
-            ),
-            SizedBox(height: UiSpacing.smallGap),
-            const Text(
-              'This can happen when security-scoped bookmarks expire or when directory permissions change.',
-              textAlign: TextAlign.center,
-              style: TextStyle(fontSize: 14, color: Colors.grey),
-            ),
-            SizedBox(height: UiSpacing.verticalGap * 1.5),
-            ElevatedButton.icon(
-              onPressed: () async {
-                try {
-                  await viewModel.recoverPermissions();
-                  // Show success feedback
-                  if (context.mounted) {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(
-                        content: Text('Permissions recovered successfully!'),
-                        backgroundColor: Colors.green,
-                      ),
-                    );
-                  }
-                } catch (e) {
-                  // Show error feedback
-                  if (context.mounted) {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        content: Text('Failed to recover permissions: $e'),
-                        backgroundColor: Colors.red,
-                      ),
-                    );
-                  }
-                }
-              },
-              icon: const Icon(Icons.folder_open),
-              label: const Text('Re-select Directory'),
-              style: ElevatedButton.styleFrom(
-                backgroundColor: UiColors.orange,
-                foregroundColor: UiColors.white,
-                padding: UiSpacing.buttonPadding,
-              ),
-            ),
-            const SizedBox(height: 12),
-            OutlinedButton.icon(
-              onPressed: () =>
-                  viewModel.loadMedia(), // Try refreshing without recovery
-              icon: const Icon(Icons.refresh),
-              label: const Text('Try Again'),
-            ),
-            SizedBox(height: UiSpacing.verticalGap),
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: const Text('Go Back'),
-            ),
-          ],
-        ),
+      child: PermissionIssuePanel(
+        message: 'The permissions for "$directoryName" are no longer available.',
+        helpText:
+            'This can happen when security-scoped bookmarks expire or when directory permissions change.',
+        recoverLabel: 'Re-select Directory',
+        recoverIcon: Icons.folder_open,
+        tryAgainIcon: Icons.refresh,
+        backIcon: Icons.arrow_back,
+        tryAgainLabel: 'Try Again',
+        backLabel: 'Go Back',
+        onRecover: () async {
+          try {
+            await viewModel.recoverPermissions();
+            if (context.mounted) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text('Permissions recovered successfully!'),
+                  backgroundColor: Colors.green,
+                ),
+              );
+            }
+          } catch (e) {
+            if (context.mounted) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text('Failed to recover permissions: $e'),
+                  backgroundColor: Colors.red,
+                ),
+              );
+            }
+          }
+        },
+        onTryAgain: viewModel.loadMedia,
+        onBack: () => Navigator.of(context).pop(),
       ),
     );
   }

--- a/lib/shared/widgets/permission_issue_panel.dart
+++ b/lib/shared/widgets/permission_issue_panel.dart
@@ -1,0 +1,204 @@
+import 'package:flutter/material.dart';
+
+import '../../core/constants/ui_constants.dart';
+
+/// A shared panel widget for displaying permission or access issues with
+/// consistent styling across the application.
+class PermissionIssuePanel extends StatelessWidget {
+  const PermissionIssuePanel({
+    super.key,
+    this.icon = Icons.lock,
+    this.showIcon = true,
+    this.title = 'Access to this directory has been revoked',
+    this.message,
+    this.helpText,
+    this.footerText,
+    this.onRecover,
+    this.onTryAgain,
+    this.onBack,
+    this.recoverLabel = 'Recover Access',
+    this.tryAgainLabel = 'Try Again',
+    this.backLabel = 'Back',
+    this.recoverIcon = Icons.refresh,
+    this.tryAgainIcon = Icons.refresh,
+    this.backIcon = Icons.arrow_back,
+    this.accentColor,
+    this.backgroundColor,
+    this.borderColor,
+    this.margin,
+    this.padding,
+    this.fullWidth = false,
+    this.dense = false,
+  });
+
+  /// Icon displayed at the top of the panel.
+  final IconData icon;
+
+  /// Whether the icon should be displayed.
+  final bool showIcon;
+
+  /// Title text describing the permission issue.
+  final String title;
+
+  /// Optional descriptive message providing more context.
+  final String? message;
+
+  /// Optional helper text to guide the user.
+  final String? helpText;
+
+  /// Optional footer text shown after the actions.
+  final String? footerText;
+
+  /// Callback executed when the recover action is triggered.
+  final Future<void> Function()? onRecover;
+
+  /// Callback executed when the retry action is triggered.
+  final VoidCallback? onTryAgain;
+
+  /// Callback executed when the back action is triggered.
+  final VoidCallback? onBack;
+
+  /// Label for the recover action button.
+  final String recoverLabel;
+
+  /// Label for the retry action button.
+  final String tryAgainLabel;
+
+  /// Label for the back action button.
+  final String backLabel;
+
+  /// Icon for the recover action button.
+  final IconData recoverIcon;
+
+  /// Icon for the retry action button.
+  final IconData tryAgainIcon;
+
+  /// Icon for the back action button.
+  final IconData backIcon;
+
+  /// Accent color used for the icon, border, and emphasis.
+  final Color? accentColor;
+
+  /// Background color of the panel container.
+  final Color? backgroundColor;
+
+  /// Border color of the panel container.
+  final Color? borderColor;
+
+  /// Margin applied around the panel.
+  final EdgeInsetsGeometry? margin;
+
+  /// Padding applied within the panel container.
+  final EdgeInsetsGeometry? padding;
+
+  /// Whether the panel should expand to the maximum width available.
+  final bool fullWidth;
+
+  /// Reduces spacing between elements when set to true.
+  final bool dense;
+
+  bool get _hasActions => onRecover != null || onTryAgain != null || onBack != null;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final effectiveAccent = accentColor ?? colorScheme.error;
+    final effectiveBorder = borderColor ?? effectiveAccent;
+    final effectiveBackground = backgroundColor ?? colorScheme.surface;
+    final effectiveMargin = margin ?? UiSpacing.dialogMargin;
+    final effectivePadding = padding ?? UiSpacing.dialogPadding;
+    final verticalGap = dense ? UiSpacing.smallGap : UiSpacing.verticalGap;
+
+    return Container(
+      width: fullWidth ? double.infinity : null,
+      margin: effectiveMargin,
+      padding: effectivePadding,
+      decoration: BoxDecoration(
+        color: effectiveBackground,
+        borderRadius: BorderRadius.circular(UiSizing.borderRadiusMedium),
+        border: Border.all(color: effectiveBorder, width: UiSizing.borderWidth),
+        boxShadow: const [UiShadows.standard],
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          if (showIcon)
+            Icon(
+              icon,
+              size: UiSizing.iconHuge,
+              color: effectiveAccent,
+            ),
+          if (showIcon) SizedBox(height: verticalGap),
+          Text(
+            title,
+            style: TextStyle(
+              color: colorScheme.onSurface,
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          if (message != null) ...[
+            SizedBox(height: UiSpacing.smallGap),
+            Text(
+              message!,
+              textAlign: TextAlign.center,
+              style: TextStyle(color: colorScheme.onSurface, fontSize: 16),
+            ),
+          ],
+          if (helpText != null) ...[
+            SizedBox(height: UiSpacing.smallGap),
+            Text(
+              helpText!,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: colorScheme.onSurfaceVariant,
+                fontSize: 14,
+              ),
+            ),
+          ],
+          if (_hasActions) ...[
+            SizedBox(height: dense ? UiSpacing.smallGap : UiSpacing.verticalGap * 1.5),
+            Wrap(
+              alignment: WrapAlignment.center,
+              spacing: UiSpacing.smallGap,
+              runSpacing: UiSpacing.smallGap,
+              children: [
+                if (onRecover != null)
+                  ElevatedButton.icon(
+                    onPressed: () async => await onRecover!(),
+                    icon: Icon(recoverIcon),
+                    label: Text(recoverLabel),
+                  ),
+                if (onTryAgain != null)
+                  OutlinedButton.icon(
+                    onPressed: onTryAgain,
+                    icon: Icon(tryAgainIcon),
+                    label: Text(tryAgainLabel),
+                  ),
+                if (onBack != null)
+                  TextButton.icon(
+                    onPressed: onBack,
+                    icon: Icon(backIcon),
+                    label: Text(backLabel),
+                  ),
+              ],
+            ),
+          ],
+          if (footerText != null) ...[
+            SizedBox(height: UiSpacing.smallGap),
+            Text(
+              footerText!,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: colorScheme.onSurfaceVariant,
+                fontSize: 12,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable `PermissionIssuePanel` widget to standardize locked-access messaging
- replace the ad-hoc permission revoked UIs in the full screen viewer, media grid, and directory grid screens with the shared panel

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f6a8b685b88320b814327aa9195abe