### PR TITLE
Add shared permission issue panel for recovery flows

### DIFF
--- a/lib/features/full_screen/presentation/screens/full_screen_viewer_screen.dart
+++ b/lib/features/full_screen/presentation/screens/full_screen_viewer_screen.dart
@@ -13,6 +13,7 @@ import '../widgets/full_screen_favorite_toggle.dart';
 import '../widgets/full_screen_image_viewer.dart';
 import '../widgets/full_screen_video_controls.dart';
 import '../widgets/full_screen_video_player.dart';
+import '../../../../shared/widgets/permission_issue_panel.dart';
 
 /// Full-screen media viewer screen
 class FullScreenViewerScreen extends ConsumerStatefulWidget {
@@ -345,93 +346,70 @@ class _FullScreenViewerScreenState
   Widget _buildPermissionRevoked() {
     final colorScheme = Theme.of(context).colorScheme;
     return Center(
-      child: Container(
-        padding: const EdgeInsets.all(24),
+      child: PermissionIssuePanel(
         margin: const EdgeInsets.symmetric(horizontal: 32),
-        decoration: BoxDecoration(
-          color: colorScheme.surface.withValues(alpha: 0.9),
-          borderRadius: BorderRadius.circular(12),
-          border: Border.all(color: colorScheme.error, width: 2),
-          boxShadow: [
-            BoxShadow(
-              color: colorScheme.shadow.withValues(alpha: 0.3),
-              blurRadius: 10,
-              offset: const Offset(0, 4),
+        maxWidth: 520,
+        backgroundColor: colorScheme.surface.withValues(alpha: 0.9),
+        borderColor: colorScheme.error,
+        iconColor: colorScheme.error,
+        boxShadow: [
+          BoxShadow(
+            color: colorScheme.shadow.withValues(alpha: 0.3),
+            blurRadius: 10,
+            offset: const Offset(0, 4),
+          ),
+        ],
+        actions: [
+          PermissionIssueAction(
+            label: 'Try to Recover',
+            icon: Icons.refresh,
+            buttonStyle: ElevatedButton.styleFrom(
+              backgroundColor: colorScheme.primary,
+              foregroundColor: colorScheme.onPrimary,
             ),
-          ],
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(
-              Icons.lock,
-              size: 64,
-              color: colorScheme.error,
-            ),
-            const SizedBox(height: 16),
-            Text(
-              'Access to this directory has been revoked',
-              style: TextStyle(
-                color: colorScheme.onSurface,
-                fontSize: 18,
-                fontWeight: FontWeight.bold,
-              ),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'The permissions for this directory are no longer available.',
-              style: TextStyle(color: colorScheme.onSurfaceVariant, fontSize: 16),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'This can happen when security-scoped bookmarks expire or when directory permissions change.',
-              style: TextStyle(color: colorScheme.onSurfaceVariant, fontSize: 14),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 24),
-            ElevatedButton.icon(
-              onPressed: () async {
-                // Try to recover permissions using the view model
-                final success = await _viewModel.attemptPermissionRecovery(
-                  widget.directoryPath,
-                  bookmarkData: widget.bookmarkData,
-                );
+            onPressed: () async {
+              final success = await _viewModel.attemptPermissionRecovery(
+                widget.directoryPath,
+                bookmarkData: widget.bookmarkData,
+              );
 
-                if (context.mounted) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: Text(success ? 'Access recovered successfully!' : 'Recovery failed. Please go back and re-select the directory.'),
-                      backgroundColor: success ? colorScheme.primary : colorScheme.error,
+              if (context.mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(
+                    content: Text(
+                      success
+                          ? 'Access recovered successfully!'
+                          : 'Recovery failed. Please go back and re-select the directory.',
                     ),
-                  );
-                }
-              },
-              icon: const Icon(Icons.refresh),
-              label: const Text('Try to Recover'),
-              style: ElevatedButton.styleFrom(
-                backgroundColor: colorScheme.primary,
-                foregroundColor: colorScheme.onPrimary,
-              ),
+                    backgroundColor:
+                        success ? colorScheme.primary : colorScheme.error,
+                  ),
+                );
+              }
+            },
+          ),
+          PermissionIssueAction(
+            label: 'Back to Grid',
+            icon: Icons.arrow_back,
+            buttonStyle: ElevatedButton.styleFrom(
+              backgroundColor: colorScheme.secondary,
+              foregroundColor: colorScheme.onSecondary,
             ),
-            const SizedBox(height: 12),
-            ElevatedButton.icon(
-              onPressed: () => Navigator.of(context).pop(),
-              icon: const Icon(Icons.arrow_back),
-              label: const Text('Back to Grid'),
-              style: ElevatedButton.styleFrom(
-                backgroundColor: colorScheme.secondary,
-                foregroundColor: colorScheme.onSecondary,
-              ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'Return to the media grid and re-select the directory to restore full access.',
-              style: TextStyle(color: colorScheme.onSurfaceVariant, fontSize: 12),
-              textAlign: TextAlign.center,
-            ),
-          ],
+            onPressed: () async => Navigator.of(context).pop(),
+          ),
+        ],
+        messages: const [
+          PermissionIssueMessage(
+            'The permissions for this directory are no longer available.',
+            type: PermissionIssueMessageType.secondary,
+          ),
+          PermissionIssueMessage(
+            'This can happen when security-scoped bookmarks expire or when directory permissions change.',
+            type: PermissionIssueMessageType.helper,
+          ),
+        ],
+        footer: const Text(
+          'Return to the media grid and re-select the directory to restore full access.',
         ),
       ),
     );

--- a/lib/features/media_library/presentation/screens/directory_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/directory_grid_screen.dart
@@ -14,6 +14,7 @@ import '../../../../core/constants/ui_constants.dart';
 
 import '../../../../shared/providers/grid_columns_provider.dart';
 import '../../../../shared/providers/repository_providers.dart';
+import '../../../../shared/widgets/permission_issue_panel.dart';
 import '../../../tagging/domain/entities/tag_entity.dart';
 import '../../../tagging/presentation/states/tag_state.dart';
 import '../../../tagging/presentation/view_models/tag_management_view_model.dart';
@@ -501,30 +502,38 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
     return Column(
       children: [
         if (inaccessibleDirectories.isNotEmpty)
-          Container(
-            padding: UiSpacing.gridPadding,
-            color: Colors.orange.shade50,
-            child: Row(
-              children: [
-                Icon(Icons.warning, color: UiColors.orange),
-                SizedBox(width: UiSpacing.smallGap),
-                Expanded(
-                  child: Text(
-                    '${inaccessibleDirectories.length} directory(ies) are inaccessible due to permission changes. '
-                    'Click "Re-grant Permissions" to restore access.',
-                    style: TextStyle(color: UiColors.orange),
-                  ),
+          PermissionIssuePanel(
+            title: 'Some directories are inaccessible',
+            margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 20),
+            maxWidth: null,
+            backgroundColor: Colors.orange.shade50,
+            iconColor: UiColors.orange,
+            borderColor: UiColors.orange,
+            boxShadow: const [],
+            actions: [
+              PermissionIssueAction(
+                label: 'Re-grant Permissions',
+                buttonStyle: ElevatedButton.styleFrom(
+                  backgroundColor: UiColors.orange,
+                  foregroundColor: UiColors.white,
                 ),
-                ElevatedButton(
-                  onPressed: () => _showReGrantPermissionsDialog(
-                    context,
-                    inaccessibleDirectories,
-                    viewModel,
-                  ),
-                  child: const Text('Re-grant Permissions'),
+                onPressed: () async => _showReGrantPermissionsDialog(
+                  context,
+                  inaccessibleDirectories,
+                  viewModel,
                 ),
-              ],
-            ),
+              ),
+            ],
+            messages: [
+              PermissionIssueMessage(
+                '${inaccessibleDirectories.length} directory(ies) are inaccessible due to permission changes.',
+              ),
+              const PermissionIssueMessage(
+                'Click "Re-grant Permissions" to restore access.',
+                type: PermissionIssueMessageType.helper,
+              ),
+            ],
           ),
         Expanded(
           child: _buildDirectoryMarqueeWrapper(
@@ -589,30 +598,37 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
     return Column(
       children: [
         if (invalidDirectories.isNotEmpty)
-          Container(
-            padding: UiSpacing.gridPadding,
-            color: Colors.red.shade50,
-            child: Row(
-              children: [
-                Icon(Icons.error, color: UiColors.red),
-                SizedBox(width: UiSpacing.smallGap),
-                Expanded(
-                  child: Text(
-                    '${invalidDirectories.length} directory(ies) have invalid bookmarks. '
-                    'Click "Recover Bookmarks" to re-select directories.',
-                    style: TextStyle(color: UiColors.red),
-                  ),
+          PermissionIssuePanel(
+            title: 'Bookmarks need recovery',
+            margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 20),
+            backgroundColor: Colors.red.shade50,
+            iconColor: UiColors.red,
+            borderColor: UiColors.red,
+            boxShadow: const [],
+            actions: [
+              PermissionIssueAction(
+                label: 'Recover Bookmarks',
+                buttonStyle: ElevatedButton.styleFrom(
+                  backgroundColor: UiColors.red,
+                  foregroundColor: UiColors.white,
                 ),
-                ElevatedButton(
-                  onPressed: () => _showRecoverBookmarksDialog(
-                    context,
-                    invalidDirectories,
-                    viewModel,
-                  ),
-                  child: const Text('Recover Bookmarks'),
+                onPressed: () async => _showRecoverBookmarksDialog(
+                  context,
+                  invalidDirectories,
+                  viewModel,
                 ),
-              ],
-            ),
+              ),
+            ],
+            messages: [
+              PermissionIssueMessage(
+                '${invalidDirectories.length} directory(ies) have invalid bookmarks.',
+              ),
+              const PermissionIssueMessage(
+                'Click "Recover Bookmarks" to re-select directories.',
+                type: PermissionIssueMessageType.helper,
+              ),
+            ],
           ),
         Expanded(
           child: _buildDirectoryMarqueeWrapper(

--- a/lib/features/media_library/presentation/screens/media_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/media_grid_screen.dart
@@ -12,6 +12,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../core/config/app_config.dart';
 import '../../../../core/constants/ui_constants.dart';
 import '../../../../shared/providers/grid_columns_provider.dart';
+import '../../../../shared/widgets/permission_issue_panel.dart';
 
 import '../../../favorites/presentation/view_models/favorites_view_model.dart';
 import '../../../full_screen/presentation/screens/full_screen_viewer_screen.dart';
@@ -663,88 +664,65 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
     MediaViewModel viewModel,
   ) {
     return Center(
-      child: Container(
-        padding: UiSpacing.dialogPadding,
+      child: PermissionIssuePanel(
         margin: UiSpacing.dialogMargin,
-        decoration: BoxDecoration(
-          color: UiColors.white,
-          borderRadius: BorderRadius.circular(UiSizing.borderRadiusMedium),
-          border: Border.all(
-            color: UiColors.orange,
-            width: UiSizing.borderWidth,
-          ),
-          boxShadow: [UiShadows.standard],
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(Icons.lock, size: UiSizing.iconHuge, color: UiColors.orange),
-            SizedBox(height: UiSpacing.verticalGap),
-            const Text(
-              'Access to this directory has been revoked',
-              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-              textAlign: TextAlign.center,
+        maxWidth: 480,
+        backgroundColor: UiColors.white,
+        iconColor: UiColors.orange,
+        borderColor: UiColors.orange,
+        actions: [
+          PermissionIssueAction(
+            label: 'Re-select Directory',
+            icon: Icons.folder_open,
+            buttonStyle: ElevatedButton.styleFrom(
+              backgroundColor: UiColors.orange,
+              foregroundColor: UiColors.white,
+              padding: UiSpacing.buttonPadding,
             ),
-            SizedBox(height: UiSpacing.smallGap),
-            Text(
-              'The permissions for "$directoryName" are no longer available.',
-              textAlign: TextAlign.center,
-              style: const TextStyle(fontSize: 16),
-            ),
-            SizedBox(height: UiSpacing.smallGap),
-            const Text(
-              'This can happen when security-scoped bookmarks expire or when directory permissions change.',
-              textAlign: TextAlign.center,
-              style: TextStyle(fontSize: 14, color: Colors.grey),
-            ),
-            SizedBox(height: UiSpacing.verticalGap * 1.5),
-            ElevatedButton.icon(
-              onPressed: () async {
-                try {
-                  await viewModel.recoverPermissions();
-                  // Show success feedback
-                  if (context.mounted) {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(
-                        content: Text('Permissions recovered successfully!'),
-                        backgroundColor: Colors.green,
-                      ),
-                    );
-                  }
-                } catch (e) {
-                  // Show error feedback
-                  if (context.mounted) {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        content: Text('Failed to recover permissions: $e'),
-                        backgroundColor: Colors.red,
-                      ),
-                    );
-                  }
+            onPressed: () async {
+              try {
+                await viewModel.recoverPermissions();
+                if (context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('Permissions recovered successfully!'),
+                      backgroundColor: Colors.green,
+                    ),
+                  );
                 }
-              },
-              icon: const Icon(Icons.folder_open),
-              label: const Text('Re-select Directory'),
-              style: ElevatedButton.styleFrom(
-                backgroundColor: UiColors.orange,
-                foregroundColor: UiColors.white,
-                padding: UiSpacing.buttonPadding,
-              ),
-            ),
-            const SizedBox(height: 12),
-            OutlinedButton.icon(
-              onPressed: () =>
-                  viewModel.loadMedia(), // Try refreshing without recovery
-              icon: const Icon(Icons.refresh),
-              label: const Text('Try Again'),
-            ),
-            SizedBox(height: UiSpacing.verticalGap),
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: const Text('Go Back'),
-            ),
-          ],
-        ),
+              } catch (e) {
+                if (context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text('Failed to recover permissions: $e'),
+                      backgroundColor: Colors.red,
+                    ),
+                  );
+                }
+              }
+            },
+          ),
+          PermissionIssueAction(
+            label: 'Try Again',
+            icon: Icons.refresh,
+            style: PermissionIssueActionStyle.secondary,
+            onPressed: () async => viewModel.loadMedia(),
+          ),
+          PermissionIssueAction(
+            label: 'Go Back',
+            style: PermissionIssueActionStyle.tertiary,
+            onPressed: () async => Navigator.of(context).pop(),
+          ),
+        ],
+        messages: [
+          PermissionIssueMessage(
+            'The permissions for "$directoryName" are no longer available.',
+          ),
+          const PermissionIssueMessage(
+            'This can happen when security-scoped bookmarks expire or when directory permissions change.',
+            type: PermissionIssueMessageType.helper,
+          ),
+        ],
       ),
     );
   }

--- a/lib/shared/widgets/permission_issue_panel.dart
+++ b/lib/shared/widgets/permission_issue_panel.dart
@@ -1,0 +1,306 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../../core/constants/ui_constants.dart';
+
+/// Visual emphasis levels for descriptive messaging within a
+/// [PermissionIssuePanel].
+enum PermissionIssueMessageType {
+  /// Standard emphasis for primary descriptive messaging.
+  primary,
+
+  /// Reduced emphasis for secondary messaging.
+  secondary,
+
+  /// Small helper copy used for additional hints or follow-up guidance.
+  helper,
+}
+
+/// Model describing a block of text shown inside a [PermissionIssuePanel].
+class PermissionIssueMessage {
+  const PermissionIssueMessage(
+    this.text, {
+    this.type = PermissionIssueMessageType.primary,
+  });
+
+  /// Message to render.
+  final String text;
+
+  /// Styling hint to determine text emphasis.
+  final PermissionIssueMessageType type;
+}
+
+/// Button style variants supported by the [PermissionIssuePanel].
+enum PermissionIssueActionStyle {
+  /// Elevated button – primary action.
+  primary,
+
+  /// Outlined button – secondary action.
+  secondary,
+
+  /// Text button – tertiary action.
+  tertiary,
+}
+
+/// Configuration for an actionable control rendered by [PermissionIssuePanel].
+class PermissionIssueAction {
+  const PermissionIssueAction({
+    required this.label,
+    this.icon,
+    this.onPressed,
+    this.style = PermissionIssueActionStyle.primary,
+    this.buttonStyle,
+  });
+
+  /// Display label for the button.
+  final String label;
+
+  /// Optional leading icon.
+  final IconData? icon;
+
+  /// Callback triggered when the button is pressed.
+  final FutureOr<void> Function()? onPressed;
+
+  /// Visual style to apply to the button.
+  final PermissionIssueActionStyle style;
+
+  /// Optional custom button style overrides.
+  final ButtonStyle? buttonStyle;
+}
+
+/// Shared panel used to surface permission or access issues alongside
+/// recovery actions.
+class PermissionIssuePanel extends StatelessWidget {
+  const PermissionIssuePanel({
+    super.key,
+    this.title = 'Access to this directory has been revoked',
+    this.messages = const <PermissionIssueMessage>[
+      PermissionIssueMessage(
+        'The permissions for this directory are no longer available.',
+      ),
+      PermissionIssueMessage(
+        'This can happen when security-scoped bookmarks expire or when directory permissions change.',
+        type: PermissionIssueMessageType.helper,
+      ),
+    ],
+    this.icon = Icons.lock,
+    this.iconColor,
+    this.backgroundColor,
+    this.borderColor,
+    this.actions = const <PermissionIssueAction>[],
+    this.footer,
+    this.margin,
+    this.padding = UiSpacing.dialogPadding,
+    this.maxWidth,
+    this.boxShadow,
+  });
+
+  /// Headline displayed at the top of the panel.
+  final String title;
+
+  /// Supporting descriptive copy shown under the title.
+  final List<PermissionIssueMessage> messages;
+
+  /// Icon used to represent the issue state.
+  final IconData icon;
+
+  /// Overrides the icon color if provided.
+  final Color? iconColor;
+
+  /// Overrides the container background color if provided.
+  final Color? backgroundColor;
+
+  /// Overrides the container border color if provided.
+  final Color? borderColor;
+
+  /// Actions rendered below the descriptive messaging.
+  final List<PermissionIssueAction> actions;
+
+  /// Optional trailing widget, typically additional helper copy.
+  final Widget? footer;
+
+  /// Margin applied around the panel.
+  final EdgeInsetsGeometry? margin;
+
+  /// Padding applied within the panel.
+  final EdgeInsetsGeometry padding;
+
+  /// Maximum width constraint for the panel. Leave `null` for no constraint.
+  final double? maxWidth;
+
+  /// Overrides the panel box shadow if provided. Use an empty list to remove
+  /// shadows.
+  final List<BoxShadow>? boxShadow;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    final resolvedIconColor = iconColor ?? colorScheme.error;
+    final resolvedBorderColor = borderColor ?? resolvedIconColor;
+    final resolvedBackgroundColor =
+        backgroundColor ?? colorScheme.surface.withValues(alpha: 0.95);
+    final resolvedBoxShadow =
+        boxShadow ?? <BoxShadow>[UiShadows.standard];
+
+    Widget panel = Container(
+      padding: padding,
+      decoration: BoxDecoration(
+        color: resolvedBackgroundColor,
+        borderRadius: BorderRadius.circular(UiSizing.borderRadiusMedium),
+        border: Border.all(
+          color: resolvedBorderColor,
+          width: UiSizing.borderWidth,
+        ),
+        boxShadow: resolvedBoxShadow,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: UiSizing.iconHuge, color: resolvedIconColor),
+          SizedBox(height: UiSpacing.verticalGap),
+          Text(
+            title,
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+              color: colorScheme.onSurface,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          for (var index = 0; index < messages.length; index++) ...[
+            SizedBox(
+              height:
+                  index == 0 ? UiSpacing.smallGap : UiSpacing.extraSmallGap,
+            ),
+            Text(
+              messages[index].text,
+              style: _resolveMessageStyle(
+                theme,
+                colorScheme,
+                messages[index].type,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+          if (actions.isNotEmpty) ...[
+            SizedBox(height: UiSpacing.verticalGap),
+            for (var i = 0; i < actions.length; i++) ...[
+              _buildActionButton(actions[i]),
+              if (i != actions.length - 1)
+                SizedBox(height: UiSpacing.smallGap),
+            ],
+          ],
+          if (footer != null) ...[
+            SizedBox(height: UiSpacing.smallGap),
+            DefaultTextStyle.merge(
+              style: theme.textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ) ??
+                  TextStyle(color: colorScheme.onSurfaceVariant, fontSize: 12),
+              textAlign: TextAlign.center,
+              child: footer!,
+            ),
+          ],
+        ],
+      ),
+    );
+
+    if (maxWidth != null) {
+      panel = ConstrainedBox(
+        constraints: BoxConstraints(maxWidth: maxWidth!),
+        child: panel,
+      );
+    }
+
+    if (margin != null) {
+      panel = Padding(padding: margin!, child: panel);
+    }
+
+    return panel;
+  }
+
+  TextStyle _resolveMessageStyle(
+    ThemeData theme,
+    ColorScheme colorScheme,
+    PermissionIssueMessageType type,
+  ) {
+    switch (type) {
+      case PermissionIssueMessageType.primary:
+        return theme.textTheme.bodyMedium?.copyWith(
+              color: colorScheme.onSurface,
+            ) ??
+            TextStyle(color: colorScheme.onSurface, fontSize: 16);
+      case PermissionIssueMessageType.secondary:
+        return theme.textTheme.bodyMedium?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+            ) ??
+            TextStyle(color: colorScheme.onSurfaceVariant, fontSize: 16);
+      case PermissionIssueMessageType.helper:
+        return theme.textTheme.bodySmall?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+            ) ??
+            TextStyle(color: colorScheme.onSurfaceVariant, fontSize: 12);
+    }
+  }
+
+  Widget _buildActionButton(PermissionIssueAction action) {
+    final label = Text(action.label);
+    final icon = action.icon != null ? Icon(action.icon) : null;
+
+    switch (action.style) {
+      case PermissionIssueActionStyle.primary:
+        return icon != null
+            ? ElevatedButton.icon(
+                onPressed: action.onPressed == null
+                    ? null
+                    : () async => await action.onPressed!.call(),
+                icon: icon,
+                label: label,
+                style: action.buttonStyle,
+              )
+            : ElevatedButton(
+                onPressed: action.onPressed == null
+                    ? null
+                    : () async => await action.onPressed!.call(),
+                style: action.buttonStyle,
+                child: label,
+              );
+      case PermissionIssueActionStyle.secondary:
+        return icon != null
+            ? OutlinedButton.icon(
+                onPressed: action.onPressed == null
+                    ? null
+                    : () async => await action.onPressed!.call(),
+                icon: icon,
+                label: label,
+                style: action.buttonStyle,
+              )
+            : OutlinedButton(
+                onPressed: action.onPressed == null
+                    ? null
+                    : () async => await action.onPressed!.call(),
+                style: action.buttonStyle,
+                child: label,
+              );
+      case PermissionIssueActionStyle.tertiary:
+        return icon != null
+            ? TextButton.icon(
+                onPressed: action.onPressed == null
+                    ? null
+                    : () async => await action.onPressed!.call(),
+                icon: icon,
+                label: label,
+                style: action.buttonStyle,
+              )
+            : TextButton(
+                onPressed: action.onPressed == null
+                    ? null
+                    : () async => await action.onPressed!.call(),
+                style: action.buttonStyle,
+                child: label,
+              );
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable PermissionIssuePanel widget for permission recovery messaging
- refactor media grid, directory grid, and full screen viewer screens to use the shared panel
- centralize action styling and helper copy for permission-related surfaces

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f6a8b685b88320b814327aa9195abe