### PR TITLE
Refactor media fetching to go through GetMediaUseCase

### DIFF
--- a/lib/features/media_library/domain/use_cases/get_media_use_case.dart
+++ b/lib/features/media_library/domain/use_cases/get_media_use_case.dart
@@ -1,1 +1,45 @@
+import '../entities/media_entity.dart';
+import '../repositories/media_repository.dart';
 
+/// Use case that retrieves media from the library through the repository
+/// abstraction. It provides helpers for loading media scoped to a specific
+/// directory as well as retrieving the entire media library.
+class GetMediaUseCase {
+  const GetMediaUseCase(this._mediaRepository);
+
+  final MediaRepository _mediaRepository;
+
+  /// Loads media for the directory located at [directoryPath].
+  Future<List<MediaEntity>> forDirectoryPath(
+    String directoryPath, {
+    String? bookmarkData,
+  }) {
+    return _mediaRepository.getMediaForDirectoryPath(
+      directoryPath,
+      bookmarkData: bookmarkData,
+    );
+  }
+
+  /// Loads media for the directory identified by [directoryId].
+  Future<List<MediaEntity>> forDirectoryId(String directoryId) {
+    return _mediaRepository.getMediaForDirectory(directoryId);
+  }
+
+  /// Loads media for the entire library.
+  Future<List<MediaEntity>> entireLibrary() {
+    return _mediaRepository.filterMediaByTags(const <String>[]);
+  }
+
+  /// Filters media by [tagIds] for the directory at [directoryPath].
+  Future<List<MediaEntity>> filterByTagsForDirectory(
+    List<String> tagIds,
+    String directoryPath, {
+    String? bookmarkData,
+  }) {
+    return _mediaRepository.filterMediaByTagsForDirectory(
+      tagIds,
+      directoryPath,
+      bookmarkData: bookmarkData,
+    );
+  }
+}

--- a/lib/features/media_library/domain/use_cases/get_media_use_case.dart
+++ b/lib/features/media_library/domain/use_cases/get_media_use_case.dart
@@ -30,6 +30,11 @@ class GetMediaUseCase {
     return _mediaRepository.filterMediaByTags(const <String>[]);
   }
 
+  /// Loads a single media entity by [id] if available.
+  Future<MediaEntity?> byId(String id) {
+    return _mediaRepository.getMediaById(id);
+  }
+
   /// Filters media by [tagIds] for the directory at [directoryPath].
   Future<List<MediaEntity>> filterByTagsForDirectory(
     List<String> tagIds,

--- a/lib/shared/providers/repository_providers.dart
+++ b/lib/shared/providers/repository_providers.dart
@@ -25,6 +25,7 @@ import '../../features/media_library/domain/use_cases/clear_directories_use_case
 import '../../features/media_library/domain/use_cases/delete_directory_use_case.dart';
 import '../../features/media_library/domain/use_cases/delete_file_use_case.dart';
 import '../../features/media_library/domain/use_cases/get_directories_use_case.dart';
+import '../../features/media_library/domain/use_cases/get_media_use_case.dart';
 import '../../features/media_library/domain/use_cases/remove_directory_use_case.dart';
 import '../../features/media_library/domain/use_cases/search_directories_use_case.dart';
 import '../../features/media_library/domain/use_cases/validate_path_use_case.dart';
@@ -171,6 +172,10 @@ class FavoritesRepositoryNotifier extends StateNotifier<FavoritesRepository> {
 // Use case providers
 final getDirectoriesUseCaseProvider = Provider<GetDirectoriesUseCase>((ref) {
   return GetDirectoriesUseCase(ref.watch(directoryRepositoryProvider));
+});
+
+final getMediaUseCaseProvider = Provider<GetMediaUseCase>((ref) {
+  return GetMediaUseCase(ref.watch(mediaRepositoryProvider));
 });
 
 final searchDirectoriesUseCaseProvider = Provider<SearchDirectoriesUseCase>((

--- a/test/features/favorites/presentation/view_models/favorites_view_model_test.dart
+++ b/test/features/favorites/presentation/view_models/favorites_view_model_test.dart
@@ -6,8 +6,9 @@ import 'package:media_fast_view/features/favorites/domain/repositories/favorites
 import 'package:media_fast_view/features/favorites/presentation/view_models/favorites_view_model.dart';
 import 'package:media_fast_view/features/media_library/domain/entities/directory_entity.dart';
 import 'package:media_fast_view/features/media_library/domain/entities/media_entity.dart';
-import 'package:media_fast_view/features/media_library/domain/use_cases/get_media_use_case.dart';
 import 'package:media_fast_view/features/media_library/data/isar/isar_media_data_source.dart';
+import 'package:media_fast_view/features/media_library/data/models/media_model.dart';
+import 'package:media_fast_view/features/media_library/domain/use_cases/get_media_use_case.dart';
 
 class _MockFavoritesRepository extends Mock implements FavoritesRepository {}
 
@@ -25,6 +26,18 @@ void main() {
   final now = DateTime(2024, 1, 1);
   const directoryId = 'directory-1';
   const directoryPath = '/path/to/directory';
+
+  final mediaModel = MediaModel(
+    id: mediaId,
+    path: '/path/to/media.jpg',
+    name: 'media.jpg',
+    type: MediaType.image,
+    size: 1024,
+    lastModified: now,
+    tagIds: const [],
+    directoryId: directoryId,
+    bookmarkData: null,
+  );
 
   final mediaEntity = MediaEntity(
     id: mediaId,
@@ -79,7 +92,8 @@ void main() {
       when(
         favoritesRepository.getFavoriteMediaIds(),
       ).thenAnswer((_) async => [mediaId]);
-      when(getMediaUseCase.entireLibrary()).thenAnswer((_) async => const []);
+      when(mediaDataSource.getMedia()).thenAnswer((_) async => const []);
+      when(getMediaUseCase.byId(mediaId)).thenAnswer((_) async => null);
       when(favoritesRepository.getFavorites())
           .thenAnswer((_) async => const []);
 
@@ -87,7 +101,8 @@ void main() {
 
       expect(viewModel.state, isA<FavoritesEmpty>());
       verify(favoritesRepository.getFavoriteMediaIds()).called(1);
-      verify(getMediaUseCase.entireLibrary()).called(1);
+      verify(mediaDataSource.getMedia()).called(1);
+      verify(getMediaUseCase.byId(mediaId)).called(1);
     });
 
     test(
@@ -96,8 +111,7 @@ void main() {
         when(
           favoritesRepository.getFavoriteMediaIds(),
         ).thenAnswer((_) async => [mediaId]);
-        when(getMediaUseCase.entireLibrary())
-            .thenAnswer((_) async => [mediaEntity]);
+        when(mediaDataSource.getMedia()).thenAnswer((_) async => [mediaModel]);
         when(favoritesRepository.getFavorites())
             .thenAnswer((_) async => const []);
 
@@ -107,7 +121,8 @@ void main() {
         final loaded = viewModel.state as FavoritesLoaded;
         expect(loaded.favorites, [mediaId]);
         expect(loaded.media.single.id, mediaId);
-        verify(getMediaUseCase.entireLibrary()).called(1);
+        verify(mediaDataSource.getMedia()).called(1);
+        verifyNever(getMediaUseCase.byId(any));
       },
     );
   });
@@ -125,8 +140,7 @@ void main() {
       when(mediaDataSource.upsertMedia(any)).thenAnswer((_) async {});
       when(favoritesRepository.getFavoriteMediaIds())
           .thenAnswer((_) async => [mediaId]);
-      when(getMediaUseCase.entireLibrary())
-          .thenAnswer((_) async => [mediaEntity]);
+      when(mediaDataSource.getMedia()).thenAnswer((_) async => [mediaModel]);
       when(favoritesRepository.getFavorites()).thenAnswer((_) async => const []);
 
       final result = await viewModel.toggleFavoritesForMedia([mediaEntity]);
@@ -137,7 +151,8 @@ void main() {
       verify(favoritesRepository.addFavorites(any)).called(1);
       verify(mediaDataSource.upsertMedia(any)).called(1);
       verifyNever(favoritesRepository.removeFavorites(any));
-      verify(getMediaUseCase.entireLibrary()).called(1);
+      verify(mediaDataSource.getMedia()).called(1);
+      verifyNever(getMediaUseCase.byId(any));
     });
 
     test('removes favorites when already favorited', () async {
@@ -217,14 +232,14 @@ void main() {
       when(
         favoritesRepository.getFavoriteMediaIds(),
       ).thenAnswer((_) async => [mediaId]);
-      when(getMediaUseCase.entireLibrary())
-          .thenAnswer((_) async => [mediaEntity]);
+      when(mediaDataSource.getMedia()).thenAnswer((_) async => [mediaModel]);
       when(favoritesRepository.getFavorites()).thenAnswer((_) async => const []);
 
       await viewModel.loadFavorites();
 
       expect(viewModel.isFavoriteInState(mediaId), isTrue);
-      verify(getMediaUseCase.entireLibrary()).called(1);
+      verify(mediaDataSource.getMedia()).called(1);
+      verifyNever(getMediaUseCase.byId(any));
     });
 
     test('returns false when favorites not loaded', () {

--- a/test/features/media_library/domain/use_cases/get_media_use_case_test.dart
+++ b/test/features/media_library/domain/use_cases/get_media_use_case_test.dart
@@ -62,6 +62,17 @@ void main() {
     });
   });
 
+  group('byId', () {
+    test('delegates to repository', () async {
+      when(mediaRepository.getMediaById(any))
+          .thenAnswer((_) async => null);
+
+      await useCase.byId('media-id');
+
+      verify(mediaRepository.getMediaById('media-id')).called(1);
+    });
+  });
+
   group('filterByTagsForDirectory', () {
     test('delegates to repository with bookmark data', () async {
       const tags = ['tag-1', 'tag-2'];

--- a/test/features/media_library/domain/use_cases/get_media_use_case_test.dart
+++ b/test/features/media_library/domain/use_cases/get_media_use_case_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import 'package:media_fast_view/features/media_library/domain/entities/media_entity.dart';
+import 'package:media_fast_view/features/media_library/domain/repositories/media_repository.dart';
+import 'package:media_fast_view/features/media_library/domain/use_cases/get_media_use_case.dart';
+
+class _MockMediaRepository extends Mock implements MediaRepository {}
+
+void main() {
+  late _MockMediaRepository mediaRepository;
+  late GetMediaUseCase useCase;
+
+  const directoryPath = '/path/to/directory';
+  const directoryId = 'directory-id';
+  const bookmark = 'bookmark-data';
+
+  setUp(() {
+    mediaRepository = _MockMediaRepository();
+    useCase = GetMediaUseCase(mediaRepository);
+  });
+
+  group('forDirectoryPath', () {
+    test('delegates to repository with bookmark data', () async {
+      when(
+        mediaRepository.getMediaForDirectoryPath(
+          any,
+          bookmarkData: anyNamed('bookmarkData'),
+        ),
+      ).thenAnswer((_) async => const <MediaEntity>[]);
+
+      await useCase.forDirectoryPath(directoryPath, bookmarkData: bookmark);
+
+      verify(
+        mediaRepository.getMediaForDirectoryPath(
+          directoryPath,
+          bookmarkData: bookmark,
+        ),
+      ).called(1);
+    });
+  });
+
+  group('forDirectoryId', () {
+    test('delegates to repository', () async {
+      when(mediaRepository.getMediaForDirectory(any))
+          .thenAnswer((_) async => const <MediaEntity>[]);
+
+      await useCase.forDirectoryId(directoryId);
+
+      verify(mediaRepository.getMediaForDirectory(directoryId)).called(1);
+    });
+  });
+
+  group('entireLibrary', () {
+    test('delegates to filterMediaByTags with empty tags', () async {
+      when(mediaRepository.filterMediaByTags(any))
+          .thenAnswer((_) async => const <MediaEntity>[]);
+
+      await useCase.entireLibrary();
+
+      verify(mediaRepository.filterMediaByTags(const <String>[])).called(1);
+    });
+  });
+
+  group('filterByTagsForDirectory', () {
+    test('delegates to repository with bookmark data', () async {
+      const tags = ['tag-1', 'tag-2'];
+      when(
+        mediaRepository.filterMediaByTagsForDirectory(
+          any,
+          any,
+          bookmarkData: anyNamed('bookmarkData'),
+        ),
+      ).thenAnswer((_) async => const <MediaEntity>[]);
+
+      await useCase.filterByTagsForDirectory(
+        tags,
+        directoryPath,
+        bookmarkData: bookmark,
+      );
+
+      verify(
+        mediaRepository.filterMediaByTagsForDirectory(
+          tags,
+          directoryPath,
+          bookmarkData: bookmark,
+        ),
+      ).called(1);
+    });
+  });
+}

--- a/test/features/media_library/presentation/view_models/media_view_model_test.dart
+++ b/test/features/media_library/presentation/view_models/media_view_model_test.dart
@@ -8,6 +8,7 @@ import '../../../../../lib/features/favorites/domain/entities/favorite_item_type
 import '../../../../../lib/features/favorites/domain/repositories/favorites_repository.dart';
 import '../../../../../lib/features/media_library/domain/entities/media_entity.dart';
 import '../../../../../lib/features/media_library/domain/repositories/media_repository.dart';
+import '../../../../../lib/features/media_library/domain/use_cases/get_media_use_case.dart';
 import '../../../../../lib/features/media_library/presentation/view_models/media_grid_view_model.dart';
 import '../../../../../lib/shared/providers/repository_providers.dart';
 
@@ -132,6 +133,7 @@ class _MockIsarMediaDataSource extends Mock implements IsarMediaDataSource {}
 ProviderContainer _createMediaTestContainer({
   required IsarMediaDataSource mediaDataSource,
   required InMemoryMediaRepository mediaRepository,
+  required GetMediaUseCase getMediaUseCase,
   required InMemoryFavoritesRepository favoritesRepository,
 }) {
   return ProviderContainer(
@@ -144,7 +146,7 @@ ProviderContainer _createMediaTestContainer({
           (ref) => MediaViewModel(
             ref,
             params,
-            mediaRepository: mediaRepository,
+            getMediaUseCase: getMediaUseCase,
             mediaDataSource: mediaDataSource,
           ),
         );
@@ -159,6 +161,7 @@ void main() {
   late _MockIsarMediaDataSource mediaCache;
   late InMemoryMediaRepository mediaRepository;
   late InMemoryFavoritesRepository favoritesRepository;
+  late GetMediaUseCase getMediaUseCase;
   const params = MediaViewModelParams(
     directoryPath: '/dir1',
     directoryName: 'Directory 1',
@@ -202,12 +205,14 @@ void main() {
         directoryId: '/dir1',
       ),
     ]);
+    getMediaUseCase = GetMediaUseCase(mediaRepository);
   });
 
   test('toggleMediaSelection toggles selection state', () async {
     final container = _createMediaTestContainer(
       mediaDataSource: mediaCache,
       mediaRepository: mediaRepository,
+      getMediaUseCase: getMediaUseCase,
       favoritesRepository: favoritesRepository,
     );
     addTearDown(container.dispose);
@@ -234,6 +239,7 @@ void main() {
     final container = _createMediaTestContainer(
       mediaDataSource: mediaCache,
       mediaRepository: mediaRepository,
+      getMediaUseCase: getMediaUseCase,
       favoritesRepository: favoritesRepository,
     );
     addTearDown(container.dispose);
@@ -256,6 +262,7 @@ void main() {
     final container = _createMediaTestContainer(
       mediaDataSource: mediaCache,
       mediaRepository: mediaRepository,
+      getMediaUseCase: getMediaUseCase,
       favoritesRepository: favoritesRepository,
     );
     addTearDown(container.dispose);
@@ -278,6 +285,7 @@ void main() {
     final container = _createMediaTestContainer(
       mediaDataSource: mediaCache,
       mediaRepository: mediaRepository,
+      getMediaUseCase: getMediaUseCase,
       favoritesRepository: favoritesRepository,
     );
     addTearDown(container.dispose);
@@ -293,6 +301,7 @@ void main() {
     final container = _createMediaTestContainer(
       mediaDataSource: mediaCache,
       mediaRepository: mediaRepository,
+      getMediaUseCase: getMediaUseCase,
       favoritesRepository: favoritesRepository,
     );
     addTearDown(container.dispose);


### PR DESCRIPTION
## Summary
- implement `GetMediaUseCase` to wrap media repository access for directory and full-library retrieval
- update media grid and favorites view models plus provider wiring to depend on the new use case
- add unit coverage for the use case and refresh existing view model tests

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f6ba670d0c832090dd0a2cfe1532f6