### PR TITLE
Refactor tag dialogs into reusable selection dialog

### DIFF
--- a/lib/features/media_library/presentation/widgets/directory_tag_assignment_dialog.dart
+++ b/lib/features/media_library/presentation/widgets/directory_tag_assignment_dialog.dart
@@ -1,156 +1,35 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../domain/entities/tag_entity.dart';
-import '../../../tagging/presentation/states/tag_state.dart';
-import '../../../tagging/presentation/view_models/tag_management_view_model.dart';
-import '../../../tagging/presentation/widgets/tag_chip.dart';
+import '../../../../shared/widgets/tag_selection_dialog.dart';
 import '../../domain/entities/directory_entity.dart';
 
-/// A dialog for assigning tags to a directory.
-/// Allows users to select/deselect tags for a specific directory.
-class DirectoryTagAssignmentDialog extends ConsumerStatefulWidget {
-  const DirectoryTagAssignmentDialog({
-    super.key,
-    required this.directory,
-    required this.onTagsAssigned,
-  });
-
-  final DirectoryEntity directory;
-  final Future<void> Function(List<String>) onTagsAssigned;
+class DirectoryTagAssignmentDialog {
+  const DirectoryTagAssignmentDialog._();
 
   static Future<void> show(
     BuildContext context, {
     required DirectoryEntity directory,
-    required Future<void> Function(List<String>) onTagsAssigned,
+    required Future<void> Function(List<String> tagIds) onTagsAssigned,
   }) {
     return showDialog(
       context: context,
-      builder: (context) => DirectoryTagAssignmentDialog(
-        directory: directory,
-        onTagsAssigned: onTagsAssigned,
-      ),
-    );
-  }
-
-  @override
-  ConsumerState<DirectoryTagAssignmentDialog> createState() =>
-      _DirectoryTagAssignmentDialogState();
-}
-
-class _DirectoryTagAssignmentDialogState
-    extends ConsumerState<DirectoryTagAssignmentDialog> {
-  late List<String> _tempSelectedTagIds;
-  bool _isSaving = false;
-  String? _errorMessage;
-
-  @override
-  void initState() {
-    super.initState();
-    _tempSelectedTagIds = List<String>.from(widget.directory.tagIds);
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final tagState = ref.watch(tagViewModelProvider);
-
-    return AlertDialog(
-      title: Text('Assign Tags to "${widget.directory.name}"'),
-      content: SizedBox(
-        width: double.maxFinite,
-        child: switch (tagState) {
-          TagLoaded(:final tags) => _buildContent(context, tags),
-          TagLoading() => const Center(child: CircularProgressIndicator()),
-          TagError(:final message) => Center(
-            child: Text(
-              'Error: $message',
-              style: TextStyle(color: Theme.of(context).colorScheme.error),
-            ),
-          ),
-          TagEmpty() => _buildEmptyState(context),
+      builder: (context) => TagSelectionDialog<void>(
+        title: 'Assign Tags to "${directory.name}"',
+        description: 'Select tags to assign to this directory.',
+        initialSelectedTagIds: directory.tagIds,
+        onConfirm: (selected) async {
+          await onTagsAssigned(selected);
+          return null;
         },
+        confirmLabel: 'Save',
+        cancelLabel: 'Cancel',
+        emptyStateBuilder: (context) => _buildEmptyState(context),
       ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(),
-          child: const Text('Cancel'),
-        ),
-        ElevatedButton(
-          onPressed: _isSaving
-              ? null
-              : () async {
-                  setState(() {
-                    _isSaving = true;
-                    _errorMessage = null;
-                  });
-                  try {
-                    await widget.onTagsAssigned(_tempSelectedTagIds);
-                    if (mounted) {
-                      Navigator.of(context).pop();
-                    }
-                  } catch (e) {
-                    if (!mounted) {
-                      return;
-                    }
-                    setState(() {
-                      _isSaving = false;
-                      _errorMessage = 'Failed to save tags: $e';
-                    });
-                  }
-                },
-          child: _isSaving
-              ? const SizedBox(
-                  height: 16,
-                  width: 16,
-                  child: CircularProgressIndicator(strokeWidth: 2),
-                )
-              : const Text('Save'),
-        ),
-      ],
     );
   }
 
-  Widget _buildContent(BuildContext context, List<TagEntity> tags) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          'Select tags to assign to this directory.',
-          style: Theme.of(context).textTheme.bodySmall?.copyWith(
-            color: Theme.of(context).colorScheme.onSurfaceVariant,
-          ),
-        ),
-        const SizedBox(height: 16),
-        Flexible(
-          child: SingleChildScrollView(
-            child: Wrap(
-              spacing: 8,
-              runSpacing: 8,
-              children: tags.map(
-                (tag) => TagChip(
-                  tag: tag,
-                  selected: _tempSelectedTagIds.contains(tag.id),
-                  onTap: () => _toggleTagSelection(tag.id),
-                ),
-              ).toList(),
-            ),
-          ),
-        ),
-        if (_errorMessage != null) ...[
-          const SizedBox(height: 16),
-          Text(
-            _errorMessage!,
-            style: TextStyle(
-              color: Theme.of(context).colorScheme.error,
-            ),
-          ),
-        ],
-      ],
-    );
-  }
-
-  Widget _buildEmptyState(BuildContext context) {
+  static Widget _buildEmptyState(BuildContext context) {
+    final theme = Theme.of(context);
     return Center(
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -158,33 +37,20 @@ class _DirectoryTagAssignmentDialogState
           Icon(
             Icons.tag,
             size: 48,
-            color: Theme.of(context).colorScheme.outline,
+            color: theme.colorScheme.outline,
           ),
           const SizedBox(height: 16),
-          Text('No tags available', style: Theme.of(context).textTheme.titleMedium),
+          Text('No tags available', style: theme.textTheme.titleMedium),
           const SizedBox(height: 8),
           Text(
             'Create tags first to assign them to directories',
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
             ),
             textAlign: TextAlign.center,
           ),
         ],
       ),
     );
-  }
-
-  void _toggleTagSelection(String tagId) {
-    if (_isSaving) {
-      return;
-    }
-    setState(() {
-      if (_tempSelectedTagIds.contains(tagId)) {
-        _tempSelectedTagIds.remove(tagId);
-      } else {
-        _tempSelectedTagIds.add(tagId);
-      }
-    });
   }
 }

--- a/lib/features/tagging/presentation/widgets/bulk_tag_assignment_dialog.dart
+++ b/lib/features/tagging/presentation/widgets/bulk_tag_assignment_dialog.dart
@@ -1,34 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../domain/entities/tag_entity.dart';
-import '../states/tag_state.dart';
-import '../view_models/tag_management_view_model.dart';
-import 'tag_chip.dart';
+import '../../../../shared/widgets/tag_selection_dialog.dart';
 
-/// Dialog that lets users assign a shared set of tags to a collection of items.
-class BulkTagAssignmentDialog extends ConsumerStatefulWidget {
-  const BulkTagAssignmentDialog({
-    super.key,
-    required this.title,
-    required this.description,
-    required this.initialTagIds,
-    required this.onTagsAssigned,
-  });
+class BulkTagAssignmentDialog {
+  const BulkTagAssignmentDialog._();
 
-  /// Title displayed in the dialog header.
-  final String title;
-
-  /// Descriptive helper text that explains how the assignment behaves.
-  final String description;
-
-  /// Tag IDs that should be pre-selected when the dialog opens.
-  final List<String> initialTagIds;
-
-  /// Callback invoked when the user confirms their selection.
-  final Future<void> Function(List<String> tagIds) onTagsAssigned;
-
-  /// Shows the dialog and returns true when the selection was saved.
   static Future<bool> show(
     BuildContext context, {
     required String title,
@@ -38,139 +14,25 @@ class BulkTagAssignmentDialog extends ConsumerStatefulWidget {
   }) async {
     final result = await showDialog<bool>(
       context: context,
-      builder: (context) => BulkTagAssignmentDialog(
+      builder: (context) => TagSelectionDialog<bool>(
         title: title,
         description: description,
-        initialTagIds: initialTagIds,
-        onTagsAssigned: onTagsAssigned,
+        initialSelectedTagIds: initialTagIds,
+        onConfirm: (selected) async {
+          await onTagsAssigned(selected);
+          return true;
+        },
+        confirmLabel: 'Apply Tags',
+        cancelLabel: 'Cancel',
+        cancelResult: false,
+        emptyStateBuilder: (context) => _buildEmptyState(context),
       ),
     );
     return result ?? false;
   }
 
-  @override
-  ConsumerState<BulkTagAssignmentDialog> createState() =>
-      _BulkTagAssignmentDialogState();
-}
-
-class _BulkTagAssignmentDialogState
-    extends ConsumerState<BulkTagAssignmentDialog> {
-  late final List<String> _tempSelectedTagIds;
-  bool _isSaving = false;
-  String? _errorMessage;
-
-  @override
-  void initState() {
-    super.initState();
-    _tempSelectedTagIds = List<String>.from(widget.initialTagIds);
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final tagState = ref.watch(tagViewModelProvider);
-
-    return AlertDialog(
-      title: Text(widget.title),
-      content: SizedBox(
-        width: double.maxFinite,
-        child: switch (tagState) {
-          TagLoaded(:final tags) => _buildContent(context, tags),
-          TagLoading() => const Center(child: CircularProgressIndicator()),
-          TagError(:final message) => Center(
-              child: Text(
-                'Error: $message',
-                style: TextStyle(color: Theme.of(context).colorScheme.error),
-              ),
-            ),
-          TagEmpty() => _buildEmptyState(context),
-        },
-      ),
-      actions: [
-        TextButton(
-          onPressed: _isSaving ? null : () => Navigator.of(context).pop(false),
-          child: const Text('Cancel'),
-        ),
-        FilledButton(
-          onPressed: _isSaving
-              ? null
-              : () async {
-                  setState(() {
-                    _isSaving = true;
-                    _errorMessage = null;
-                  });
-                  try {
-                    await widget.onTagsAssigned(
-                      List<String>.from(_tempSelectedTagIds),
-                    );
-                    if (!mounted) {
-                      return;
-                    }
-                    Navigator.of(context).pop(true);
-                  } catch (error) {
-                    if (!mounted) {
-                      return;
-                    }
-                    setState(() {
-                      _isSaving = false;
-                      _errorMessage = 'Failed to save tags: $error';
-                    });
-                  }
-                },
-          child: _isSaving
-              ? const SizedBox(
-                  width: 16,
-                  height: 16,
-                  child: CircularProgressIndicator(strokeWidth: 2),
-                )
-              : const Text('Apply Tags'),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildContent(BuildContext context, List<TagEntity> tags) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          widget.description,
-          style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: Theme.of(context).colorScheme.onSurfaceVariant,
-              ),
-        ),
-        const SizedBox(height: 16),
-        Flexible(
-          child: SingleChildScrollView(
-            child: Wrap(
-              spacing: 8,
-              runSpacing: 8,
-              children: tags
-                  .map(
-                    (tag) => TagChip(
-                      tag: tag,
-                      selected: _tempSelectedTagIds.contains(tag.id),
-                      onTap: () => _toggleTagSelection(tag.id),
-                    ),
-                  )
-                  .toList(),
-            ),
-          ),
-        ),
-        if (_errorMessage != null) ...[
-          const SizedBox(height: 16),
-          Text(
-            _errorMessage!,
-            style: TextStyle(
-              color: Theme.of(context).colorScheme.error,
-            ),
-          ),
-        ],
-      ],
-    );
-  }
-
-  Widget _buildEmptyState(BuildContext context) {
+  static Widget _buildEmptyState(BuildContext context) {
+    final theme = Theme.of(context);
     return Center(
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -178,33 +40,20 @@ class _BulkTagAssignmentDialogState
           Icon(
             Icons.tag,
             size: 48,
-            color: Theme.of(context).colorScheme.outline,
+            color: theme.colorScheme.outline,
           ),
           const SizedBox(height: 16),
-          Text('No tags available', style: Theme.of(context).textTheme.titleMedium),
+          Text('No tags available', style: theme.textTheme.titleMedium),
           const SizedBox(height: 8),
           Text(
             'Create tags first to assign them to selected items.',
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Theme.of(context).colorScheme.onSurfaceVariant,
-                ),
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
             textAlign: TextAlign.center,
           ),
         ],
       ),
     );
-  }
-
-  void _toggleTagSelection(String tagId) {
-    if (_isSaving) {
-      return;
-    }
-    setState(() {
-      if (_tempSelectedTagIds.contains(tagId)) {
-        _tempSelectedTagIds.remove(tagId);
-      } else {
-        _tempSelectedTagIds.add(tagId);
-      }
-    });
   }
 }

--- a/lib/features/tagging/presentation/widgets/tag_filter_dialog.dart
+++ b/lib/features/tagging/presentation/widgets/tag_filter_dialog.dart
@@ -1,22 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../domain/entities/tag_entity.dart';
-import '../states/tag_state.dart';
-import '../view_models/tag_management_view_model.dart';
-import 'tag_chip.dart';
+import '../../../../shared/widgets/tag_selection_dialog.dart';
 
-/// A dialog for filtering tags when there are too many to display in chips.
-/// Allows users to select/deselect tags for filtering.
-class TagFilterDialog extends ConsumerStatefulWidget {
-  const TagFilterDialog({
-    super.key,
-    required this.selectedTagIds,
-    required this.onSelectionChanged,
-  });
-
-  final List<String> selectedTagIds;
-  final ValueChanged<List<String>> onSelectionChanged;
+class TagFilterDialog {
+  const TagFilterDialog._();
 
   static Future<void> show(
     BuildContext context, {
@@ -25,108 +12,27 @@ class TagFilterDialog extends ConsumerStatefulWidget {
   }) {
     return showDialog(
       context: context,
-      builder: (context) => TagFilterDialog(
-        selectedTagIds: selectedTagIds,
+      builder: (context) => TagSelectionDialog<void>(
+        title: 'Filter by Tags',
+        description:
+            'Select tags to filter by. Selecting none shows all items.',
+        initialSelectedTagIds: selectedTagIds,
         onSelectionChanged: onSelectionChanged,
-      ),
-    );
-  }
-
-  @override
-  ConsumerState<TagFilterDialog> createState() => _TagFilterDialogState();
-}
-
-class _TagFilterDialogState extends ConsumerState<TagFilterDialog> {
-  late List<String> _tempSelectedTagIds;
-
-  @override
-  void initState() {
-    super.initState();
-    _tempSelectedTagIds = List<String>.from(widget.selectedTagIds);
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final tagState = ref.watch(tagViewModelProvider);
-
-    return AlertDialog(
-      title: const Text('Filter by Tags'),
-      content: SizedBox(
-        width: double.maxFinite,
-        child: switch (tagState) {
-          TagLoaded(:final tags) => _buildContent(context, tags),
-          TagLoading() => const Center(child: CircularProgressIndicator()),
-          TagError(:final message) => Center(
-            child: Text(
-              'Error: $message',
-              style: TextStyle(color: Theme.of(context).colorScheme.error),
-            ),
-          ),
-          TagEmpty() => _buildEmptyState(context),
+        onConfirm: (selection) async {
+          onSelectionChanged(selection);
+          return null;
         },
+        confirmLabel: 'Apply',
+        cancelLabel: 'Cancel',
+        showAllOption: true,
+        allOptionLabel: 'All',
+        emptyStateBuilder: (context) => _buildEmptyState(context),
       ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(),
-          child: const Text('Cancel'),
-        ),
-        ElevatedButton(
-          onPressed: () {
-            widget.onSelectionChanged(_tempSelectedTagIds);
-            Navigator.of(context).pop();
-          },
-          child: const Text('Apply'),
-        ),
-      ],
     );
   }
 
-  Widget _buildContent(BuildContext context, List<TagEntity> tags) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          'Select tags to filter by. Selecting none shows all items.',
-          style: Theme.of(context).textTheme.bodySmall?.copyWith(
-            color: Theme.of(context).colorScheme.onSurfaceVariant,
-          ),
-        ),
-        const SizedBox(height: 16),
-        Flexible(
-          child: SingleChildScrollView(
-            child: Wrap(
-              spacing: 8,
-              runSpacing: 8,
-              children: [
-                // "All" option
-                TagChip(
-                  tag: TagEntity(
-                    id: 'all',
-                    name: 'All',
-                    color: 0xFF9E9E9E, // Grey color
-                    createdAt: DateTime.now(),
-                  ),
-                  selected: _tempSelectedTagIds.isEmpty,
-                  onTap: _toggleAllSelection,
-                ),
-                // Individual tags
-                ...tags.map(
-                  (tag) => TagChip(
-                    tag: tag,
-                    selected: _tempSelectedTagIds.contains(tag.id),
-                    onTap: () => _toggleTagSelection(tag.id),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildEmptyState(BuildContext context) {
+  static Widget _buildEmptyState(BuildContext context) {
+    final theme = Theme.of(context);
     return Center(
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -134,28 +40,12 @@ class _TagFilterDialogState extends ConsumerState<TagFilterDialog> {
           Icon(
             Icons.tag,
             size: 48,
-            color: Theme.of(context).colorScheme.outline,
+            color: theme.colorScheme.outline,
           ),
           const SizedBox(height: 16),
-          Text('No tags available', style: Theme.of(context).textTheme.titleMedium),
+          Text('No tags available', style: theme.textTheme.titleMedium),
         ],
       ),
     );
-  }
-
-  void _toggleTagSelection(String tagId) {
-    setState(() {
-      if (_tempSelectedTagIds.contains(tagId)) {
-        _tempSelectedTagIds.remove(tagId);
-      } else {
-        _tempSelectedTagIds.add(tagId);
-      }
-    });
-  }
-
-  void _toggleAllSelection() {
-    setState(() {
-      _tempSelectedTagIds.clear();
-    });
   }
 }

--- a/lib/features/tagging/presentation/widgets/tag_management_dialog.dart
+++ b/lib/features/tagging/presentation/widgets/tag_management_dialog.dart
@@ -1,20 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../../features/media_library/domain/entities/media_entity.dart';
 import '../../../../shared/providers/repository_providers.dart';
+import '../../../../shared/widgets/tag_selection_dialog.dart';
+import '../../../media_library/domain/entities/media_entity.dart';
 import '../../domain/entities/tag_entity.dart';
 import '../../domain/use_cases/assign_tag_use_case.dart';
-import '../view_models/tags_view_model.dart';
-import '../states/tag_state.dart';
 import '../view_models/tag_management_view_model.dart';
-import 'tag_chip.dart';
+import '../view_models/tags_view_model.dart';
 import 'tag_creation_dialog.dart';
 
-/// A dialog for managing tags - viewing, adding, and removing tags.
-/// Shows all existing tags with options to delete them and add new ones.
-/// If a media item is provided, allows assigning/removing tags from that item.
-class TagManagementDialog extends ConsumerStatefulWidget {
+/// A dialog for managing tags - viewing, adding, removing, and assigning.
+class TagManagementDialog extends ConsumerWidget {
   const TagManagementDialog({super.key, this.media});
 
   final MediaEntity? media;
@@ -27,221 +24,56 @@ class TagManagementDialog extends ConsumerStatefulWidget {
   }
 
   @override
-  ConsumerState<TagManagementDialog> createState() => _TagManagementDialogState();
-}
+  Widget build(BuildContext context, WidgetRef ref) {
+    final assignTagUseCase = ref.read(assignTagUseCaseProvider);
+    final tagsNotifier = ref.read(tagsViewModelProvider.notifier);
+    final tagViewModel = ref.read(tagViewModelProvider.notifier);
+    final mediaRepository = ref.read(mediaRepositoryProvider);
 
-class _TagManagementDialogState extends ConsumerState<TagManagementDialog> {
-  late Future<List<String>> _assignedTagIdsFuture;
-  List<String> _assignedTagIds = <String>[];
-  bool _hasLoadedInitialAssignments = false;
-
-  @override
-  void initState() {
-    super.initState();
-    _assignedTagIdsFuture = _loadInitialAssignedTagIds();
-  }
-
-  @override
-  void didUpdateWidget(covariant TagManagementDialog oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.media?.id != widget.media?.id) {
-      setState(() {
-        _hasLoadedInitialAssignments = false;
-        _assignedTagIdsFuture = _loadInitialAssignedTagIds();
-      });
-    }
-  }
-
-  Future<List<String>> _loadInitialAssignedTagIds() async {
-    final requestedMediaId = widget.media?.id;
-
-    if (requestedMediaId == null) {
-      _assignedTagIds = <String>[];
-      _hasLoadedInitialAssignments = true;
-      return const <String>[];
-    }
-
-    final repository = ref.read(mediaRepositoryProvider);
-    final media = await repository.getMediaById(requestedMediaId);
-
-    if (!mounted || requestedMediaId != widget.media?.id) {
-      return _assignedTagIds;
-    }
-
-    final ids = media?.tagIds ?? <String>[];
-    _assignedTagIds = List<String>.from(ids);
-    _hasLoadedInitialAssignments = true;
-    return _assignedTagIds;
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return FutureBuilder<List<String>>(
-      future: _assignedTagIdsFuture,
-      builder: (context, snapshot) {
-        if (snapshot.connectionState == ConnectionState.waiting && !_hasLoadedInitialAssignments) {
-          return const AlertDialog(
-            title: Text('Loading...'),
-            content: CircularProgressIndicator(),
-          );
-        }
-
-        if (snapshot.hasError) {
-          return AlertDialog(
-            title: const Text('Error'),
-            content: Text('Failed to load current tags: ${snapshot.error}'),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(),
-                child: const Text('Close'),
-              ),
-            ],
-          );
-        }
-
-        final tagState = ref.watch(tagViewModelProvider);
-        final tagViewModel = ref.read(tagViewModelProvider.notifier);
-        final assignTagUseCase = ref.read(assignTagUseCaseProvider);
-
-        return AlertDialog(
-          title: Text(widget.media != null ? 'Assign Tags' : 'Manage Tags'),
-          content: SizedBox(
-            width: double.maxFinite,
-            child: switch (tagState) {
-              TagLoaded(:final tags) =>
-                  _buildContent(context, tags, tagViewModel, assignTagUseCase),
-              TagLoading() => const Center(child: CircularProgressIndicator()),
-              TagError(:final message) => Center(
-                child: Text(
-                  'Error: $message',
-                  style: TextStyle(
-                    color: Theme.of(context).colorScheme.error,
-                  ),
-                ),
-              ),
-              TagEmpty() => _buildEmptyState(context),
+    return TagSelectionDialog<void>(
+      title: media != null ? 'Assign Tags' : 'Manage Tags',
+      assignmentTargetLabel: media != null
+          ? 'Assign tags to "${media!.name}"'
+          : null,
+      loadInitialSelection: media != null
+          ? () async {
+              final fetched = await mediaRepository.getMediaById(media!.id);
+              return fetched?.tagIds ?? <String>[];
+            }
+          : null,
+      initialSelectedTagIds:
+          media == null ? const <String>[] : media!.tagIds,
+      onTagToggle: media == null
+          ? null
+          : (TagEntity tag, bool isSelected) async {
+              if (media!.type == MediaType.directory) {
+                await assignTagUseCase.toggleTagOnDirectory(media!.id, tag);
+              } else {
+                await assignTagUseCase.toggleTagOnMedia(media!.id, tag);
+              }
+              await tagsNotifier.refreshTags();
             },
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: const Text('Close'),
-            ),
-          ],
-        );
-      },
+      showCancelButton: true,
+      cancelLabel: 'Close',
+      showConfirmButton: false,
+      showCreateButton: media == null,
+      onCreateTag: media == null
+          ? (context) => TagCreationDialog.show(context)
+          : null,
+      showDeleteButtons: media == null,
+      onDeleteTag: media == null
+          ? (context, tag) => _confirmDeleteTag(context, tag, tagViewModel)
+          : null,
+      emptyStateBuilder: (context) => _buildEmptyState(context, media != null),
     );
   }
 
-  Widget _buildContent(
-    BuildContext context,
-    List<TagEntity> tags,
-    TagViewModel tagViewModel,
-    AssignTagUseCase assignTagUseCase,
-  ) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        if (widget.media != null)
-          Text(
-            'Assign tags to "${widget.media!.name}"',
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
-            ),
-          )
-        else
-          Row(
-            children: [
-              const Text('Tags', style: TextStyle(fontWeight: FontWeight.w600)),
-              const Spacer(),
-              TextButton.icon(
-                onPressed: () => _showCreateTagDialog(context),
-                icon: const Icon(Icons.add, size: 18),
-                label: const Text('Add Tag'),
-                style: TextButton.styleFrom(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 12,
-                    vertical: 8,
-                  ),
-                ),
-              ),
-            ],
-          ),
-        const SizedBox(height: 12),
-        if (tags.isEmpty)
-          _buildEmptyState(context)
-        else
-          Flexible(
-            child: Wrap(
-              spacing: 8,
-              runSpacing: 8,
-              children: tags
-                  .map(
-                    (tag) => widget.media != null
-                        ? TagChip(
-                            tag: tag,
-                            selected: _assignedTagIds.contains(tag.id),
-                            onTap: () => _toggleTagAssignment(tag, assignTagUseCase),
-                          )
-                        : TagChip(
-                            tag: tag,
-                            showDeleteIcon: true,
-                            onDeleted: () =>
-                                _confirmDeleteTag(context, tag, tagViewModel),
-                          ),
-                  )
-                  .toList(),
-            ),
-          ),
-      ],
-    );
-  }
-
-  Widget _buildEmptyState(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(
-            Icons.tag,
-            size: 48,
-            color: Theme.of(context).colorScheme.outline,
-          ),
-          const SizedBox(height: 16),
-          Text('No tags yet', style: Theme.of(context).textTheme.titleMedium),
-          const SizedBox(height: 8),
-          Text(
-            widget.media != null
-                ? 'Create tags first to assign them to this item'
-                : 'Create your first tag to organize your content',
-            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
-            ),
-            textAlign: TextAlign.center,
-          ),
-          const SizedBox(height: 16),
-          if (widget.media == null)
-            ElevatedButton.icon(
-              onPressed: () => _showCreateTagDialog(context),
-              icon: const Icon(Icons.add),
-              label: const Text('Create Tag'),
-            ),
-        ],
-      ),
-    );
-  }
-
-  void _showCreateTagDialog(BuildContext context) {
-    TagCreationDialog.show(context);
-  }
-
-  void _confirmDeleteTag(
+  static Future<void> _confirmDeleteTag(
     BuildContext context,
     TagEntity tag,
-    TagViewModel tagViewModel,
+    TagManagementViewModel tagViewModel,
   ) {
-    showDialog(
+    return showDialog(
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('Delete Tag'),
@@ -256,7 +88,7 @@ class _TagManagementDialogState extends ConsumerState<TagManagementDialog> {
           TextButton(
             onPressed: () {
               tagViewModel.deleteTag(tag.id);
-              Navigator.of(context).pop(); // Close confirmation dialog
+              Navigator.of(context).pop();
             },
             style: TextButton.styleFrom(
               foregroundColor: Theme.of(context).colorScheme.error,
@@ -268,38 +100,39 @@ class _TagManagementDialogState extends ConsumerState<TagManagementDialog> {
     );
   }
 
-  void _toggleTagAssignment(TagEntity tag, AssignTagUseCase assignTagUseCase) async {
-    if (widget.media == null) return;
-
-    setState(() {
-      if (_assignedTagIds.contains(tag.id)) {
-        _assignedTagIds.remove(tag.id);
-      } else {
-        _assignedTagIds.add(tag.id);
-      }
-    });
-
-    try {
-      if (widget.media!.type == MediaType.directory) {
-        await assignTagUseCase.toggleTagOnDirectory(widget.media!.id, tag);
-      } else {
-        await assignTagUseCase.toggleTagOnMedia(widget.media!.id, tag);
-      }
-      await ref.read(tagsViewModelProvider.notifier).refreshTags();
-    } catch (e) {
-      // Revert on error
-      setState(() {
-        if (_assignedTagIds.contains(tag.id)) {
-          _assignedTagIds.remove(tag.id);
-        } else {
-          _assignedTagIds.add(tag.id);
-        }
-      });
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Failed to update tag: $e')),
-        );
-      }
-    }
+  static Widget _buildEmptyState(BuildContext context, bool forAssignment) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.tag,
+            size: 48,
+            color: theme.colorScheme.outline,
+          ),
+          const SizedBox(height: 16),
+          Text('No tags yet', style: theme.textTheme.titleMedium),
+          const SizedBox(height: 8),
+          Text(
+            forAssignment
+                ? 'Create tags first to assign them to this item'
+                : 'Create your first tag to organize your content',
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          if (!forAssignment) ...[
+            const SizedBox(height: 16),
+            ElevatedButton.icon(
+              onPressed: () => TagCreationDialog.show(context),
+              icon: const Icon(Icons.add),
+              label: const Text('Create Tag'),
+            ),
+          ],
+        ],
+      ),
+    );
   }
 }

--- a/lib/features/tagging/presentation/widgets/tag_management_dialog.dart
+++ b/lib/features/tagging/presentation/widgets/tag_management_dialog.dart
@@ -71,7 +71,7 @@ class TagManagementDialog extends ConsumerWidget {
   static Future<void> _confirmDeleteTag(
     BuildContext context,
     TagEntity tag,
-    TagManagementViewModel tagViewModel,
+    TagViewModel tagViewModel,
   ) {
     return showDialog(
       context: context,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'shared/providers/theme_provider.dart';
-import 'shared/widgets/error_boundary.dart';
 import 'shared/widgets/main_navigation.dart';
 
 void main() async {

--- a/lib/shared/widgets/tag_selection_dialog.dart
+++ b/lib/shared/widgets/tag_selection_dialog.dart
@@ -1,0 +1,458 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../features/tagging/domain/entities/tag_entity.dart';
+import '../../features/tagging/presentation/states/tag_state.dart';
+import '../../features/tagging/presentation/view_models/tag_management_view_model.dart';
+import '../../features/tagging/presentation/widgets/tag_chip.dart';
+
+typedef TagToggleCallback = Future<void> Function(TagEntity tag, bool isSelected);
+typedef TagDeletionCallback = Future<void> Function(BuildContext context, TagEntity tag);
+typedef TagCreationCallback = Future<void> Function(BuildContext context);
+typedef TagSelectionConfirmCallback<T> = Future<T?> Function(List<String> tagIds);
+typedef TagSelectionLoader = Future<List<String>> Function();
+
+/// A flexible dialog for selecting and managing tags across multiple flows.
+///
+/// The dialog centralises tag fetching, loading/error/empty states, chip grids
+/// and confirmation logic so feature flows only need to supply the behaviour
+/// differences (copy, destructive actions, etc.).
+class TagSelectionDialog<T> extends ConsumerStatefulWidget {
+  const TagSelectionDialog({
+    super.key,
+    required this.title,
+    this.description,
+    this.initialSelectedTagIds = const <String>[],
+    this.loadInitialSelection,
+    this.assignmentTargetLabel,
+    this.confirmLabel,
+    this.cancelLabel = 'Cancel',
+    this.showCancelButton = true,
+    this.showConfirmButton,
+    this.onConfirm,
+    this.cancelResult,
+    this.onSelectionChanged,
+    this.onTagToggle,
+    this.onDeleteTag,
+    this.onCreateTag,
+    this.showCreateButton = false,
+    this.showDeleteButtons = false,
+    this.selectionLimit,
+    this.selectionLimitMessage,
+    this.showAllOption = false,
+    this.allOptionLabel = 'All',
+    this.emptyStateBuilder,
+    this.popOnConfirm = true,
+  });
+
+  /// Title displayed in the dialog header.
+  final String title;
+
+  /// Optional descriptive helper text.
+  final String? description;
+
+  /// Optional text describing the assignment target ("Assign to <name>").
+  final String? assignmentTargetLabel;
+
+  /// Pre-selected tag ids when no [loadInitialSelection] is provided.
+  final List<String> initialSelectedTagIds;
+
+  /// Lazy loader for fetching the initial selection when it depends on IO.
+  final TagSelectionLoader? loadInitialSelection;
+
+  /// Callback invoked when the confirm button is pressed.
+  final TagSelectionConfirmCallback<T>? onConfirm;
+
+  /// Called every time the in-memory selection changes.
+  final ValueChanged<List<String>>? onSelectionChanged;
+
+  /// Invoked when a tag is toggled. Used for immediate persistence flows.
+  final TagToggleCallback? onTagToggle;
+
+  /// Callback that is invoked when the delete icon on a tag is pressed.
+  final TagDeletionCallback? onDeleteTag;
+
+  /// Callback to open a creation experience for tags.
+  final TagCreationCallback? onCreateTag;
+
+  /// Label for the confirmation button. Defaults to `Save` when [onConfirm]
+  /// is provided.
+  final String? confirmLabel;
+
+  /// Label for the cancel/close button.
+  final String cancelLabel;
+
+  /// Whether to show the cancel button. Defaults to true.
+  final bool showCancelButton;
+
+  /// Whether to show the confirm button. Defaults to [onConfirm] != null.
+  final bool? showConfirmButton;
+
+  /// Value returned when the dialog is closed via cancel/back.
+  final T? cancelResult;
+
+  /// Whether destructive actions (delete icons) should be displayed.
+  final bool showDeleteButtons;
+
+  /// Whether the "Create tag" button should be shown.
+  final bool showCreateButton;
+
+  /// Selection limit, if any.
+  final int? selectionLimit;
+
+  /// Message shown when attempting to exceed [selectionLimit].
+  final String? selectionLimitMessage;
+
+  /// Adds an "All" option that clears the selection when tapped.
+  final bool showAllOption;
+
+  /// Label used for the "All" option when [showAllOption] is true.
+  final String allOptionLabel;
+
+  /// Builds a custom empty state for when no tags are available.
+  final WidgetBuilder? emptyStateBuilder;
+
+  /// Controls whether the dialog should pop automatically after confirm.
+  final bool popOnConfirm;
+
+  @override
+  ConsumerState<TagSelectionDialog<T>> createState() =>
+      _TagSelectionDialogState<T>();
+}
+
+class _TagSelectionDialogState<T>
+    extends ConsumerState<TagSelectionDialog<T>> {
+  static const String _allOptionId = '__tag_selection_all__';
+
+  late List<String> _selectedTagIds;
+  Future<List<String>>? _initialSelectionFuture;
+  bool _initialisedFromFuture = false;
+  bool _isProcessing = false;
+  String? _errorMessage;
+  final Set<String> _inFlightTagIds = <String>{};
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedTagIds = List<String>.from(widget.initialSelectedTagIds);
+    if (widget.loadInitialSelection != null) {
+      _initialSelectionFuture = widget.loadInitialSelection!().then((value) {
+        _selectedTagIds = List<String>.from(value);
+        _initialisedFromFuture = true;
+        widget.onSelectionChanged?.call(List<String>.from(_selectedTagIds));
+        return _selectedTagIds;
+      });
+    } else {
+      _initialisedFromFuture = true;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_initialSelectionFuture != null && !_initialisedFromFuture) {
+      return FutureBuilder<List<String>>(
+        future: _initialSelectionFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const AlertDialog(
+              title: Text('Loading...'),
+              content: SizedBox(
+                height: 64,
+                child: Center(child: CircularProgressIndicator()),
+              ),
+            );
+          }
+
+          if (snapshot.hasError) {
+            return AlertDialog(
+              title: const Text('Error'),
+              content: Text('Failed to load current tags: ${snapshot.error}'),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(widget.cancelResult),
+                  child: const Text('Close'),
+                ),
+              ],
+            );
+          }
+
+          _initialisedFromFuture = true;
+          return _buildDialog(context);
+        },
+      );
+    }
+
+    return _buildDialog(context);
+  }
+
+  Widget _buildDialog(BuildContext context) {
+    final tagState = ref.watch(tagViewModelProvider);
+    final bool showConfirmButton =
+        widget.showConfirmButton ?? widget.onConfirm != null;
+
+    return AlertDialog(
+      title: Text(widget.title),
+      content: SizedBox(
+        width: double.maxFinite,
+        child: switch (tagState) {
+          TagLoaded(:final tags) => _buildContent(context, tags),
+          TagLoading() => const Center(child: CircularProgressIndicator()),
+          TagError(:final message) => Center(
+              child: Text(
+                'Error: $message',
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
+              ),
+            ),
+          TagEmpty() => widget.emptyStateBuilder?.call(context) ??
+              _buildDefaultEmptyState(context),
+        },
+      ),
+      actions: [
+        if (widget.showCancelButton)
+          TextButton(
+            onPressed: _isProcessing
+                ? null
+                : () => Navigator.of(context).pop(widget.cancelResult),
+            child: Text(widget.cancelLabel),
+          ),
+        if (showConfirmButton)
+          FilledButton(
+            onPressed: _isProcessing || widget.onConfirm == null
+                ? null
+                : () => _handleConfirm(context),
+            child: _isProcessing
+                ? const SizedBox(
+                    height: 16,
+                    width: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : Text(widget.confirmLabel ?? 'Save'),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildContent(BuildContext context, List<TagEntity> tags) {
+    final theme = Theme.of(context);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (widget.assignmentTargetLabel != null) ...[
+          Text(
+            widget.assignmentTargetLabel!,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 8),
+        ],
+        if (widget.description != null)
+          Text(
+            widget.description!,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        if (widget.showCreateButton)
+          Padding(
+            padding: EdgeInsets.only(
+              top: widget.assignmentTargetLabel != null ||
+                      widget.description != null
+                  ? 16
+                  : 0,
+            ),
+            child: Row(
+              children: [
+                const Text(
+                  'Tags',
+                  style: TextStyle(fontWeight: FontWeight.w600),
+                ),
+                const Spacer(),
+                TextButton.icon(
+                  onPressed: widget.onCreateTag == null
+                      ? null
+                      : () => widget.onCreateTag!(context),
+                  icon: const Icon(Icons.add, size: 18),
+                  label: const Text('Add Tag'),
+                ),
+              ],
+            ),
+          ),
+        const SizedBox(height: 12),
+        if (tags.isEmpty)
+          widget.emptyStateBuilder?.call(context) ??
+              _buildDefaultEmptyState(context)
+        else
+          Flexible(
+            child: SingleChildScrollView(
+              child: Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  if (widget.showAllOption)
+                    TagChip(
+                      tag: TagEntity(
+                        id: _allOptionId,
+                        name: widget.allOptionLabel,
+                        color: theme.colorScheme.outline.value,
+                        createdAt: DateTime.now(),
+                      ),
+                      selected: _selectedTagIds.isEmpty,
+                      onTap: _handleAllOptionSelected,
+                    ),
+                  ...tags.map(
+                    (tag) => TagChip(
+                      tag: tag,
+                      selected: _selectedTagIds.contains(tag.id),
+                      onTap: () => _handleTagTapped(context, tag),
+                      showDeleteIcon: widget.showDeleteButtons,
+                      onDeleted: widget.showDeleteButtons
+                          ? () => widget.onDeleteTag?.call(context, tag)
+                          : null,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        if (_errorMessage != null) ...[
+          const SizedBox(height: 16),
+          Text(
+            _errorMessage!,
+            style: TextStyle(color: theme.colorScheme.error),
+          ),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildDefaultEmptyState(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.tag,
+            size: 48,
+            color: theme.colorScheme.outline,
+          ),
+          const SizedBox(height: 16),
+          Text('No tags available', style: theme.textTheme.titleMedium),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _handleConfirm(BuildContext context) async {
+    if (widget.onConfirm == null) {
+      if (widget.popOnConfirm) {
+        Navigator.of(context).pop();
+      }
+      return;
+    }
+
+    setState(() {
+      _isProcessing = true;
+      _errorMessage = null;
+    });
+
+    try {
+      final result = await widget.onConfirm!(List<String>.from(_selectedTagIds));
+      if (!mounted) {
+        return;
+      }
+      if (widget.popOnConfirm) {
+        Navigator.of(context).pop(result);
+      } else {
+        setState(() {
+          _isProcessing = false;
+        });
+      }
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _isProcessing = false;
+        _errorMessage = 'Failed to save tags: $error';
+      });
+    }
+  }
+
+  void _handleAllOptionSelected() {
+    if (_selectedTagIds.isEmpty) {
+      return;
+    }
+    setState(() {
+      _selectedTagIds.clear();
+      _errorMessage = null;
+    });
+    widget.onSelectionChanged?.call(List<String>.from(_selectedTagIds));
+  }
+
+  Future<void> _handleTagTapped(BuildContext context, TagEntity tag) async {
+    if (_isProcessing || _inFlightTagIds.contains(tag.id)) {
+      return;
+    }
+
+    final bool wasSelected = _selectedTagIds.contains(tag.id);
+
+    if (!wasSelected &&
+        widget.selectionLimit != null &&
+        _selectedTagIds.length >= widget.selectionLimit!) {
+      final messenger = ScaffoldMessenger.maybeOf(context);
+      final message =
+          widget.selectionLimitMessage ?? 'You can only select ${widget.selectionLimit} tags.';
+      messenger?.showSnackBar(SnackBar(content: Text(message)));
+      return;
+    }
+
+    setState(() {
+      _errorMessage = null;
+      if (wasSelected) {
+        _selectedTagIds.remove(tag.id);
+      } else {
+        _selectedTagIds.add(tag.id);
+      }
+    });
+    widget.onSelectionChanged?.call(List<String>.from(_selectedTagIds));
+
+    if (widget.onTagToggle == null) {
+      return;
+    }
+
+    setState(() {
+      _inFlightTagIds.add(tag.id);
+    });
+
+    try {
+      await widget.onTagToggle!(tag, !wasSelected);
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        // revert
+        if (wasSelected) {
+          _selectedTagIds.add(tag.id);
+        } else {
+          _selectedTagIds.remove(tag.id);
+        }
+        _errorMessage = 'Failed to update tag: $error';
+      });
+      widget.onSelectionChanged?.call(List<String>.from(_selectedTagIds));
+      ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+        SnackBar(content: Text('Failed to update tag: $error')),
+      );
+    } finally {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _inFlightTagIds.remove(tag.id);
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a configurable TagSelectionDialog shared widget to centralize tag-loading, chip rendering, and confirmation handling
- refactor TagManagementDialog to delegate to the shared dialog while preserving assignment, creation, and deletion flows
- update directory, bulk, and filter dialogs to wrap the shared dialog for consistent UX and reduced duplication

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f6d274f1e4832082b764336656d1cf