### PR TITLE
Refactor horizontal tag chip strips to reuse shared widget

### DIFF
--- a/lib/features/media_library/presentation/screens/directory_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/directory_grid_screen.dart
@@ -20,6 +20,8 @@ import '../../../tagging/presentation/states/tag_state.dart';
 import '../../../tagging/presentation/view_models/tag_management_view_model.dart';
 import '../../../tagging/presentation/widgets/bulk_tag_assignment_dialog.dart';
 import '../../../tagging/presentation/widgets/tag_creation_dialog.dart';
+import '../../../tagging/presentation/widgets/tag_filter_chips.dart';
+import '../../../tagging/presentation/widgets/tag_selectable_chip_strip.dart';
 import '../../../favorites/presentation/view_models/favorites_view_model.dart';
 import '../../domain/entities/directory_entity.dart';
 import '../view_models/directory_grid_view_model.dart';
@@ -398,48 +400,29 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
     return Container(
       height: UiSizing.tagFilterHeight,
       padding: const EdgeInsets.symmetric(horizontal: 16),
-      child: ListView(
-        scrollDirection: Axis.horizontal,
-        children: [
-          FilterChip(
-            label: const Text('All'),
-            selected: selectedTagIds.isEmpty,
-            onSelected: (_) {
-              debugPrint(
-                'DirectoryGridScreen: "All" filter chip selected, calling filterByTags with empty list',
-              );
-              viewModel.filterByTags(const []);
-            },
-          ),
-          SizedBox(width: UiSpacing.smallGap),
-          ...tags.map(
-            (tag) => Padding(
-              padding: UiSpacing.filterChipRight,
-              child: FilterChip(
-                label: Text(tag.name),
-                selected: selectedTagIds.contains(tag.id),
-                onSelected: (selected) {
-                  debugPrint(
-                    'DirectoryGridScreen: Tag "${tag.name}" (${tag.id}) chip ${selected ? 'selected' : 'deselected'}',
-                  );
-                  debugPrint(
-                    'DirectoryGridScreen: Current selectedTagIds before change: $selectedTagIds',
-                  );
-                  final newSelected = List<String>.from(selectedTagIds);
-                  if (selected) {
-                    newSelected.add(tag.id);
-                  } else {
-                    newSelected.remove(tag.id);
-                  }
-                  debugPrint(
-                    'DirectoryGridScreen: New selectedTagIds: $newSelected',
-                  );
-                  viewModel.filterByTags(newSelected);
-                },
-              ),
-            ),
-          ),
-        ],
+      child: TagFilterChips(
+        // Share the same horizontal tag filtering strip implementation used
+        // elsewhere to keep selection behaviour consistent and testable.
+        selectedTagIds: selectedTagIds,
+        onSelectionChanged: (newSelection) {
+          debugPrint(
+            'DirectoryGridScreen: Current selectedTagIds before change: $selectedTagIds',
+          );
+          debugPrint('DirectoryGridScreen: New selectedTagIds: $newSelection');
+          viewModel.filterByTags(newSelection);
+        },
+        chipVariant: TagChipVariant.filter,
+        chipPadding: UiSpacing.filterChipRight,
+        onAllChipSelected: (_) {
+          debugPrint(
+            'DirectoryGridScreen: "All" filter chip selected, calling filterByTags with empty list',
+          );
+        },
+        onTagSelectionToggle: (tag, isSelected, _, __) {
+          debugPrint(
+            'DirectoryGridScreen: Tag "${tag.name}" (${tag.id}) chip ${isSelected ? 'selected' : 'deselected'}',
+          );
+        },
       ),
     );
   }

--- a/lib/features/media_library/presentation/screens/media_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/media_grid_screen.dart
@@ -18,6 +18,7 @@ import '../../../favorites/presentation/view_models/favorites_view_model.dart';
 import '../../../full_screen/presentation/screens/full_screen_viewer_screen.dart';
 import '../../../tagging/presentation/widgets/bulk_tag_assignment_dialog.dart';
 import '../../../tagging/presentation/widgets/tag_filter_chips.dart';
+import '../../../tagging/presentation/widgets/tag_selectable_chip_strip.dart';
 import '../../../tagging/presentation/widgets/tag_management_dialog.dart';
 import '../../domain/entities/media_entity.dart';
 import '../view_models/media_grid_view_model.dart';
@@ -281,9 +282,13 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
     return Container(
       padding: UiSpacing.tagFilterPadding,
       child: TagFilterChips(
+        // Keep the library tab chips aligned with the horizontal filter strip
+        // shared across the directory and tags flows.
         selectedTagIds: selectedTagIds,
         onSelectionChanged: viewModel.filterByTags,
         maxChipsToShow: UiGrid.maxFilterChips, // Limit to prevent overflow
+        chipVariant: TagChipVariant.filter,
+        chipPadding: UiSpacing.filterChipRight,
       ),
     );
   }

--- a/lib/features/tagging/presentation/widgets/tag_filter_chips.dart
+++ b/lib/features/tagging/presentation/widgets/tag_filter_chips.dart
@@ -4,8 +4,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../domain/entities/tag_entity.dart';
 import '../states/tag_state.dart';
 import '../view_models/tag_management_view_model.dart';
-import 'tag_chip.dart';
 import 'tag_filter_dialog.dart';
+import 'tag_selectable_chip_strip.dart';
 
 /// A widget that displays filterable tag chips for multi-select filtering.
 /// Allows users to select/deselect tags to filter content.
@@ -16,12 +16,20 @@ class TagFilterChips extends ConsumerWidget {
     required this.onSelectionChanged,
     this.maxChipsToShow,
     this.showAllButton = true,
+    this.chipVariant = TagChipVariant.filter,
+    this.chipPadding = const EdgeInsets.only(right: 8),
+    this.onTagSelectionToggle,
+    this.onAllChipSelected,
   });
 
   final List<String> selectedTagIds;
   final ValueChanged<List<String>> onSelectionChanged;
   final int? maxChipsToShow;
   final bool showAllButton;
+  final TagChipVariant chipVariant;
+  final EdgeInsetsGeometry chipPadding;
+  final TagSelectionToggleCallback? onTagSelectionToggle;
+  final AllChipSelectionCallback? onAllChipSelected;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -30,109 +38,40 @@ class TagFilterChips extends ConsumerWidget {
     return switch (tagState) {
       TagLoaded(:final tags) => _buildFilterChips(context, tags),
       TagLoading() => const SizedBox(
-        height: 40,
-        child: Center(child: CircularProgressIndicator()),
-      ),
+          height: 40,
+          child: Center(child: CircularProgressIndicator()),
+        ),
       TagError(:final message) => SizedBox(
-        height: 40,
-        child: Center(
-          child: Text(
-            'Error loading tags: $message',
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-              color: Theme.of(context).colorScheme.error,
+          height: 40,
+          child: Center(
+            child: Text(
+              'Error loading tags: $message',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.error,
+                  ),
             ),
           ),
         ),
-      ),
       TagEmpty() => const SizedBox.shrink(),
     };
   }
 
   Widget _buildFilterChips(BuildContext context, List<TagEntity> allTags) {
-    final displayTags =
-        maxChipsToShow != null && allTags.length > maxChipsToShow!
-        ? allTags.take(maxChipsToShow!).toList()
-        : allTags;
-
-    final showMoreButton =
-        maxChipsToShow != null && allTags.length > maxChipsToShow!;
-
-    return SingleChildScrollView(
-      scrollDirection: Axis.horizontal,
-      child: Row(
-        children: [
-          if (showAllButton) ...[
-            _buildAllFilterChip(context),
-            const SizedBox(width: 8),
-          ],
-          ...displayTags.map(
-            (tag) => Padding(
-              padding: const EdgeInsets.only(right: 8),
-              child: TagChip(
-                tag: tag,
-                selected: selectedTagIds.contains(tag.id),
-                compact: true,
-                onTap: () => _toggleTagSelection(tag.id),
-              ),
-            ),
-          ),
-          if (showMoreButton) ...[
-            const SizedBox(width: 8),
-            _buildMoreButton(context, allTags.length - maxChipsToShow!),
-          ],
-        ],
-      ),
-    );
-  }
-
-  Widget _buildAllFilterChip(BuildContext context) {
-    final isAllSelected = selectedTagIds.isEmpty;
-
-    return TagChip(
-      tag: TagEntity(
-        id: 'all',
-        name: 'All',
-        color: 0xFF9E9E9E, // Grey color
-        createdAt:
-            DateTime.now(), // Not used for display, just for construction
-      ),
-      selected: isAllSelected,
-      compact: true,
-      onTap: _selectAll,
-    );
-  }
-
-  Widget _buildMoreButton(BuildContext context, int remainingCount) {
-    return ActionChip(
-      label: Text('+$remainingCount'),
-      onPressed: () => _showAllTagsDialog(context),
-      backgroundColor:
-          Theme.of(context).colorScheme.surfaceContainerHighest,
-      labelStyle: TextStyle(
-        color: Theme.of(context).colorScheme.onSurfaceVariant,
-      ),
-    );
-  }
-
-  void _toggleTagSelection(String tagId) {
-    final newSelection = List<String>.from(selectedTagIds);
-    if (newSelection.contains(tagId)) {
-      newSelection.remove(tagId);
-    } else {
-      newSelection.add(tagId);
-    }
-    onSelectionChanged(newSelection);
-  }
-
-  void _selectAll() {
-    onSelectionChanged([]);
-  }
-
-  void _showAllTagsDialog(BuildContext context) {
-    TagFilterDialog.show(
-      context,
+    return TagSelectableChipStrip(
+      tags: allTags,
       selectedTagIds: selectedTagIds,
       onSelectionChanged: onSelectionChanged,
+      maxChipsToShow: maxChipsToShow,
+      showAllChip: showAllButton,
+      chipVariant: chipVariant,
+      chipPadding: chipPadding,
+      onTagSelectionToggle: onTagSelectionToggle,
+      onAllChipSelected: onAllChipSelected,
+      onShowOverflowDialog: (context, selection, callback) => TagFilterDialog.show(
+        context,
+        selectedTagIds: selection,
+        onSelectionChanged: callback,
+      ),
     );
   }
 }

--- a/lib/features/tagging/presentation/widgets/tag_selectable_chip_strip.dart
+++ b/lib/features/tagging/presentation/widgets/tag_selectable_chip_strip.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/material.dart';
+
+import '../../domain/entities/tag_entity.dart';
+import 'tag_chip.dart';
+
+/// Signature for displaying an overflow dialog when not all chips fit inline.
+typedef TagOverflowDialogBuilder = Future<void> Function(
+  BuildContext context,
+  List<String> selectedTagIds,
+  ValueChanged<List<String>> onSelectionChanged,
+);
+
+/// Callback invoked whenever an individual tag chip is toggled.
+typedef TagSelectionToggleCallback = void Function(
+  TagEntity tag,
+  bool isSelected,
+  List<String> previousSelection,
+  List<String> updatedSelection,
+);
+
+/// Callback invoked when the "All" chip is tapped.
+typedef AllChipSelectionCallback = void Function(List<String> previousSelection);
+
+/// Controls how individual chips are rendered.
+enum TagChipVariant { colored, filter }
+
+/// Horizontal chip strip that keeps tag selection behaviour consistent across
+/// different screens. Handles the "All" chip, inline overflow affordance and
+/// selection wiring so each caller only needs to respond to the new list of
+/// selected tag ids.
+class TagSelectableChipStrip extends StatelessWidget {
+  const TagSelectableChipStrip({
+    super.key,
+    required this.tags,
+    required this.selectedTagIds,
+    required this.onSelectionChanged,
+    this.maxChipsToShow,
+    this.showAllChip = true,
+    this.allChipLabel = 'All',
+    this.chipVariant = TagChipVariant.filter,
+    this.chipPadding = const EdgeInsets.only(right: 8),
+    this.onShowOverflowDialog,
+    this.onTagSelectionToggle,
+    this.onAllChipSelected,
+  });
+
+  final List<TagEntity> tags;
+  final List<String> selectedTagIds;
+  final ValueChanged<List<String>> onSelectionChanged;
+  final int? maxChipsToShow;
+  final bool showAllChip;
+  final String allChipLabel;
+  final TagChipVariant chipVariant;
+  final EdgeInsetsGeometry chipPadding;
+  final TagOverflowDialogBuilder? onShowOverflowDialog;
+  final TagSelectionToggleCallback? onTagSelectionToggle;
+  final AllChipSelectionCallback? onAllChipSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final displayTags = _displayTags();
+    final showOverflowChip = maxChipsToShow != null && tags.length > maxChipsToShow!;
+
+    if (!showAllChip && displayTags.isEmpty && !showOverflowChip) {
+      return const SizedBox.shrink();
+    }
+
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: [
+          if (showAllChip)
+            Padding(
+              padding: chipPadding,
+              child: _buildAllChip(context),
+            ),
+          ...displayTags.map(
+            (tag) => Padding(
+              padding: chipPadding,
+              child: _buildTagChip(context, tag),
+            ),
+          ),
+          if (showOverflowChip)
+            Padding(
+              padding: chipPadding,
+              child: _buildOverflowChip(
+                context,
+                tags.length - displayTags.length,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  List<TagEntity> _displayTags() {
+    if (maxChipsToShow != null && tags.length > maxChipsToShow!) {
+      return tags.take(maxChipsToShow!).toList(growable: false);
+    }
+    return tags;
+  }
+
+  Widget _buildAllChip(BuildContext context) {
+    final isAllSelected = selectedTagIds.isEmpty;
+
+    return switch (chipVariant) {
+      TagChipVariant.colored => TagChip(
+          tag: TagEntity(
+            id: '__tag_filter_all__',
+            name: allChipLabel,
+            color: 0xFF9E9E9E,
+            createdAt: DateTime.fromMillisecondsSinceEpoch(0),
+          ),
+          selected: isAllSelected,
+          compact: true,
+          onTap: () => _handleAllSelected(),
+        ),
+      TagChipVariant.filter => FilterChip(
+          label: Text(allChipLabel),
+          selected: isAllSelected,
+          onSelected: (_) => _handleAllSelected(),
+        ),
+    };
+  }
+
+  Widget _buildTagChip(BuildContext context, TagEntity tag) {
+    final isSelected = selectedTagIds.contains(tag.id);
+
+    return switch (chipVariant) {
+      TagChipVariant.colored => TagChip(
+          tag: tag,
+          selected: isSelected,
+          compact: true,
+          onTap: () => _handleTagToggled(tag, !isSelected),
+        ),
+      TagChipVariant.filter => FilterChip(
+          label: Text(tag.name),
+          selected: isSelected,
+          onSelected: (selected) => _handleTagToggled(tag, selected),
+        ),
+    };
+  }
+
+  Widget _buildOverflowChip(BuildContext context, int remainingCount) {
+    return ActionChip(
+      label: Text('+$remainingCount'),
+      onPressed: onShowOverflowDialog == null
+          ? null
+          : () => onShowOverflowDialog!(
+                context,
+                selectedTagIds,
+                onSelectionChanged,
+              ),
+      backgroundColor: Theme.of(context).colorScheme.surfaceContainerHighest,
+      labelStyle: TextStyle(
+        color: Theme.of(context).colorScheme.onSurfaceVariant,
+      ),
+    );
+  }
+
+  void _handleAllSelected() {
+    final previousSelection = List<String>.from(selectedTagIds);
+    onAllChipSelected?.call(previousSelection);
+    onSelectionChanged(const []);
+  }
+
+  void _handleTagToggled(TagEntity tag, bool isSelected) {
+    final previousSelection = List<String>.from(selectedTagIds);
+    final updatedSelection = List<String>.from(selectedTagIds);
+
+    if (isSelected) {
+      if (!updatedSelection.contains(tag.id)) {
+        updatedSelection.add(tag.id);
+      }
+    } else {
+      updatedSelection.remove(tag.id);
+    }
+
+    onTagSelectionToggle?.call(tag, isSelected, previousSelection, updatedSelection);
+    onSelectionChanged(updatedSelection);
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable TagSelectableChipStrip that encapsulates horizontal tag selection behaviour
- update TagFilterChips and both media and directory grid screens to consume the shared strip and keep chip styling consistent

## Testing
- `flutter test` *(fails: flutter executable is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68f6d982fd1c8320af55e75420f8a5ba