### PR TITLE
Refactor tag filter chips into shared strip

### DIFF
--- a/lib/features/tagging/presentation/widgets/selectable_tag_chip_strip.dart
+++ b/lib/features/tagging/presentation/widgets/selectable_tag_chip_strip.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+
+import '../../domain/entities/tag_entity.dart';
+import 'tag_chip.dart';
+
+/// Shared horizontal strip for displaying selectable tag chips.
+///
+/// This widget encapsulates the selection handling and layout for the
+/// horizontally scrolling chip rows that appear across the app (e.g. media
+/// library filters, directory filters). It keeps the tag chip visuals
+/// consistent and centralises overflow behaviours.
+class SelectableTagChipStrip extends StatelessWidget {
+  const SelectableTagChipStrip({
+    super.key,
+    required this.tags,
+    required this.selectedTagIds,
+    required this.onSelectionChanged,
+    this.maxChipsToShow,
+    this.showAllChip = true,
+    this.allChipLabel = 'All',
+    this.allChipColor = const Color(0xFF9E9E9E),
+    this.onOverflowPressed,
+  });
+
+  /// Full list of tags available for selection.
+  final List<TagEntity> tags;
+
+  /// Currently selected tag identifiers.
+  final List<String> selectedTagIds;
+
+  /// Callback invoked when the selection changes.
+  final ValueChanged<List<String>> onSelectionChanged;
+
+  /// Maximum number of chips to render inline before showing an overflow chip.
+  final int? maxChipsToShow;
+
+  /// Whether to render the "All" chip that clears the selection.
+  final bool showAllChip;
+
+  /// Label used for the "All" chip.
+  final String allChipLabel;
+
+  /// Background colour used for the "All" chip when not selected.
+  final Color allChipColor;
+
+  /// Callback invoked when the overflow chip is tapped.
+  final VoidCallback? onOverflowPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final displayTags = _tagsToDisplay();
+    final showOverflowChip =
+        maxChipsToShow != null && tags.length > maxChipsToShow!;
+    final remainingCount =
+        showOverflowChip ? tags.length - maxChipsToShow! : 0;
+
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: [
+          if (showAllChip) ...[
+            _buildAllChip(),
+            const SizedBox(width: 8),
+          ],
+          ...displayTags.map(
+            (tag) => Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: TagChip(
+                tag: tag,
+                selected: selectedTagIds.contains(tag.id),
+                compact: true,
+                onTap: () => _toggleTagSelection(tag.id),
+              ),
+            ),
+          ),
+          if (showOverflowChip && remainingCount > 0) ...[
+            const SizedBox(width: 8),
+            ActionChip(
+              label: Text('+$remainingCount'),
+              onPressed: onOverflowPressed,
+              backgroundColor:
+                  Theme.of(context).colorScheme.surfaceContainerHighest,
+              labelStyle: TextStyle(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  List<TagEntity> _tagsToDisplay() {
+    if (maxChipsToShow != null && tags.length > maxChipsToShow!) {
+      return tags.take(maxChipsToShow!).toList();
+    }
+    return tags;
+  }
+
+  Widget _buildAllChip() {
+    final isAllSelected = selectedTagIds.isEmpty;
+    return TagChip(
+      tag: TagEntity(
+        id: '__all__',
+        name: allChipLabel,
+        color: allChipColor.value,
+        createdAt: DateTime.now(),
+      ),
+      selected: isAllSelected,
+      compact: true,
+      onTap: () => onSelectionChanged(const []),
+    );
+  }
+
+  void _toggleTagSelection(String tagId) {
+    final newSelection = List<String>.from(selectedTagIds);
+    if (newSelection.contains(tagId)) {
+      newSelection.remove(tagId);
+    } else {
+      newSelection.add(tagId);
+    }
+    onSelectionChanged(newSelection);
+  }
+}

--- a/lib/features/tagging/presentation/widgets/tag_filter_chips.dart
+++ b/lib/features/tagging/presentation/widgets/tag_filter_chips.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../domain/entities/tag_entity.dart';
 import '../states/tag_state.dart';
 import '../view_models/tag_management_view_model.dart';
-import 'tag_chip.dart';
+import 'selectable_tag_chip_strip.dart';
 import 'tag_filter_dialog.dart';
 
 /// A widget that displays filterable tag chips for multi-select filtering.
@@ -28,105 +27,37 @@ class TagFilterChips extends ConsumerWidget {
     final tagState = ref.watch(tagViewModelProvider);
 
     return switch (tagState) {
-      TagLoaded(:final tags) => _buildFilterChips(context, tags),
+      TagLoaded(:final tags) => SelectableTagChipStrip(
+          tags: tags,
+          selectedTagIds: selectedTagIds,
+          onSelectionChanged: onSelectionChanged,
+          maxChipsToShow: maxChipsToShow,
+          showAllChip: showAllButton,
+          onOverflowPressed: _shouldShowOverflow(tags.length)
+              ? () => _showAllTagsDialog(context)
+              : null,
+        ),
       TagLoading() => const SizedBox(
-        height: 40,
-        child: Center(child: CircularProgressIndicator()),
-      ),
+          height: 40,
+          child: Center(child: CircularProgressIndicator()),
+        ),
       TagError(:final message) => SizedBox(
-        height: 40,
-        child: Center(
-          child: Text(
-            'Error loading tags: $message',
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-              color: Theme.of(context).colorScheme.error,
+          height: 40,
+          child: Center(
+            child: Text(
+              'Error loading tags: $message',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.error,
+                  ),
             ),
           ),
         ),
-      ),
       TagEmpty() => const SizedBox.shrink(),
     };
   }
 
-  Widget _buildFilterChips(BuildContext context, List<TagEntity> allTags) {
-    final displayTags =
-        maxChipsToShow != null && allTags.length > maxChipsToShow!
-        ? allTags.take(maxChipsToShow!).toList()
-        : allTags;
-
-    final showMoreButton =
-        maxChipsToShow != null && allTags.length > maxChipsToShow!;
-
-    return SingleChildScrollView(
-      scrollDirection: Axis.horizontal,
-      child: Row(
-        children: [
-          if (showAllButton) ...[
-            _buildAllFilterChip(context),
-            const SizedBox(width: 8),
-          ],
-          ...displayTags.map(
-            (tag) => Padding(
-              padding: const EdgeInsets.only(right: 8),
-              child: TagChip(
-                tag: tag,
-                selected: selectedTagIds.contains(tag.id),
-                compact: true,
-                onTap: () => _toggleTagSelection(tag.id),
-              ),
-            ),
-          ),
-          if (showMoreButton) ...[
-            const SizedBox(width: 8),
-            _buildMoreButton(context, allTags.length - maxChipsToShow!),
-          ],
-        ],
-      ),
-    );
-  }
-
-  Widget _buildAllFilterChip(BuildContext context) {
-    final isAllSelected = selectedTagIds.isEmpty;
-
-    return TagChip(
-      tag: TagEntity(
-        id: 'all',
-        name: 'All',
-        color: 0xFF9E9E9E, // Grey color
-        createdAt:
-            DateTime.now(), // Not used for display, just for construction
-      ),
-      selected: isAllSelected,
-      compact: true,
-      onTap: _selectAll,
-    );
-  }
-
-  Widget _buildMoreButton(BuildContext context, int remainingCount) {
-    return ActionChip(
-      label: Text('+$remainingCount'),
-      onPressed: () => _showAllTagsDialog(context),
-      backgroundColor:
-          Theme.of(context).colorScheme.surfaceContainerHighest,
-      labelStyle: TextStyle(
-        color: Theme.of(context).colorScheme.onSurfaceVariant,
-      ),
-    );
-  }
-
-  void _toggleTagSelection(String tagId) {
-    final newSelection = List<String>.from(selectedTagIds);
-    if (newSelection.contains(tagId)) {
-      newSelection.remove(tagId);
-    } else {
-      newSelection.add(tagId);
-    }
-    onSelectionChanged(newSelection);
-  }
-
-  void _selectAll() {
-    onSelectionChanged([]);
-  }
+  bool _shouldShowOverflow(int tagCount) =>
+      maxChipsToShow != null && tagCount > maxChipsToShow!;
 
   void _showAllTagsDialog(BuildContext context) {
     TagFilterDialog.show(


### PR DESCRIPTION
## Summary
- extract a shared `SelectableTagChipStrip` widget for horizontal tag filters
- update `TagFilterChips` to delegate rendering and overflow handling to the shared strip
- reuse the shared strip in the directory grid so tag chips match the library styling and logic

## Testing
- Not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68f6dcf13c608320906f7e6301034a9c