### PR TITLE
Fix tag persistence for nested directory tag assignments

### DIFF
--- a/lib/features/tagging/presentation/widgets/tag_management_dialog.dart
+++ b/lib/features/tagging/presentation/widgets/tag_management_dialog.dart
@@ -46,11 +46,11 @@ class TagManagementDialog extends ConsumerWidget {
       onTagToggle: media == null
           ? null
           : (TagEntity tag, bool isSelected) async {
-              if (media!.type == MediaType.directory) {
-                await assignTagUseCase.toggleTagOnDirectory(media!.id, tag);
-              } else {
-                await assignTagUseCase.toggleTagOnMedia(media!.id, tag);
-              }
+              // Directory entries surfaced within the media grid are persisted as media
+              // items, so ensure their tag assignments are updated through the media
+              // repository. Updating via the directory repository would miss these
+              // nested directories, causing the new tag to be lost on reload.
+              await assignTagUseCase.toggleTagOnMedia(media!.id, tag);
               await tagsNotifier.refreshTags();
             },
       showCancelButton: true,


### PR DESCRIPTION
## Summary
- update the tag management dialog to persist directory tags through the media repository so nested directories retain their selections

## Testing
- flutter test *(fails: Flutter SDK not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f6e16e14588320ad8e9eb64251ea83