### PR TITLE
Persist recovered directories and renewed bookmarks

### DIFF
--- a/lib/features/media_library/data/repositories/directory_repository_impl.dart
+++ b/lib/features/media_library/data/repositories/directory_repository_impl.dart
@@ -295,7 +295,7 @@ class DirectoryRepositoryImpl implements DirectoryRepository {
       updatedModel = updatedModel.copyWith(name: name);
     }
 
-    if (bookmarkData != normalizedModel.bookmarkData) {
+    if (bookmarkData != null && bookmarkData != normalizedModel.bookmarkData) {
       updatedModel = updatedModel.copyWith(bookmarkData: bookmarkData);
     }
 

--- a/lib/features/media_library/data/repositories/filesystem_media_repository_impl.dart
+++ b/lib/features/media_library/data/repositories/filesystem_media_repository_impl.dart
@@ -72,11 +72,20 @@ class FilesystemMediaRepositoryImpl implements MediaRepository {
       }
     }
 
+    String? effectiveBookmarkData = bookmarkData;
+    if (validationResult.renewedBookmarkData != null) {
+      effectiveBookmarkData = validationResult.renewedBookmarkData;
+      await _directoryRepository.updateDirectoryBookmark(
+        directoryId,
+        validationResult.renewedBookmarkData,
+      );
+    }
+
     try {
       final models = await _filesystemDataSource.scanMediaForDirectory(
         directoryPath,
         directoryId,
-        bookmarkData: bookmarkData,
+        bookmarkData: effectiveBookmarkData,
       );
 
       // Merge tags from local storage

--- a/lib/features/media_library/domain/repositories/directory_repository.dart
+++ b/lib/features/media_library/domain/repositories/directory_repository.dart
@@ -36,6 +36,15 @@ abstract class DirectoryRepository {
   /// Updates the bookmark data for a directory.
   Future<void> updateDirectoryBookmark(String directoryId, String? bookmarkData);
 
+  /// Updates persisted metadata for a directory, allowing callers to refresh
+  /// the stored path, display name, and bookmark in a single operation.
+  Future<void> updateDirectoryMetadata(
+    String directoryId, {
+    String? path,
+    String? name,
+    String? bookmarkData,
+  });
+
   /// Clears all stored directory data.
   Future<void> clearAllDirectories();
 }

--- a/lib/features/media_library/domain/use_cases/update_directory_access_use_case.dart
+++ b/lib/features/media_library/domain/use_cases/update_directory_access_use_case.dart
@@ -1,0 +1,23 @@
+import '../repositories/directory_repository.dart';
+
+/// Use case responsible for persisting refreshed directory metadata after
+/// recovering permissions or renewing bookmarks.
+class UpdateDirectoryAccessUseCase {
+  const UpdateDirectoryAccessUseCase(this._repository);
+
+  final DirectoryRepository _repository;
+
+  Future<void> call({
+    required String directoryId,
+    String? newPath,
+    String? newName,
+    String? bookmarkData,
+  }) {
+    return _repository.updateDirectoryMetadata(
+      directoryId,
+      path: newPath,
+      name: newName,
+      bookmarkData: bookmarkData,
+    );
+  }
+}

--- a/lib/shared/providers/repository_providers.dart
+++ b/lib/shared/providers/repository_providers.dart
@@ -29,6 +29,7 @@ import '../../features/media_library/domain/use_cases/get_media_use_case.dart';
 import '../../features/media_library/domain/use_cases/remove_directory_use_case.dart';
 import '../../features/media_library/domain/use_cases/search_directories_use_case.dart';
 import '../../features/media_library/domain/use_cases/validate_path_use_case.dart';
+import '../../features/media_library/domain/use_cases/update_directory_access_use_case.dart';
 import '../../features/tagging/domain/use_cases/get_tags_use_case.dart';
 import '../../features/tagging/domain/use_cases/assign_tag_use_case.dart';
 import '../../features/tagging/domain/use_cases/create_tag_use_case.dart';
@@ -194,6 +195,11 @@ final removeDirectoryUseCaseProvider = Provider<RemoveDirectoryUseCase>((ref) {
     ref.watch(mediaRepositoryProvider),
     ref.watch(favoritesRepositoryProvider),
   );
+});
+
+final updateDirectoryAccessUseCaseProvider =
+    Provider<UpdateDirectoryAccessUseCase>((ref) {
+  return UpdateDirectoryAccessUseCase(ref.watch(directoryRepositoryProvider));
 });
 
 final clearDirectoriesUseCaseProvider = Provider<ClearDirectoriesUseCase>((ref) {

--- a/test/features/media_library/data/repositories/directory_repository_impl_test.dart
+++ b/test/features/media_library/data/repositories/directory_repository_impl_test.dart
@@ -144,5 +144,36 @@ void main() {
         verify(isarDirectoryDataSource.addDirectory(any)).called(1);
       });
     });
+
+    group('updateDirectoryMetadata', () {
+      test('preserves existing bookmark when new value is not provided', () async {
+        const directoryId = 'dir-1';
+        final existingModel = DirectoryModel(
+          id: directoryId,
+          path: '/test/path',
+          name: 'Original',
+          thumbnailPath: null,
+          tagIds: const ['tag-1'],
+          lastModified: DateTime(2024, 1, 1),
+          bookmarkData: 'existing-bookmark',
+        );
+
+        when(isarDirectoryDataSource.getDirectoryById(directoryId)).thenAnswer(
+          (_) async => existingModel,
+        );
+        when(isarDirectoryDataSource.updateDirectory(any)).thenAnswer((_) async {});
+
+        await repository.updateDirectoryMetadata(
+          directoryId,
+          name: 'Renamed directory',
+        );
+
+        final captured =
+            verify(isarDirectoryDataSource.updateDirectory(captureAny)).captured.single
+                as DirectoryModel;
+
+        expect(captured.bookmarkData, equals(existingModel.bookmarkData));
+      });
+    });
   });
 }

--- a/test/features/media_library/presentation/view_models/directory_grid_view_model_test.dart
+++ b/test/features/media_library/presentation/view_models/directory_grid_view_model_test.dart
@@ -97,6 +97,26 @@ class InMemoryDirectoryRepository implements DirectoryRepository {
       _directories[index] = _directories[index].copyWith(tagIds: tagIds);
     }
   }
+
+  @override
+  Future<void> updateDirectoryMetadata(
+    String directoryId, {
+    String? path,
+    String? name,
+    String? bookmarkData,
+  }) async {
+    final index = _directories.indexWhere((dir) => dir.id == directoryId);
+    if (index == -1) {
+      return;
+    }
+
+    final existing = _directories[index];
+    _directories[index] = existing.copyWith(
+      path: path ?? existing.path,
+      name: name ?? existing.name,
+      bookmarkData: bookmarkData ?? existing.bookmarkData,
+    );
+  }
 }
 
 class InMemoryMediaRepository implements MediaRepository {

--- a/test/features/media_library/presentation/view_models/media_view_model_test.dart
+++ b/test/features/media_library/presentation/view_models/media_view_model_test.dart
@@ -7,8 +7,10 @@ import '../../../../../lib/features/favorites/domain/entities/favorite_entity.da
 import '../../../../../lib/features/favorites/domain/entities/favorite_item_type.dart';
 import '../../../../../lib/features/favorites/domain/repositories/favorites_repository.dart';
 import '../../../../../lib/features/media_library/domain/entities/media_entity.dart';
+import '../../../../../lib/features/media_library/domain/repositories/directory_repository.dart';
 import '../../../../../lib/features/media_library/domain/repositories/media_repository.dart';
 import '../../../../../lib/features/media_library/domain/use_cases/get_media_use_case.dart';
+import '../../../../../lib/features/media_library/domain/use_cases/update_directory_access_use_case.dart';
 import '../../../../../lib/features/media_library/presentation/view_models/media_grid_view_model.dart';
 import '../../../../../lib/shared/providers/repository_providers.dart';
 
@@ -130,11 +132,14 @@ class InMemoryFavoritesRepository implements FavoritesRepository {
 
 class _MockIsarMediaDataSource extends Mock implements IsarMediaDataSource {}
 
+class _MockDirectoryRepository extends Mock implements DirectoryRepository {}
+
 ProviderContainer _createMediaTestContainer({
   required IsarMediaDataSource mediaDataSource,
   required InMemoryMediaRepository mediaRepository,
   required GetMediaUseCase getMediaUseCase,
   required InMemoryFavoritesRepository favoritesRepository,
+  required UpdateDirectoryAccessUseCase updateDirectoryAccessUseCase,
 }) {
   return ProviderContainer(
     overrides: [
@@ -148,6 +153,7 @@ ProviderContainer _createMediaTestContainer({
             params,
             getMediaUseCase: getMediaUseCase,
             mediaDataSource: mediaDataSource,
+            updateDirectoryAccessUseCase: updateDirectoryAccessUseCase,
           ),
         );
       }),
@@ -162,6 +168,8 @@ void main() {
   late InMemoryMediaRepository mediaRepository;
   late InMemoryFavoritesRepository favoritesRepository;
   late GetMediaUseCase getMediaUseCase;
+  late UpdateDirectoryAccessUseCase updateDirectoryAccessUseCase;
+  late _MockDirectoryRepository directoryRepository;
   const params = MediaViewModelParams(
     directoryPath: '/dir1',
     directoryName: 'Directory 1',
@@ -173,6 +181,18 @@ void main() {
     when(mediaCache.removeMediaForDirectory(any)).thenAnswer((_) async {});
     when(mediaCache.upsertMedia(any)).thenAnswer((_) async {});
     favoritesRepository = InMemoryFavoritesRepository();
+    directoryRepository = _MockDirectoryRepository();
+    when(
+      directoryRepository.updateDirectoryMetadata(
+        any,
+        path: anyNamed('path'),
+        name: anyNamed('name'),
+        bookmarkData: anyNamed('bookmarkData'),
+      ),
+    ).thenAnswer((_) async {});
+    updateDirectoryAccessUseCase = UpdateDirectoryAccessUseCase(
+      directoryRepository,
+    );
     mediaRepository = InMemoryMediaRepository([
       MediaEntity(
         id: 'm1',
@@ -214,6 +234,7 @@ void main() {
       mediaRepository: mediaRepository,
       getMediaUseCase: getMediaUseCase,
       favoritesRepository: favoritesRepository,
+      updateDirectoryAccessUseCase: updateDirectoryAccessUseCase,
     );
     addTearDown(container.dispose);
 
@@ -241,6 +262,7 @@ void main() {
       mediaRepository: mediaRepository,
       getMediaUseCase: getMediaUseCase,
       favoritesRepository: favoritesRepository,
+      updateDirectoryAccessUseCase: updateDirectoryAccessUseCase,
     );
     addTearDown(container.dispose);
 
@@ -264,6 +286,7 @@ void main() {
       mediaRepository: mediaRepository,
       getMediaUseCase: getMediaUseCase,
       favoritesRepository: favoritesRepository,
+      updateDirectoryAccessUseCase: updateDirectoryAccessUseCase,
     );
     addTearDown(container.dispose);
 
@@ -287,6 +310,7 @@ void main() {
       mediaRepository: mediaRepository,
       getMediaUseCase: getMediaUseCase,
       favoritesRepository: favoritesRepository,
+      updateDirectoryAccessUseCase: updateDirectoryAccessUseCase,
     );
     addTearDown(container.dispose);
 
@@ -303,6 +327,7 @@ void main() {
       mediaRepository: mediaRepository,
       getMediaUseCase: getMediaUseCase,
       favoritesRepository: favoritesRepository,
+      updateDirectoryAccessUseCase: updateDirectoryAccessUseCase,
     );
     addTearDown(container.dispose);
 

--- a/test/features/tagging/domain/use_cases/filter_by_tags_use_case_test.dart
+++ b/test/features/tagging/domain/use_cases/filter_by_tags_use_case_test.dart
@@ -54,6 +54,16 @@ class _DummyDirectoryRepository implements DirectoryRepository {
   Future<void> updateDirectoryTags(String directoryId, List<String> tagIds) {
     throw UnimplementedError();
   }
+
+  @override
+  Future<void> updateDirectoryMetadata(
+    String directoryId, {
+    String? path,
+    String? name,
+    String? bookmarkData,
+  }) {
+    throw UnimplementedError();
+  }
 }
 
 void main() {


### PR DESCRIPTION
## Summary
- add a use case and repository API for updating stored directory metadata when permissions are recovered
- persist refreshed bookmark data in the filesystem media repository before scanning directories
- wire the media grid view model to store recovered paths/bookmarks and expand tests to cover the new behaviour

## Testing
- Tests not run (flutter was not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68f6e29d46188320b4cee829aa4df463