### PR TITLE
Align test hashing helpers with Isar id implementation

### DIFF
--- a/test/features/favorites/data/isar/favorite_collection_test.dart
+++ b/test/features/favorites/data/isar/favorite_collection_test.dart
@@ -1,10 +1,11 @@
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:isar/isar.dart';
 import 'package:media_fast_view/features/favorites/data/isar/favorite_collection.dart';
 import 'package:media_fast_view/features/favorites/data/models/favorite_model.dart';
 import 'package:media_fast_view/features/favorites/domain/entities/favorite_item_type.dart';
+
+import '../../../../helpers/isar_id.dart';
 
 void main() {
   group('FavoriteCollection', () {
@@ -31,7 +32,7 @@ void main() {
       );
       expect(
         collection.id,
-        Isar.fastHash('${model.itemType.name}::${model.itemId}'),
+        isarIdForString('${model.itemType.name}::${model.itemId}'),
       );
 
       final roundTrip = collection.toModel();

--- a/test/features/favorites/data/isar/isar_favorites_data_source_test.dart
+++ b/test/features/favorites/data/isar/isar_favorites_data_source_test.dart
@@ -13,6 +13,8 @@ import 'package:media_fast_view/features/media_library/data/models/directory_mod
 import 'package:media_fast_view/features/media_library/data/models/media_model.dart';
 import 'package:media_fast_view/features/media_library/domain/entities/media_entity.dart';
 
+import '../../../../helpers/isar_id.dart';
+
 class _FakeIsarDatabase extends IsarDatabase {
   _FakeIsarDatabase()
       : super(
@@ -77,7 +79,7 @@ class _InMemoryFavoriteCollectionStore implements FavoriteCollectionStore {
     String itemId,
     FavoriteItemType type,
   ) async {
-    final favorite = _data[Isar.fastHash('${type.name}::$itemId')];
+    final favorite = _data[isarIdForString('${type.name}::$itemId')];
     return favorite == null ? null : _clone(favorite);
   }
 
@@ -158,7 +160,7 @@ class _InMemoryMediaCollectionStore implements MediaCollectionStore {
 
   @override
   Future<void> put(MediaCollection media) async {
-    _data[Isar.fastHash(media.mediaId)] = _clone(media);
+    _data[isarIdForString(media.mediaId)] = _clone(media);
   }
 
   @override
@@ -200,13 +202,13 @@ class _InMemoryDirectoryCollectionStore implements DirectoryCollectionStore {
 
   @override
   Future<DirectoryCollection?> getByDirectoryId(String directoryId) async {
-    final directory = _data[Isar.fastHash(directoryId)];
+    final directory = _data[isarIdForString(directoryId)];
     return directory == null ? null : _clone(directory);
   }
 
   @override
   Future<void> put(DirectoryCollection directory) async {
-    _data[Isar.fastHash(directory.directoryId)] = _clone(directory);
+    _data[isarIdForString(directory.directoryId)] = _clone(directory);
   }
 
   @override

--- a/test/features/media_library/data/isar/directory_collection_test.dart
+++ b/test/features/media_library/data/isar/directory_collection_test.dart
@@ -1,7 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:isar/isar.dart';
 import 'package:media_fast_view/features/media_library/data/isar/directory_collection.dart';
 import 'package:media_fast_view/features/media_library/data/models/directory_model.dart';
+
+import '../../../../helpers/isar_id.dart';
 
 void main() {
   group('DirectoryCollection', () {
@@ -25,7 +26,7 @@ void main() {
       expect(collection.tagIds, equals(model.tagIds));
       expect(collection.lastModified, model.lastModified);
       expect(collection.bookmarkData, model.bookmarkData);
-      expect(collection.id, Isar.fastHash(model.id));
+      expect(collection.id, isarIdForString(model.id));
 
       final roundTrip = collection.toModel();
 

--- a/test/features/media_library/data/isar/isar_directory_data_source_test.dart
+++ b/test/features/media_library/data/isar/isar_directory_data_source_test.dart
@@ -5,6 +5,8 @@ import 'package:media_fast_view/features/media_library/data/isar/directory_colle
 import 'package:media_fast_view/features/media_library/data/isar/isar_directory_data_source.dart';
 import 'package:media_fast_view/features/media_library/data/models/directory_model.dart';
 
+import '../../../../helpers/isar_id.dart';
+
 class _FakeIsarDatabase extends IsarDatabase {
   _FakeIsarDatabase()
       : super(
@@ -47,13 +49,13 @@ class _InMemoryDirectoryCollectionStore implements DirectoryCollectionStore {
 
   @override
   Future<DirectoryCollection?> getByDirectoryId(String directoryId) async {
-    final directory = _data[Isar.fastHash(directoryId)];
+    final directory = _data[isarIdForString(directoryId)];
     return directory != null ? _clone(directory) : null;
   }
 
   @override
   Future<void> put(DirectoryCollection directory) async {
-    _data[Isar.fastHash(directory.directoryId)] = _clone(directory);
+    _data[isarIdForString(directory.directoryId)] = _clone(directory);
   }
 
   @override

--- a/test/features/media_library/data/isar/isar_media_data_source_test.dart
+++ b/test/features/media_library/data/isar/isar_media_data_source_test.dart
@@ -9,6 +9,8 @@ import 'package:media_fast_view/features/media_library/data/models/directory_mod
 import 'package:media_fast_view/features/media_library/data/models/media_model.dart';
 import 'package:media_fast_view/features/media_library/domain/entities/media_entity.dart';
 
+import '../../../../helpers/isar_id.dart';
+
 class _FakeIsarDatabase extends IsarDatabase {
   _FakeIsarDatabase()
       : super(
@@ -51,13 +53,13 @@ class _InMemoryDirectoryCollectionStore implements DirectoryCollectionStore {
 
   @override
   Future<DirectoryCollection?> getByDirectoryId(String directoryId) async {
-    final directory = _data[Isar.fastHash(directoryId)];
+    final directory = _data[isarIdForString(directoryId)];
     return directory != null ? _clone(directory) : null;
   }
 
   @override
   Future<void> put(DirectoryCollection directory) async {
-    _data[Isar.fastHash(directory.directoryId)] = _clone(directory);
+    _data[isarIdForString(directory.directoryId)] = _clone(directory);
   }
 
   @override
@@ -113,7 +115,7 @@ class _InMemoryMediaCollectionStore implements MediaCollectionStore {
 
   @override
   Future<void> put(MediaCollection media) async {
-    _data[Isar.fastHash(media.mediaId)] = _clone(media);
+    _data[isarIdForString(media.mediaId)] = _clone(media);
   }
 
   @override

--- a/test/features/media_library/data/isar/media_collection_test.dart
+++ b/test/features/media_library/data/isar/media_collection_test.dart
@@ -1,7 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:isar/isar.dart';
 import 'package:media_fast_view/features/media_library/data/isar/media_collection.dart';
 import 'package:media_fast_view/features/media_library/data/models/media_model.dart';
+
+import '../../../../helpers/isar_id.dart';
 
 void main() {
   group('MediaCollection', () {
@@ -29,7 +30,7 @@ void main() {
       expect(collection.tagIds, equals(model.tagIds));
       expect(collection.directoryId, model.directoryId);
       expect(collection.bookmarkData, model.bookmarkData);
-      expect(collection.id, Isar.fastHash(model.id));
+      expect(collection.id, isarIdForString(model.id));
 
       final roundTrip = collection.toModel();
 

--- a/test/features/tagging/data/isar/isar_tag_data_source_test.dart
+++ b/test/features/tagging/data/isar/isar_tag_data_source_test.dart
@@ -7,10 +7,12 @@ import 'package:media_fast_view/features/media_library/data/isar/isar_media_data
 import 'package:media_fast_view/features/media_library/data/isar/media_collection.dart';
 import 'package:media_fast_view/features/media_library/data/models/directory_model.dart';
 import 'package:media_fast_view/features/media_library/data/models/media_model.dart';
+import 'package:media_fast_view/features/media_library/data/models/tag_model.dart';
 import 'package:media_fast_view/features/media_library/domain/entities/media_entity.dart';
 import 'package:media_fast_view/features/tagging/data/isar/isar_tag_data_source.dart';
 import 'package:media_fast_view/features/tagging/data/isar/tag_collection.dart';
-import 'package:media_fast_view/features/media_library/data/models/tag_model.dart';
+
+import '../../../../helpers/isar_id.dart';
 
 class _FakeIsarDatabase extends IsarDatabase {
   _FakeIsarDatabase()
@@ -54,14 +56,14 @@ class _InMemoryTagCollectionStore implements TagCollectionStore {
 
   @override
   Future<TagCollection?> getByTagId(String tagId) async {
-    final tag = _data[Isar.fastHash(tagId)];
+    final tag = _data[isarIdForString(tagId)];
     return tag == null ? null : _clone(tag);
   }
 
   @override
   Future<List<TagCollection>> getByTagIds(List<String> tagIds) async {
     return tagIds
-        .map((tagId) => _data[Isar.fastHash(tagId)])
+        .map((tagId) => _data[isarIdForString(tagId)])
         .whereType<TagCollection>()
         .map(_clone)
         .toList(growable: false);
@@ -69,7 +71,7 @@ class _InMemoryTagCollectionStore implements TagCollectionStore {
 
   @override
   Future<void> put(TagCollection tag) async {
-    _data[Isar.fastHash(tag.tagId)] = _clone(tag);
+    _data[tag.id] = _clone(tag);
   }
 
   @override
@@ -109,13 +111,13 @@ class _InMemoryDirectoryCollectionStore implements DirectoryCollectionStore {
 
   @override
   Future<DirectoryCollection?> getByDirectoryId(String directoryId) async {
-    final directory = _data[Isar.fastHash(directoryId)];
+    final directory = _data[isarIdForString(directoryId)];
     return directory == null ? null : _clone(directory);
   }
 
   @override
   Future<void> put(DirectoryCollection directory) async {
-    _data[Isar.fastHash(directory.directoryId)] = _clone(directory);
+    _data[isarIdForString(directory.directoryId)] = _clone(directory);
   }
 
   @override
@@ -171,7 +173,7 @@ class _InMemoryMediaCollectionStore implements MediaCollectionStore {
 
   @override
   Future<void> put(MediaCollection media) async {
-    _data[Isar.fastHash(media.mediaId)] = _clone(media);
+    _data[isarIdForString(media.mediaId)] = _clone(media);
   }
 
   @override

--- a/test/features/tagging/data/isar/tag_collection_test.dart
+++ b/test/features/tagging/data/isar/tag_collection_test.dart
@@ -1,7 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:isar/isar.dart';
-import 'package:media_fast_view/features/tagging/data/isar/tag_collection.dart';
 import 'package:media_fast_view/features/media_library/data/models/tag_model.dart';
+import 'package:media_fast_view/features/tagging/data/isar/tag_collection.dart';
+
+import '../../../../helpers/isar_id.dart';
 
 void main() {
   group('TagCollection', () {
@@ -19,7 +20,7 @@ void main() {
       expect(collection.name, model.name);
       expect(collection.color, model.color);
       expect(collection.createdAt, model.createdAt);
-      expect(collection.id, Isar.fastHash(model.id));
+      expect(collection.id, isarIdForString(model.id));
 
       final roundTrip = collection.toModel();
 

--- a/test/helpers/isar_id.dart
+++ b/test/helpers/isar_id.dart
@@ -1,0 +1,10 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+import 'package:isar/isar.dart';
+
+/// Mimics the hashing logic used by Isar collection id getters.
+Id isarIdForString(String value) {
+  final hash = sha256.convert(utf8.encode(value)).bytes;
+  return hash.fold<int>(0, (previousValue, element) => previousValue + element);
+}


### PR DESCRIPTION
## Summary
- add a shared helper that mirrors the Isar collection id hashing
- update favorites, media library, and tagging data source tests to use the shared helper
- remove remaining usages of the removed `Isar.fastHash` helper in unit tests

## Testing
- not run (Flutter SDK not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68f7e9bcd7f08320b5839dc0aa3906ae