### PR TITLE
Expand media extension support

### DIFF
--- a/lib/core/services/file_service.dart
+++ b/lib/core/services/file_service.dart
@@ -126,7 +126,10 @@ class FileService {
     return path.extension(filePath).toLowerCase();
   }
 
-  /// Determines media type from file extension
+  /// Determines media type from file extension.
+  ///
+  /// Keep the supported extensions in sync with
+  /// [FilesystemMediaDataSource] to ensure consistent media detection.
   String getMediaTypeFromExtension(String filePath) {
     final extension = getFileExtension(filePath);
 
@@ -139,6 +142,19 @@ class FileService {
       case '.webp':
       case '.tiff':
       case '.tif':
+      case '.heic':
+      case '.heif':
+      case '.heics':
+      case '.dng':
+      case '.nef':
+      case '.cr2':
+      case '.cr3':
+      case '.arw':
+      case '.raf':
+      case '.orf':
+      case '.rw2':
+      case '.sr2':
+      case '.pef':
         return 'image';
       case '.mp4':
       case '.avi':
@@ -147,6 +163,7 @@ class FileService {
       case '.wmv':
       case '.flv':
       case '.webm':
+      case '.m4v':
         return 'video';
       case '.txt':
       case '.md':

--- a/lib/features/media_library/data/data_sources/filesystem_media_data_source.dart
+++ b/lib/features/media_library/data/data_sources/filesystem_media_data_source.dart
@@ -37,7 +37,10 @@ class FilesystemMediaDataSource {
   /// Gets the permission service, creating one if not provided
   PermissionService get _permissionSvc => _permissionService ?? PermissionService();
 
-  /// Supported image file extensions
+  /// Supported image file extensions.
+  ///
+  /// Keep these in sync with [FileService.getMediaTypeFromExtension] to ensure
+  /// consistent media detection across the app.
   static const Set<String> _imageExtensions = {
     'jpg',
     'jpeg',
@@ -46,9 +49,26 @@ class FilesystemMediaDataSource {
     'jfif',
     'bmp',
     'webp',
+    'tiff',
+    'tif',
+    'heic',
+    'heif',
+    'heics',
+    'dng',
+    'nef',
+    'cr2',
+    'cr3',
+    'arw',
+    'raf',
+    'orf',
+    'rw2',
+    'sr2',
+    'pef',
   };
 
-  /// Supported video file extensions
+  /// Supported video file extensions.
+  ///
+  /// Keep these in sync with [FileService.getMediaTypeFromExtension].
   static const Set<String> _videoExtensions = {
     'mp4',
     'mov',
@@ -57,6 +77,7 @@ class FilesystemMediaDataSource {
     'wmv',
     'flv',
     'webm',
+    'm4v',
   };
 
   /// Supported text file extensions

--- a/test/core/services/file_service_test.dart
+++ b/test/core/services/file_service_test.dart
@@ -168,12 +168,15 @@ void main() {
         expect(fileService.getMediaTypeFromExtension('photo.jpg'), 'image');
         expect(fileService.getMediaTypeFromExtension('pic.png'), 'image');
         expect(fileService.getMediaTypeFromExtension('anim.gif'), 'image');
+        expect(fileService.getMediaTypeFromExtension('capture.heic'), 'image');
+        expect(fileService.getMediaTypeFromExtension('raw.dng'), 'image');
       });
 
       test('returns video for video extensions', () {
         expect(fileService.getMediaTypeFromExtension('movie.mp4'), 'video');
         expect(fileService.getMediaTypeFromExtension('clip.avi'), 'video');
         expect(fileService.getMediaTypeFromExtension('film.mkv'), 'video');
+        expect(fileService.getMediaTypeFromExtension('export.m4v'), 'video');
       });
 
       test('returns text for text extensions', () {


### PR DESCRIPTION
## Summary
- align FileService and filesystem scanner media extension whitelists with contemporary photo/video formats
- add support for high-efficiency images (HEIC/HEIF) and common RAW camera formats to image detection
- include m4v support for video assets and document the need to keep the lists in sync

## Testing
- flutter test test/core/services/file_service_test.dart *(fails: flutter is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f7ea24e5288320bb5d9de6fce69dc3