### PR TITLE
Add favorites filtering support across library views

### DIFF
--- a/lib/features/favorites/data/isar/isar_favorites_data_source.dart
+++ b/lib/features/favorites/data/isar/isar_favorites_data_source.dart
@@ -227,6 +227,18 @@ class IsarFavoritesDataSource {
         .toList(growable: false);
   }
 
+  /// Convenience accessor returning IDs for all favorited directories.
+  Future<List<String>> getFavoriteDirectoryIds() async {
+    await _ensureReady();
+    final directoryFavorites = await getFavoritesByType(
+      FavoriteItemType.directory,
+      newestFirst: false,
+    );
+    return directoryFavorites
+        .map((favorite) => favorite.itemId)
+        .toList(growable: false);
+  }
+
   Future<List<FavoriteCollection>> _mapModels(
     List<FavoriteModel> favorites,
   ) async {

--- a/lib/features/favorites/data/repositories/favorites_repository_impl.dart
+++ b/lib/features/favorites/data/repositories/favorites_repository_impl.dart
@@ -20,11 +20,12 @@ class FavoritesRepositoryImpl implements FavoritesRepository {
 
   @override
   Future<List<String>> getFavoriteMediaIds() async {
-    final favorites = await _favoritesDataSource.getFavorites();
-    return favorites
-        .where((favorite) => favorite.itemType == FavoriteItemType.media)
-        .map((favorite) => favorite.itemId)
-        .toList(growable: false);
+    return _favoritesDataSource.getFavoriteMediaIds();
+  }
+
+  @override
+  Future<List<String>> getFavoriteDirectoryIds() {
+    return _favoritesDataSource.getFavoriteDirectoryIds();
   }
 
   @override

--- a/lib/features/favorites/domain/repositories/favorites_repository.dart
+++ b/lib/features/favorites/domain/repositories/favorites_repository.dart
@@ -10,6 +10,9 @@ abstract class FavoritesRepository {
   /// Retrieves all favorite media IDs.
   Future<List<String>> getFavoriteMediaIds();
 
+  /// Retrieves all favorite directory IDs.
+  Future<List<String>> getFavoriteDirectoryIds();
+
   /// Adds a media item to favorites.
   Future<void> addFavorite(String mediaId);
 


### PR DESCRIPTION
## Summary
- expose directory favorite identifiers from the favorites repository and view model
- add favorites-only filtering logic to the directory and media grid view models
- surface a favorites filter chip in the directory and media library screens

## Testing
- Not run (Flutter SDK unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f7eb4e7528832081bceb50eb2ea687