### PR TITLE
Fix directory grid thumbnails to load from filesystem

### DIFF
--- a/lib/features/media_library/presentation/widgets/directory_grid_item.dart
+++ b/lib/features/media_library/presentation/widgets/directory_grid_item.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import '../../../../core/constants/ui_constants.dart';
@@ -132,8 +134,8 @@ class _DirectoryGridItemState extends State<DirectoryGridItem>
                                 color:
                                     Theme.of(context).colorScheme.surfaceContainerHighest,
                                 child: widget.directory.thumbnailPath != null
-                                    ? Image.asset(
-                                        widget.directory.thumbnailPath!,
+                                    ? Image.file(
+                                        File(widget.directory.thumbnailPath!),
                                         fit: BoxFit.cover,
                                         errorBuilder: (context, error, stackTrace) =>
                                             _buildPlaceholder(),


### PR DESCRIPTION
## Summary
- switch directory grid thumbnails to use Image.file so stored filesystem paths render instead of falling back to the placeholder

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f8365570848320a2463858109ba4f5