### PR TITLE
Add tag assignment controls to full screen viewer

### DIFF
--- a/lib/features/full_screen/domain/entities/viewer_state_entity.dart
+++ b/lib/features/full_screen/domain/entities/viewer_state_entity.dart
@@ -1,4 +1,5 @@
 import '../../../media_library/domain/entities/media_entity.dart';
+import '../../../tagging/domain/entities/tag_entity.dart';
 
 /// Sealed class representing the state of the full-screen media viewer
 sealed class FullScreenState {
@@ -26,6 +27,8 @@ class FullScreenLoaded extends FullScreenState {
     required this.currentPosition,
     required this.totalDuration,
     required this.isFavorite,
+    required this.currentMediaTags,
+    required this.shortcutTags,
   });
 
   final List<MediaEntity> mediaList;
@@ -36,6 +39,8 @@ class FullScreenLoaded extends FullScreenState {
   final Duration currentPosition;
   final Duration totalDuration;
   final bool isFavorite;
+  final List<TagEntity> currentMediaTags;
+  final List<TagEntity> shortcutTags;
 
   MediaEntity get currentMedia => mediaList[currentIndex];
 
@@ -48,6 +53,8 @@ class FullScreenLoaded extends FullScreenState {
     Duration? currentPosition,
     Duration? totalDuration,
     bool? isFavorite,
+    List<TagEntity>? currentMediaTags,
+    List<TagEntity>? shortcutTags,
   }) {
     return FullScreenLoaded(
       mediaList: mediaList ?? this.mediaList,
@@ -58,6 +65,8 @@ class FullScreenLoaded extends FullScreenState {
       currentPosition: currentPosition ?? this.currentPosition,
       totalDuration: totalDuration ?? this.totalDuration,
       isFavorite: isFavorite ?? this.isFavorite,
+      currentMediaTags: currentMediaTags ?? this.currentMediaTags,
+      shortcutTags: shortcutTags ?? this.shortcutTags,
     );
   }
 }

--- a/lib/shared/providers/repository_providers.dart
+++ b/lib/shared/providers/repository_providers.dart
@@ -44,6 +44,7 @@ import '../../features/media_library/data/repositories/tag_repository_impl.dart'
 import '../../features/tagging/data/isar/isar_tag_data_source.dart';
 import '../../features/media_library/domain/repositories/tag_repository.dart';
 import '../../features/favorites/data/isar/isar_favorites_data_source.dart';
+import '../utils/tag_lookup.dart';
 
 // Isar database provider
 final isarDatabaseProvider = Provider<IsarDatabase>((ref) {
@@ -129,6 +130,10 @@ final tagRepositoryProvider =
         );
       },
     );
+
+final tagLookupProvider = Provider<TagLookup>((ref) {
+  return TagLookup(ref.watch(tagRepositoryProvider));
+});
 
 final favoritesRepositoryProvider =
     StateNotifierProvider.autoDispose<

--- a/lib/shared/utils/tag_cache_refresher.dart
+++ b/lib/shared/utils/tag_cache_refresher.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/services/logging_service.dart';
+import '../../features/tagging/presentation/view_models/tag_management_view_model.dart';
+import '../../features/tagging/presentation/view_models/tags_view_model.dart';
+
+/// Coordinates refreshing of tag-related view models after mutations.
+class TagCacheRefresher {
+  TagCacheRefresher(this._ref);
+
+  final Ref _ref;
+
+  /// Refreshes the tag selection and tagging dashboards to reflect new data.
+  Future<void> refresh() async {
+    final futures = <Future<void>>[];
+
+    try {
+      final tagsViewModel = _ref.read(tagsViewModelProvider.notifier);
+      futures.add(tagsViewModel.refreshTags());
+    } catch (error, stackTrace) {
+      LoggingService.instance
+          .error('Failed to refresh TagsViewModel cache: $error');
+      LoggingService.instance
+          .debug('TagsViewModel refresh stack trace: $stackTrace');
+    }
+
+    try {
+      final tagManagementViewModel = _ref.read(tagViewModelProvider.notifier);
+      futures.add(tagManagementViewModel.loadTags());
+    } catch (error, stackTrace) {
+      LoggingService.instance
+          .error('Failed to refresh TagViewModel cache: $error');
+      LoggingService.instance
+          .debug('TagViewModel refresh stack trace: $stackTrace');
+    }
+
+    if (futures.isNotEmpty) {
+      await Future.wait(futures, eagerError: false);
+    }
+  }
+}
+
+/// Provider exposing the cache refresher utility.
+final tagCacheRefresherProvider = Provider<TagCacheRefresher>(TagCacheRefresher.new);

--- a/lib/shared/utils/tag_lookup.dart
+++ b/lib/shared/utils/tag_lookup.dart
@@ -1,0 +1,58 @@
+import 'dart:collection';
+
+import '../../core/services/logging_service.dart';
+import '../../features/tagging/domain/entities/tag_entity.dart';
+import '../../features/tagging/domain/repositories/tag_repository.dart';
+
+/// Lightweight cache for resolving [TagEntity] instances by identifier.
+class TagLookup {
+  TagLookup(this._tagRepository);
+
+  final TagRepository _tagRepository;
+
+  List<TagEntity>? _cachedTags;
+  Map<String, TagEntity>? _tagsById;
+
+  /// Retrieves tags for the provided [ids], preserving the incoming order and
+  /// skipping any identifiers that cannot be resolved.
+  Future<List<TagEntity>> getTagsByIds(Iterable<String> ids) async {
+    await _ensureCache();
+
+    final tagsById = _tagsById;
+    if (tagsById == null || tagsById.isEmpty) {
+      return const <TagEntity>[];
+    }
+
+    final uniqueIds = LinkedHashSet<String>.from(ids);
+    return [
+      for (final id in uniqueIds)
+        if (tagsById.containsKey(id)) tagsById[id]!,
+    ];
+  }
+
+  /// Forces the cache to reload from the repository.
+  Future<void> refresh() async {
+    _cachedTags = null;
+    _tagsById = null;
+    await _ensureCache();
+  }
+
+  Future<void> _ensureCache() async {
+    if (_cachedTags != null && _tagsById != null) {
+      return;
+    }
+
+    try {
+      final tags = await _tagRepository.getTags();
+      _cachedTags = List<TagEntity>.unmodifiable(tags);
+      _tagsById = {
+        for (final tag in _cachedTags!) tag.id: tag,
+      };
+    } catch (error, stackTrace) {
+      LoggingService.instance.error('Failed to load tag cache: $error');
+      LoggingService.instance.debug('Tag cache load stack trace: $stackTrace');
+      rethrow;
+    }
+  }
+}
+

--- a/lib/shared/utils/tag_usage_ranker.dart
+++ b/lib/shared/utils/tag_usage_ranker.dart
@@ -1,0 +1,45 @@
+import '../../features/media_library/domain/entities/media_entity.dart';
+
+/// Utility for ranking tag usage across a list of media items.
+class TagUsageRanker {
+  const TagUsageRanker({this.limit = defaultLimit});
+
+  /// Default number of tags exposed for keyboard shortcuts.
+  static const int defaultLimit = 10;
+
+  /// Maximum number of ranked tags to return.
+  final int limit;
+
+  /// Returns tag identifiers ordered by usage frequency (descending) and tag
+  /// identifier (ascending) to provide deterministic ordering.
+  List<String> rank(List<MediaEntity> mediaList) {
+    if (mediaList.isEmpty) {
+      return const <String>[];
+    }
+
+    final counts = <String, int>{};
+    for (final media in mediaList) {
+      for (final tagId in media.tagIds) {
+        counts.update(tagId, (value) => value + 1, ifAbsent: () => 1);
+      }
+    }
+
+    if (counts.isEmpty) {
+      return const <String>[];
+    }
+
+    final entries = counts.entries.toList()
+      ..sort((a, b) {
+        final usageCompare = b.value.compareTo(a.value);
+        if (usageCompare != 0) {
+          return usageCompare;
+        }
+        return a.key.compareTo(b.key);
+      });
+
+    return entries
+        .take(limit)
+        .map((entry) => entry.key)
+        .toList(growable: false);
+  }
+}

--- a/test/features/full_screen/presentation/mocks.dart
+++ b/test/features/full_screen/presentation/mocks.dart
@@ -1,0 +1,21 @@
+import 'package:mockito/mockito.dart';
+
+import 'package:media_fast_view/features/favorites/domain/repositories/favorites_repository.dart';
+import 'package:media_fast_view/features/favorites/presentation/view_models/favorites_view_model.dart';
+import 'package:media_fast_view/features/full_screen/domain/use_cases/load_media_for_viewing_use_case.dart';
+import 'package:media_fast_view/features/tagging/domain/use_cases/assign_tag_use_case.dart';
+import 'package:media_fast_view/shared/utils/tag_cache_refresher.dart';
+import 'package:media_fast_view/shared/utils/tag_lookup.dart';
+
+class MockLoadMediaForViewingUseCase extends Mock
+    implements LoadMediaForViewingUseCase {}
+
+class MockFavoritesViewModel extends Mock implements FavoritesViewModel {}
+
+class MockFavoritesRepository extends Mock implements FavoritesRepository {}
+
+class MockAssignTagUseCase extends Mock implements AssignTagUseCase {}
+
+class MockTagLookup extends Mock implements TagLookup {}
+
+class MockTagCacheRefresher extends Mock implements TagCacheRefresher {}

--- a/test/features/full_screen/presentation/screens/full_screen_viewer_screen_test.dart
+++ b/test/features/full_screen/presentation/screens/full_screen_viewer_screen_test.dart
@@ -1,0 +1,281 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:media_fast_view/features/full_screen/domain/entities/viewer_state_entity.dart';
+import 'package:media_fast_view/features/full_screen/presentation/screens/full_screen_viewer_screen.dart';
+import 'package:media_fast_view/features/full_screen/presentation/view_models/full_screen_view_model.dart';
+import 'package:media_fast_view/features/media_library/domain/entities/media_entity.dart';
+import 'package:media_fast_view/features/tagging/domain/entities/tag_entity.dart';
+import 'package:media_fast_view/features/tagging/domain/use_cases/assign_tag_use_case.dart';
+import 'package:media_fast_view/features/favorites/domain/repositories/favorites_repository.dart';
+import 'package:media_fast_view/features/favorites/presentation/view_models/favorites_view_model.dart';
+import 'package:media_fast_view/features/full_screen/domain/use_cases/load_media_for_viewing_use_case.dart';
+import 'package:media_fast_view/shared/utils/tag_cache_refresher.dart';
+import 'package:media_fast_view/shared/utils/tag_lookup.dart';
+import 'package:media_fast_view/shared/utils/tag_usage_ranker.dart';
+
+import '../mocks.dart';
+
+class _FakeFullScreenViewModel extends FullScreenViewModel {
+  _FakeFullScreenViewModel({
+    required LoadMediaForViewingUseCase loadMediaForViewingUseCase,
+    required FavoritesViewModel favoritesViewModel,
+    required FavoritesRepository favoritesRepository,
+    required AssignTagUseCase assignTagUseCase,
+    required TagLookup tagLookup,
+    required TagCacheRefresher tagCacheRefresher,
+    required Map<String, TagEntity> tagCatalog,
+  })  : _tagCatalog = tagCatalog,
+        super(
+          loadMediaForViewingUseCase,
+          favoritesViewModel,
+          favoritesRepository,
+          assignTagUseCase,
+          tagLookup,
+          tagCacheRefresher,
+          const VideoPlaybackSettings(autoplayVideos: false, loopVideos: false),
+          tagUsageRanker: const TagUsageRanker(limit: 10),
+        );
+
+  final Map<String, TagEntity> _tagCatalog;
+  TagMutationOutcome? lastOutcome;
+  TagUpdateResult? lastUpdate;
+
+  void seedState(FullScreenLoaded state) {
+    this.state = state;
+  }
+
+  @override
+  Future<void> initialize(
+    String directoryPath, {
+    String? initialMediaId,
+    String? bookmarkData,
+    List<MediaEntity>? mediaList,
+  }) async {}
+
+  @override
+  Future<TagMutationResult> toggleTagOnCurrentMedia(TagEntity tag) async {
+    final currentState = state as FullScreenLoaded;
+    final media = currentState.currentMedia;
+    final hasTag = media.tagIds.contains(tag.id);
+    final updatedTagIds = hasTag
+        ? media.tagIds.where((id) => id != tag.id).toList()
+        : [...media.tagIds, tag.id];
+
+    final updatedMedia = media.copyWith(tagIds: updatedTagIds);
+    final updatedMediaList = [...currentState.mediaList];
+    updatedMediaList[currentState.currentIndex] = updatedMedia;
+
+    final updatedCurrentTags = hasTag
+        ? currentState.currentMediaTags
+            .where((existing) => existing.id != tag.id)
+            .toList()
+        : [...currentState.currentMediaTags, tag];
+
+    final updatedShortcuts = hasTag
+        ? currentState.shortcutTags
+            .where((existing) => existing.id != tag.id)
+            .toList()
+        : [...currentState.shortcutTags, tag];
+
+    state = currentState.copyWith(
+      mediaList: updatedMediaList,
+      currentMediaTags: updatedCurrentTags,
+      shortcutTags: updatedShortcuts,
+    );
+
+    final outcome =
+        hasTag ? TagMutationOutcome.removed : TagMutationOutcome.added;
+    lastOutcome = outcome;
+    return TagMutationResult(outcome);
+  }
+
+  @override
+  Future<TagUpdateResult> setTagsForCurrentMedia(List<String> tagIds) async {
+    final currentState = state as FullScreenLoaded;
+    final media = currentState.currentMedia;
+    final previousIds = media.tagIds.toSet();
+    final dedupedIds = <String>[];
+    for (final id in tagIds) {
+      if (id.isEmpty || dedupedIds.contains(id)) {
+        continue;
+      }
+      dedupedIds.add(id);
+    }
+
+    final updatedMedia = media.copyWith(tagIds: dedupedIds);
+    final updatedMediaList = [...currentState.mediaList];
+    updatedMediaList[currentState.currentIndex] = updatedMedia;
+
+    final updatedTags = [
+      for (final id in dedupedIds) _tagCatalog[id]!,
+    ];
+
+    state = currentState.copyWith(
+      mediaList: updatedMediaList,
+      currentMediaTags: updatedTags,
+      shortcutTags: updatedTags,
+    );
+
+    final result = TagUpdateResult(
+      addedCount: dedupedIds.toSet().difference(previousIds).length,
+      removedCount: previousIds.difference(dedupedIds.toSet()).length,
+    );
+    lastUpdate = result;
+    return result;
+  }
+}
+
+void main() {
+  testWidgets('displays tag overlay and handles chip tap', (tester) async {
+    final loadMedia = MockLoadMediaForViewingUseCase();
+    final favoritesViewModel = MockFavoritesViewModel();
+    final favoritesRepository = MockFavoritesRepository();
+    final assignTagUseCase = MockAssignTagUseCase();
+    final tagLookup = MockTagLookup();
+    final tagCacheRefresher = MockTagCacheRefresher();
+
+    final tag = TagEntity(
+      id: 'tag-1',
+      name: 'Tag 1',
+      color: 0xFF2196F3,
+      createdAt: DateTime(2023, 1, 1),
+    );
+
+    final media = MediaEntity(
+      id: 'media-1',
+      path: '/tmp/media.jpg',
+      name: 'media.jpg',
+      type: MediaType.image,
+      size: 0,
+      lastModified: DateTime(2024, 1, 1),
+      tagIds: const ['tag-1'],
+      directoryId: 'dir-1',
+    );
+
+    final viewModel = _FakeFullScreenViewModel(
+      loadMediaForViewingUseCase: loadMedia,
+      favoritesViewModel: favoritesViewModel,
+      favoritesRepository: favoritesRepository,
+      assignTagUseCase: assignTagUseCase,
+      tagLookup: tagLookup,
+      tagCacheRefresher: tagCacheRefresher,
+      tagCatalog: {'tag-1': tag},
+    )..seedState(
+        FullScreenLoaded(
+          mediaList: [media],
+          currentIndex: 0,
+          isPlaying: false,
+          isMuted: false,
+          isLooping: false,
+          currentPosition: Duration.zero,
+          totalDuration: Duration.zero,
+          isFavorite: false,
+          currentMediaTags: [tag],
+          shortcutTags: [tag],
+        ),
+      );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          fullScreenViewModelProvider.overrideWith((ref) => viewModel),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(
+            body: FullScreenViewerScreen(directoryPath: 'dir-1'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Tag 1'), findsOneWidget);
+    expect(find.text('Manage'), findsOneWidget);
+
+    await tester.tap(find.text('Tag 1'));
+    await tester.pumpAndSettle();
+
+    expect(viewModel.lastOutcome, TagMutationOutcome.removed);
+    expect(find.text('Removed "Tag 1"'), findsOneWidget);
+  });
+
+  testWidgets('keyboard shortcut toggles top-ranked tag', (tester) async {
+    final loadMedia = MockLoadMediaForViewingUseCase();
+    final favoritesViewModel = MockFavoritesViewModel();
+    final favoritesRepository = MockFavoritesRepository();
+    final assignTagUseCase = MockAssignTagUseCase();
+    final tagLookup = MockTagLookup();
+    final tagCacheRefresher = MockTagCacheRefresher();
+
+    final tag = TagEntity(
+      id: 'tag-1',
+      name: 'Tag 1',
+      color: 0xFF2196F3,
+      createdAt: DateTime(2023, 1, 1),
+    );
+
+    final media = MediaEntity(
+      id: 'media-1',
+      path: '/tmp/media.jpg',
+      name: 'media.jpg',
+      type: MediaType.image,
+      size: 0,
+      lastModified: DateTime(2024, 1, 1),
+      tagIds: const <String>[],
+      directoryId: 'dir-1',
+    );
+
+    final viewModel = _FakeFullScreenViewModel(
+      loadMediaForViewingUseCase: loadMedia,
+      favoritesViewModel: favoritesViewModel,
+      favoritesRepository: favoritesRepository,
+      assignTagUseCase: assignTagUseCase,
+      tagLookup: tagLookup,
+      tagCacheRefresher: tagCacheRefresher,
+      tagCatalog: {'tag-1': tag},
+    )..seedState(
+        FullScreenLoaded(
+          mediaList: [media],
+          currentIndex: 0,
+          isPlaying: false,
+          isMuted: false,
+          isLooping: false,
+          currentPosition: Duration.zero,
+          totalDuration: Duration.zero,
+          isFavorite: false,
+          currentMediaTags: const <TagEntity>[],
+          shortcutTags: [tag],
+        ),
+      );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          fullScreenViewModelProvider.overrideWith((ref) => viewModel),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(
+            body: FullScreenViewerScreen(directoryPath: 'dir-1'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.altLeft);
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.digit1);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.digit1);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.altLeft);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+    await tester.pumpAndSettle();
+
+    expect(viewModel.lastOutcome, TagMutationOutcome.added);
+    expect(find.text('Added "Tag 1"'), findsOneWidget);
+  });
+}

--- a/test/features/full_screen/presentation/view_models/full_screen_view_model_test.dart
+++ b/test/features/full_screen/presentation/view_models/full_screen_view_model_test.dart
@@ -1,0 +1,220 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import 'package:media_fast_view/features/favorites/domain/repositories/favorites_repository.dart';
+import 'package:media_fast_view/features/favorites/presentation/view_models/favorites_view_model.dart';
+import 'package:media_fast_view/features/full_screen/domain/entities/viewer_state_entity.dart';
+import 'package:media_fast_view/features/full_screen/domain/use_cases/load_media_for_viewing_use_case.dart';
+import 'package:media_fast_view/features/full_screen/presentation/view_models/full_screen_view_model.dart';
+import 'package:media_fast_view/features/media_library/domain/entities/media_entity.dart';
+import 'package:media_fast_view/features/tagging/domain/entities/tag_entity.dart';
+import 'package:media_fast_view/features/tagging/domain/use_cases/assign_tag_use_case.dart';
+import 'package:media_fast_view/shared/providers/video_playback_settings_provider.dart';
+import 'package:media_fast_view/shared/utils/tag_cache_refresher.dart';
+import 'package:media_fast_view/shared/utils/tag_lookup.dart';
+import 'package:media_fast_view/shared/utils/tag_usage_ranker.dart';
+
+import '../mocks.dart';
+void main() {
+  late MockLoadMediaForViewingUseCase loadMediaForViewingUseCase;
+  late MockFavoritesViewModel favoritesViewModel;
+  late MockFavoritesRepository favoritesRepository;
+  late MockAssignTagUseCase assignTagUseCase;
+  late MockTagLookup tagLookup;
+  late MockTagCacheRefresher tagCacheRefresher;
+  late FullScreenViewModel viewModel;
+
+  const playbackSettings =
+      VideoPlaybackSettings(autoplayVideos: false, loopVideos: false);
+
+  setUp(() {
+    loadMediaForViewingUseCase = MockLoadMediaForViewingUseCase();
+    favoritesViewModel = MockFavoritesViewModel();
+    favoritesRepository = MockFavoritesRepository();
+    assignTagUseCase = MockAssignTagUseCase();
+    tagLookup = MockTagLookup();
+    tagCacheRefresher = MockTagCacheRefresher();
+
+    viewModel = FullScreenViewModel(
+      loadMediaForViewingUseCase,
+      favoritesViewModel,
+      favoritesRepository,
+      assignTagUseCase,
+      tagLookup,
+      tagCacheRefresher,
+      playbackSettings,
+      tagUsageRanker: const TagUsageRanker(limit: 10),
+    );
+  });
+
+  test('toggleTagOnCurrentMedia adds tag and refreshes caches', () async {
+    final media = MediaEntity(
+      id: 'media-1',
+      path: '/tmp/media.jpg',
+      name: 'media.jpg',
+      type: MediaType.image,
+      size: 0,
+      lastModified: DateTime(2024, 1, 1),
+      tagIds: const <String>[],
+      directoryId: 'dir-1',
+    );
+    final tag = TagEntity(
+      id: 'tag-1',
+      name: 'Favorite',
+      color: 0xFF0000FF,
+      createdAt: DateTime(2023, 1, 1),
+    );
+
+    viewModel.state = FullScreenLoaded(
+      mediaList: [media],
+      currentIndex: 0,
+      isPlaying: false,
+      isMuted: false,
+      isLooping: false,
+      currentPosition: Duration.zero,
+      totalDuration: Duration.zero,
+      isFavorite: false,
+      currentMediaTags: const <TagEntity>[],
+      shortcutTags: const <TagEntity>[],
+    );
+
+    when(assignTagUseCase.assignTagToMedia(media.id, tag))
+        .thenAnswer((_) async {});
+    when(tagLookup.getTagsByIds(['tag-1']))
+        .thenAnswer((_) async => [tag]);
+    when(tagLookup.refresh()).thenAnswer((_) async {});
+    when(tagCacheRefresher.refresh()).thenAnswer((_) async {});
+
+    final result = await viewModel.toggleTagOnCurrentMedia(tag);
+
+    expect(result.outcome, TagMutationOutcome.added);
+    final updatedState = viewModel.state as FullScreenLoaded;
+    expect(updatedState.currentMedia.tagIds, ['tag-1']);
+    expect(updatedState.currentMediaTags, [tag]);
+    expect(updatedState.shortcutTags, [tag]);
+
+    verify(assignTagUseCase.assignTagToMedia(media.id, tag)).called(1);
+    verify(tagLookup.refresh()).called(1);
+    verify(tagCacheRefresher.refresh()).called(1);
+  });
+
+  test('toggleTagOnCurrentMedia removes tag and refreshes caches', () async {
+    final tag = TagEntity(
+      id: 'tag-1',
+      name: 'Favorite',
+      color: 0xFF0000FF,
+      createdAt: DateTime(2023, 1, 1),
+    );
+    final media = MediaEntity(
+      id: 'media-1',
+      path: '/tmp/media.jpg',
+      name: 'media.jpg',
+      type: MediaType.image,
+      size: 0,
+      lastModified: DateTime(2024, 1, 1),
+      tagIds: const ['tag-1'],
+      directoryId: 'dir-1',
+    );
+
+    viewModel.state = FullScreenLoaded(
+      mediaList: [media],
+      currentIndex: 0,
+      isPlaying: false,
+      isMuted: false,
+      isLooping: false,
+      currentPosition: Duration.zero,
+      totalDuration: Duration.zero,
+      isFavorite: false,
+      currentMediaTags: [tag],
+      shortcutTags: [tag],
+    );
+
+    when(assignTagUseCase.removeTagFromMedia(media.id, tag))
+        .thenAnswer((_) async {});
+    when(tagLookup.getTagsByIds(const <String>[]))
+        .thenAnswer((_) async => const <TagEntity>[]);
+    when(tagLookup.refresh()).thenAnswer((_) async {});
+    when(tagCacheRefresher.refresh()).thenAnswer((_) async {});
+
+    final result = await viewModel.toggleTagOnCurrentMedia(tag);
+
+    expect(result.outcome, TagMutationOutcome.removed);
+    final updatedState = viewModel.state as FullScreenLoaded;
+    expect(updatedState.currentMedia.tagIds, isEmpty);
+    expect(updatedState.currentMediaTags, isEmpty);
+    expect(updatedState.shortcutTags, isEmpty);
+
+    verify(assignTagUseCase.removeTagFromMedia(media.id, tag)).called(1);
+    verify(tagLookup.refresh()).called(1);
+    verify(tagCacheRefresher.refresh()).called(1);
+  });
+
+  test('setTagsForCurrentMedia replaces tags and reports changes', () async {
+    final originalTag = TagEntity(
+      id: 'tag-1',
+      name: 'Original',
+      color: 0xFF0000FF,
+      createdAt: DateTime(2023, 1, 1),
+    );
+    final replacementTag = TagEntity(
+      id: 'tag-2',
+      name: 'Replacement',
+      color: 0xFF00FF00,
+      createdAt: DateTime(2023, 6, 1),
+    );
+    final media = MediaEntity(
+      id: 'media-1',
+      path: '/tmp/media.jpg',
+      name: 'media.jpg',
+      type: MediaType.image,
+      size: 0,
+      lastModified: DateTime(2024, 1, 1),
+      tagIds: const ['tag-1'],
+      directoryId: 'dir-1',
+    );
+
+    viewModel.state = FullScreenLoaded(
+      mediaList: [media],
+      currentIndex: 0,
+      isPlaying: false,
+      isMuted: false,
+      isLooping: false,
+      currentPosition: Duration.zero,
+      totalDuration: Duration.zero,
+      isFavorite: false,
+      currentMediaTags: [originalTag],
+      shortcutTags: [originalTag],
+    );
+
+    when(assignTagUseCase.setTagsForMedia(['media-1'], ['tag-2', 'tag-1']))
+        .thenAnswer((_) async {});
+    when(tagLookup.getTagsByIds(any)).thenAnswer((invocation) async {
+      final ids = List<String>.from(invocation.positionalArguments.first);
+      if (ids.length == 2 && ids.first == 'tag-2') {
+        return [replacementTag, originalTag];
+      }
+      if (ids.length == 2 && ids.first == 'tag-1') {
+        return [originalTag, replacementTag];
+      }
+      return const <TagEntity>[];
+    });
+    when(tagLookup.refresh()).thenAnswer((_) async {});
+    when(tagCacheRefresher.refresh()).thenAnswer((_) async {});
+
+    final result =
+        await viewModel.setTagsForCurrentMedia(['tag-2', 'tag-1', 'tag-2']);
+
+    expect(result.addedCount, 1);
+    expect(result.removedCount, 0);
+
+    final updatedState = viewModel.state as FullScreenLoaded;
+    expect(updatedState.currentMedia.tagIds, ['tag-2', 'tag-1']);
+    expect(updatedState.currentMediaTags, [replacementTag, originalTag]);
+    expect(updatedState.shortcutTags, [originalTag, replacementTag]);
+
+    verify(assignTagUseCase.setTagsForMedia(['media-1'], ['tag-2', 'tag-1']))
+        .called(1);
+    verify(tagLookup.refresh()).called(1);
+    verify(tagCacheRefresher.refresh()).called(1);
+  });
+}


### PR DESCRIPTION
## Summary
- extend the full screen view model with tag assignment, lookup, and cache refresh utilities
- surface tag chips, management dialog access, and modifier-aware keyboard shortcuts in the viewer UI
- add shared tag lookup/ranking helpers and corresponding unit and widget tests

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68fa94aaed7483208b1476506973ff7c