### PR TITLE
Add optional setting to allow deleting files from source

### DIFF
--- a/lib/features/media_library/presentation/view_models/file_operations_view_model.dart
+++ b/lib/features/media_library/presentation/view_models/file_operations_view_model.dart
@@ -43,7 +43,17 @@ class FileOperationsViewModel extends StateNotifier<FileOperationsState> {
   final ValidatePathUseCase _validatePathUseCase;
 
   /// Deletes a file
-  Future<void> deleteFile(String filePath) async {
+  Future<void> deleteFile(
+    String filePath, {
+    required bool deleteFromSource,
+  }) async {
+    if (!deleteFromSource) {
+      state = const FileOperationsError(
+        'Delete from source is disabled in settings.',
+      );
+      return;
+    }
+
     state = const FileOperationsLoading();
     try {
       await _deleteFileUseCase(filePath);
@@ -54,7 +64,17 @@ class FileOperationsViewModel extends StateNotifier<FileOperationsState> {
   }
 
   /// Deletes a directory recursively
-  Future<void> deleteDirectory(String directoryPath) async {
+  Future<void> deleteDirectory(
+    String directoryPath, {
+    required bool deleteFromSource,
+  }) async {
+    if (!deleteFromSource) {
+      state = const FileOperationsError(
+        'Delete from source is disabled in settings.',
+      );
+      return;
+    }
+
     state = const FileOperationsLoading();
     try {
       await _deleteDirectoryUseCase(directoryPath);

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../features/media_library/presentation/view_models/directory_grid_view_model.dart';
 import '../../../../features/favorites/presentation/view_models/favorites_view_model.dart';
+import '../../../../shared/providers/delete_from_source_provider.dart';
 import '../../../../shared/providers/theme_provider.dart';
 import '../../../../shared/providers/thumbnail_caching_provider.dart';
 import '../../../../shared/providers/video_playback_settings_provider.dart';
@@ -21,6 +22,9 @@ class SettingsScreen extends ConsumerWidget {
     final playbackSettings = ref.watch(videoPlaybackSettingsProvider);
     final playbackSettingsNotifier =
         ref.read(videoPlaybackSettingsProvider.notifier);
+    final deleteFromSourceEnabled = ref.watch(deleteFromSourceProvider);
+    final deleteFromSourceNotifier =
+        ref.read(deleteFromSourceProvider.notifier);
 
     return Scaffold(
       appBar: const CustomAppBar(
@@ -46,6 +50,10 @@ class SettingsScreen extends ConsumerWidget {
           _buildThumbnailCachingSetting(
             isThumbnailCachingEnabled,
             thumbnailCachingNotifier,
+          ),
+          _buildDeleteFromSourceSetting(
+            deleteFromSourceEnabled,
+            deleteFromSourceNotifier,
           ),
           _buildClearCacheTile(context, ref),
           _buildClearFavoritesTile(context, ref),
@@ -100,6 +108,25 @@ class SettingsScreen extends ConsumerWidget {
         value: isEnabled,
         onChanged: (bool value) {
           notifier.setThumbnailCaching(value);
+        },
+      ),
+    );
+  }
+
+  Widget _buildDeleteFromSourceSetting(
+    bool isEnabled,
+    DeleteFromSourceNotifier notifier,
+  ) {
+    return ListTile(
+      title: const Text('Delete From Source'),
+      subtitle: const Text(
+        'When enabled, delete operations remove the original files or directories '
+        'from disk. When disabled, files remain on disk.',
+      ),
+      trailing: Switch(
+        value: isEnabled,
+        onChanged: (bool value) {
+          notifier.setDeleteFromSource(value);
         },
       ),
     );

--- a/lib/shared/providers/delete_from_source_provider.dart
+++ b/lib/shared/providers/delete_from_source_provider.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Provider that controls whether delete operations remove files from the
+/// original source on disk.
+final deleteFromSourceProvider =
+    StateNotifierProvider<DeleteFromSourceNotifier, bool>((ref) {
+  return DeleteFromSourceNotifier();
+});
+
+/// Manages the persisted preference for deleting files from their source.
+class DeleteFromSourceNotifier extends StateNotifier<bool> {
+  DeleteFromSourceNotifier() : super(false) {
+    _loadPreference();
+  }
+
+  static const _preferenceKey = 'delete_from_source_enabled';
+
+  Future<void> _loadPreference() async {
+    final prefs = await SharedPreferences.getInstance();
+    state = prefs.getBool(_preferenceKey) ?? false;
+  }
+
+  Future<void> setDeleteFromSource(bool enabled) async {
+    debugPrint(
+      'DeleteFromSourceProvider: Updating preference from $state to $enabled',
+    );
+    state = enabled;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_preferenceKey, enabled);
+    debugPrint(
+      'DeleteFromSourceProvider: Preference persisted with value $enabled',
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a persisted delete-from-source preference using a new Riverpod state notifier
- surface the toggle in the Settings screen data management section
- guard file deletion actions so they only run when the preference is enabled

## Testing
- Not run (not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_690256490b3483209ea6226a58d3a8ae