### PR TITLE
Prevent file delete failures when view model is disposed

### DIFF
--- a/lib/features/media_library/presentation/view_models/file_operations_view_model.dart
+++ b/lib/features/media_library/presentation/view_models/file_operations_view_model.dart
@@ -48,18 +48,20 @@ class FileOperationsViewModel extends StateNotifier<FileOperationsState> {
     required bool deleteFromSource,
   }) async {
     if (!deleteFromSource) {
-      state = const FileOperationsError(
-        'Delete from source is disabled in settings.',
+      _emitState(
+        const FileOperationsError(
+          'Delete from source is disabled in settings.',
+        ),
       );
       return;
     }
 
-    state = const FileOperationsLoading();
+    _emitState(const FileOperationsLoading());
     try {
       await _deleteFileUseCase(filePath);
-      state = FileOperationsSuccess('File deleted successfully');
+      _emitState(const FileOperationsSuccess('File deleted successfully'));
     } catch (e) {
-      state = FileOperationsError(e.toString());
+      _emitState(FileOperationsError(e.toString()));
     }
   }
 
@@ -69,18 +71,22 @@ class FileOperationsViewModel extends StateNotifier<FileOperationsState> {
     required bool deleteFromSource,
   }) async {
     if (!deleteFromSource) {
-      state = const FileOperationsError(
-        'Delete from source is disabled in settings.',
+      _emitState(
+        const FileOperationsError(
+          'Delete from source is disabled in settings.',
+        ),
       );
       return;
     }
 
-    state = const FileOperationsLoading();
+    _emitState(const FileOperationsLoading());
     try {
       await _deleteDirectoryUseCase(directoryPath);
-      state = FileOperationsSuccess('Directory deleted successfully');
+      _emitState(
+        const FileOperationsSuccess('Directory deleted successfully'),
+      );
     } catch (e) {
-      state = FileOperationsError(e.toString());
+      _emitState(FileOperationsError(e.toString()));
     }
   }
 
@@ -95,7 +101,14 @@ class FileOperationsViewModel extends StateNotifier<FileOperationsState> {
 
   /// Resets the state to initial
   void reset() {
-    state = const FileOperationsInitial();
+    _emitState(const FileOperationsInitial());
+  }
+
+  void _emitState(FileOperationsState newState) {
+    if (!mounted) {
+      return;
+    }
+    state = newState;
   }
 }
 


### PR DESCRIPTION
## Summary
- guard FileOperationsViewModel state updates to avoid writing to a disposed notifier
- ensure delete file/directory flows still report status only when the notifier is mounted

## Testing
- flutter test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6903c9aa2e3c8320a172b7fc53db57bb