### PR TITLE
Add media type filter for library grid

### DIFF
--- a/lib/features/media_library/presentation/screens/media_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/media_grid_screen.dart
@@ -278,6 +278,8 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
         state is MediaLoaded ? state.selectedTagIds : const <String>[];
     final showFavoritesOnly =
         state is MediaLoaded ? state.showFavoritesOnly : viewModel.showFavoritesOnly;
+    final mediaTypeFilter =
+        state is MediaLoaded ? state.mediaTypeFilter : viewModel.mediaTypeFilter;
     final favoritesState = ref.watch(favoritesViewModelProvider);
     final hasFavoriteMedia = switch (favoritesState) {
       FavoritesLoaded(:final favorites) => favorites.isNotEmpty,
@@ -289,6 +291,8 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
       padding: UiSpacing.tagFilterPadding,
       child: Row(
         children: [
+          _buildMediaTypeFilterPicker(mediaTypeFilter, viewModel),
+          const SizedBox(width: 12),
           if (shouldShowFavoritesChip) ...[
             FilterChip(
               label: const Text('Favorites'),
@@ -313,6 +317,37 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
           ),
         ],
       ),
+    );
+  }
+
+  Widget _buildMediaTypeFilterPicker(
+    MediaTypeFilter selectedFilter,
+    MediaViewModel viewModel,
+  ) {
+    return SegmentedButton<MediaTypeFilter>(
+      selected: {selectedFilter},
+      onSelectionChanged: (selection) {
+        if (selection.isNotEmpty) {
+          viewModel.setMediaTypeFilter(selection.first);
+        }
+      },
+      segments: const [
+        ButtonSegment(
+          value: MediaTypeFilter.all,
+          label: Text('All'),
+          icon: Icon(Icons.filter_alt),
+        ),
+        ButtonSegment(
+          value: MediaTypeFilter.imagesOnly,
+          label: Text('Images'),
+          icon: Icon(Icons.photo),
+        ),
+        ButtonSegment(
+          value: MediaTypeFilter.videosOnly,
+          label: Text('Videos'),
+          icon: Icon(Icons.videocam),
+        ),
+      ],
     );
   }
 


### PR DESCRIPTION
## Summary
- add a media-type segmented control to the library grid to choose all, images, or videos
- extend the media grid view model to track the selected media type and apply it alongside favorites/search/tag filters

## Testing
- Not run (flutter not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920bcb555bc8320863dadd0e42d7d02)