### PR TITLE
Add media type filter in library grid

### DIFF
--- a/lib/features/media_library/presentation/screens/media_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/media_grid_screen.dart
@@ -278,6 +278,8 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
         state is MediaLoaded ? state.selectedTagIds : const <String>[];
     final showFavoritesOnly =
         state is MediaLoaded ? state.showFavoritesOnly : viewModel.showFavoritesOnly;
+    final mediaTypeFilter =
+        state is MediaLoaded ? state.mediaTypeFilter : viewModel.mediaTypeFilter;
     final favoritesState = ref.watch(favoritesViewModelProvider);
     final hasFavoriteMedia = switch (favoritesState) {
       FavoritesLoaded(:final favorites) => favorites.isNotEmpty,
@@ -289,6 +291,11 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
       padding: UiSpacing.tagFilterPadding,
       child: Row(
         children: [
+          _MediaTypeFilterDropdown(
+            selectedFilter: mediaTypeFilter,
+            onChanged: viewModel.setMediaTypeFilter,
+          ),
+          const SizedBox(width: 12),
           if (shouldShowFavoritesChip) ...[
             FilterChip(
               label: const Text('Favorites'),
@@ -831,6 +838,38 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
 
   String _formatDate(DateTime date) {
     return '${date.day}/${date.month}/${date.year} ${date.hour}:${date.minute.toString().padLeft(2, '0')}';
+  }
+}
+
+class _MediaTypeFilterDropdown extends StatelessWidget {
+  const _MediaTypeFilterDropdown({
+    required this.selectedFilter,
+    required this.onChanged,
+  });
+
+  final MediaTypeFilter selectedFilter;
+  final ValueChanged<MediaTypeFilter> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return DropdownButtonHideUnderline(
+      child: DropdownButton<MediaTypeFilter>(
+        value: selectedFilter,
+        onChanged: (value) {
+          if (value != null) {
+            onChanged(value);
+          }
+        },
+        items: MediaTypeFilter.values
+            .map(
+              (filter) => DropdownMenuItem(
+                value: filter,
+                child: Text(filter.label),
+              ),
+            )
+            .toList(),
+      ),
+    );
   }
 }
 

--- a/test/providers/media_grid_view_model_test.dart
+++ b/test/providers/media_grid_view_model_test.dart
@@ -120,6 +120,7 @@ void main() {
       expect(loadedState.columns, 3);
       expect(loadedState.currentDirectoryPath, testDirectoryPath);
       expect(loadedState.currentDirectoryName, testDirectoryName);
+      expect(loadedState.mediaTypeFilter, MediaTypeFilter.all);
 
       // Verify interactions
       verify(mockMediaRepository.getMediaForDirectoryPath(testDirectoryPath, bookmarkData: null)).called(1);
@@ -205,6 +206,26 @@ void main() {
       final loadedState = viewModel.state as MediaLoaded;
       expect(loadedState.media.length, 0);
       expect(loadedState.searchQuery, 'nonexistent');
+    });
+
+    test('setMediaTypeFilter filters visible media types', () async {
+      await viewModel.loadMedia();
+
+      viewModel.setMediaTypeFilter(MediaTypeFilter.videos);
+
+      expect(viewModel.state, isA<MediaLoaded>());
+      var loadedState = viewModel.state as MediaLoaded;
+      expect(loadedState.mediaTypeFilter, MediaTypeFilter.videos);
+      expect(loadedState.media, hasLength(1));
+      expect(loadedState.media.first.type, MediaType.video);
+
+      viewModel.setMediaTypeFilter(MediaTypeFilter.images);
+
+      expect(viewModel.state, isA<MediaLoaded>());
+      loadedState = viewModel.state as MediaLoaded;
+      expect(loadedState.mediaTypeFilter, MediaTypeFilter.images);
+      expect(loadedState.media, hasLength(1));
+      expect(loadedState.media.first.type, MediaType.image);
     });
 
     test('setColumns updates columns in state', () async {


### PR DESCRIPTION
## Summary
- add a media type filter to the media grid view model and preserve it across sorting, searching, and tag filtering
- expose a media type dropdown in the library filter bar to switch between all media, images, or videos
- expand media grid view model tests to cover the new filter state

## Testing
- flutter test *(fails: flutter not installed in CI image)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920bcb555bc8320863dadd0e42d7d02)