### PR TITLE
Add media type filters to library grid

### DIFF
--- a/lib/features/media_library/presentation/screens/media_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/media_grid_screen.dart
@@ -23,6 +23,7 @@ import '../../domain/entities/media_entity.dart';
 import '../view_models/media_grid_view_model.dart';
 import '../widgets/media_grid_item.dart';
 import '../widgets/column_selector_popup.dart';
+import '../widgets/media_type_filter_chips.dart';
 
 /// Screen for displaying media in a customizable grid layout.
 class MediaGridScreen extends ConsumerStatefulWidget {
@@ -278,6 +279,8 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
         state is MediaLoaded ? state.selectedTagIds : const <String>[];
     final showFavoritesOnly =
         state is MediaLoaded ? state.showFavoritesOnly : viewModel.showFavoritesOnly;
+    final activeMediaTypes =
+        state is MediaLoaded ? state.activeMediaTypes : viewModel.activeMediaTypes;
     final favoritesState = ref.watch(favoritesViewModelProvider);
     final hasFavoriteMedia = switch (favoritesState) {
       FavoritesLoaded(:final favorites) => favorites.isNotEmpty,
@@ -287,9 +290,16 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
 
     return Container(
       padding: UiSpacing.tagFilterPadding,
-      child: Row(
+      width: double.infinity,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          MediaTypeFilterChips(
+            selectedTypes: activeMediaTypes,
+            onSelectionChanged: viewModel.updateMediaTypeFilters,
+          ),
           if (shouldShowFavoritesChip) ...[
+            const SizedBox(height: 8),
             FilterChip(
               label: const Text('Favorites'),
               avatar: const Icon(Icons.star, color: Colors.amber),
@@ -301,15 +311,13 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
                 viewModel.setShowFavoritesOnly(value);
               },
             ),
-            const SizedBox(width: 12),
           ],
-          Expanded(
-            child: TagFilterChips(
-              selectedTagIds: selectedTagIds,
-              onSelectionChanged: viewModel.filterByTags,
-              maxChipsToShow:
-                  UiGrid.maxFilterChips, // Limit to prevent overflow
-            ),
+          const SizedBox(height: 12),
+          TagFilterChips(
+            selectedTagIds: selectedTagIds,
+            onSelectionChanged: viewModel.filterByTags,
+            maxChipsToShow:
+                UiGrid.maxFilterChips, // Limit to prevent overflow
           ),
         ],
       ),

--- a/lib/features/media_library/presentation/widgets/media_type_filter_chips.dart
+++ b/lib/features/media_library/presentation/widgets/media_type_filter_chips.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+
+import '../../domain/entities/media_entity.dart';
+
+class MediaTypeFilterChips extends StatelessWidget {
+  const MediaTypeFilterChips({
+    super.key,
+    required this.selectedTypes,
+    required this.onSelectionChanged,
+  });
+
+  final Set<MediaType> selectedTypes;
+  final ValueChanged<Set<MediaType>> onSelectionChanged;
+
+  static const List<_MediaTypeFilterOption> _filterOptions = <_MediaTypeFilterOption>[
+    _MediaTypeFilterOption(
+      type: MediaType.video,
+      label: 'Videos',
+      icon: Icons.videocam_outlined,
+    ),
+    _MediaTypeFilterOption(
+      type: MediaType.image,
+      label: 'Images',
+      icon: Icons.photo_outlined,
+    ),
+    _MediaTypeFilterOption(
+      type: MediaType.directory,
+      label: 'Directories',
+      icon: Icons.folder_outlined,
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: <Widget>[
+        ActionChip(
+          label: const Text('All'),
+          avatar: const Icon(Icons.select_all),
+          onPressed: () => onSelectionChanged(<MediaType>{}),
+        ),
+        ..._filterOptions.map((option) {
+          final isSelected = selectedTypes.contains(option.type);
+          return FilterChip(
+            label: Text(option.label),
+            avatar: Icon(option.icon, size: 18),
+            selected: isSelected,
+            onSelected: (selected) => _onChipToggled(option.type, selected),
+          );
+        }),
+      ],
+    );
+  }
+
+  void _onChipToggled(MediaType type, bool selected) {
+    final updatedSelection = Set<MediaType>.from(selectedTypes);
+    if (selected) {
+      updatedSelection.add(type);
+    } else {
+      updatedSelection.remove(type);
+    }
+
+    if (updatedSelection.isEmpty) {
+      onSelectionChanged(<MediaType>{});
+      return;
+    }
+
+    onSelectionChanged(updatedSelection);
+  }
+}
+
+class _MediaTypeFilterOption {
+  const _MediaTypeFilterOption({
+    required this.type,
+    required this.label,
+    required this.icon,
+  });
+
+  final MediaType type;
+  final String label;
+  final IconData icon;
+}


### PR DESCRIPTION
## Summary
- add media type filter chips to the library filter bar so users can toggle images, videos, or directories
- track active media types in the media grid view model and apply the filter alongside existing favorites/search logic

## Testing
- Not run (flutter command not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925f07e267c8320ad49dcd3b921ca8f)