### PR TITLE
Add media type filters in library grid

### DIFF
--- a/lib/features/media_library/domain/entities/media_entity.dart
+++ b/lib/features/media_library/domain/entities/media_entity.dart
@@ -1,6 +1,15 @@
 /// Enum representing different types of media.
 enum MediaType { image, video, text, directory }
 
+extension MediaTypeX on MediaType {
+  String get label => switch (this) {
+        MediaType.image => 'Images',
+        MediaType.video => 'Videos',
+        MediaType.text => 'Text',
+        MediaType.directory => 'Directories',
+      };
+}
+
 /// Domain entity representing a media item.
 class MediaEntity {
   const MediaEntity({


### PR DESCRIPTION
## Summary
- add media type labels to support selection in the library filter UI
- apply media type visibility filters in the media grid view model alongside existing search and favorites handling
- expose filter chips in the media grid screen to toggle images, videos, or directories

## Testing
- Not run (dart/flutter tooling unavailable in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925f07e267c8320ad49dcd3b921ca8f)