### PR TITLE
Limit full-screen navigation to filtered media

### DIFF
--- a/lib/features/media_library/presentation/screens/media_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/media_grid_screen.dart
@@ -46,6 +46,7 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
   MediaViewModel? _viewModel;
   final GlobalKey _mediaGridOverlayKey = GlobalKey();
   final Map<String, GlobalKey> _mediaItemKeys = <String, GlobalKey>{};
+  List<MediaEntity> _visibleMediaCache = const [];
   Rect? _mediaSelectionRect;
   Offset? _mediaDragStart;
   bool _isMediaMarqueeActive = false;
@@ -83,6 +84,11 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
     final selectedMediaIds = ref.watch(selectedMediaIdsProvider(_params!));
     final isSelectionMode = ref.watch(mediaSelectionModeProvider(_params!));
     final selectedMediaCount = ref.watch(selectedMediaCountProvider(_params!));
+    if (state case MediaLoaded(:final media)) {
+      _visibleMediaCache = media;
+    } else {
+      _visibleMediaCache = const [];
+    }
     final sortOption = state is MediaLoaded
         ? state.sortOption
         : _viewModel?.currentSortOption ?? MediaSortOption.nameAscending;
@@ -806,6 +812,8 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
             directoryPath: widget.directoryPath,
             initialMediaId: media.id,
             bookmarkData: widget.bookmarkData,
+            mediaList:
+                _visibleMediaCache.isNotEmpty ? _visibleMediaCache : null,
           ),
         ),
       );


### PR DESCRIPTION
## Summary
- cache the currently visible media in the media grid screen
- pass the filtered media list into the full-screen viewer so navigation respects active filters

## Testing
- dart format lib/features/media_library/presentation/screens/media_grid_screen.dart *(fails: dart command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926815087bc8320ac0140b4846368c5)