### PR TITLE
Enable tag toggling for media selection

### DIFF
--- a/lib/features/media_library/presentation/screens/media_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/media_grid_screen.dart
@@ -129,7 +129,11 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
               children: [
                 Column(
                   children: [
-                    _buildTagFilter(_viewModel!, state),
+                    _buildTagFilter(
+                      _viewModel!,
+                      state,
+                      isSelectionMode,
+                    ),
                     Expanded(
                       child: switch (state) {
                         MediaLoading() => const Center(
@@ -279,7 +283,11 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
     return 'Toggle Favorites';
   }
 
-  Widget _buildTagFilter(MediaViewModel viewModel, MediaState state) {
+  Widget _buildTagFilter(
+    MediaViewModel viewModel,
+    MediaState state,
+    bool isSelectionMode,
+  ) {
     final selectedTagIds =
         state is MediaLoaded ? state.selectedTagIds : const <String>[];
     final showFavoritesOnly =
@@ -334,9 +342,14 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
           ),
           const SizedBox(height: 12),
           TagFilterChips(
-            selectedTagIds: selectedTagIds,
-            onSelectionChanged: viewModel.filterByTags,
+            selectedTagIds:
+                isSelectionMode ? viewModel.tagIdsInSelection() : selectedTagIds,
+            onSelectionChanged:
+                isSelectionMode ? (_) {} : viewModel.filterByTags,
+            onTagTapped:
+                isSelectionMode ? (tag, _) => viewModel.toggleTagForSelection(tag) : null,
             maxChipsToShow: UiGrid.maxFilterChips,
+            showAllButton: !isSelectionMode,
           ),
         ],
       ),

--- a/lib/features/tagging/presentation/widgets/selectable_tag_chip_strip.dart
+++ b/lib/features/tagging/presentation/widgets/selectable_tag_chip_strip.dart
@@ -15,6 +15,7 @@ class SelectableTagChipStrip extends StatelessWidget {
     required this.tags,
     required this.selectedTagIds,
     required this.onSelectionChanged,
+    this.onTagTapped,
     this.maxChipsToShow,
     this.showAllChip = true,
     this.allChipLabel = 'All',
@@ -30,6 +31,11 @@ class SelectableTagChipStrip extends StatelessWidget {
 
   /// Callback invoked when the selection changes.
   final ValueChanged<List<String>> onSelectionChanged;
+
+  /// Callback invoked when a tag chip is tapped. When provided, selection
+  /// changes are delegated to this callback instead of the internal toggling
+  /// logic, allowing alternative behaviours (e.g. bulk tag assignment).
+  final Future<void> Function(TagEntity tag, bool isSelected)? onTagTapped;
 
   /// Maximum number of chips to render inline before showing an overflow chip.
   final int? maxChipsToShow;
@@ -69,7 +75,9 @@ class SelectableTagChipStrip extends StatelessWidget {
                 tag: tag,
                 selected: selectedTagIds.contains(tag.id),
                 compact: true,
-                onTap: () => _toggleTagSelection(tag.id),
+                onTap: onTagTapped != null
+                    ? () => onTagTapped!(tag, selectedTagIds.contains(tag.id))
+                    : () => _toggleTagSelection(tag.id),
               ),
             ),
           ),

--- a/lib/features/tagging/presentation/widgets/tag_filter_chips.dart
+++ b/lib/features/tagging/presentation/widgets/tag_filter_chips.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../domain/entities/tag_entity.dart';
 import '../states/tag_state.dart';
 import '../view_models/tag_management_view_model.dart';
 import 'selectable_tag_chip_strip.dart';
@@ -13,12 +14,14 @@ class TagFilterChips extends ConsumerWidget {
     super.key,
     required this.selectedTagIds,
     required this.onSelectionChanged,
+    this.onTagTapped,
     this.maxChipsToShow,
     this.showAllButton = true,
   });
 
   final List<String> selectedTagIds;
   final ValueChanged<List<String>> onSelectionChanged;
+  final Future<void> Function(TagEntity tag, bool isSelected)? onTagTapped;
   final int? maxChipsToShow;
   final bool showAllButton;
 
@@ -31,8 +34,9 @@ class TagFilterChips extends ConsumerWidget {
           tags: tags,
           selectedTagIds: selectedTagIds,
           onSelectionChanged: onSelectionChanged,
+          onTagTapped: onTagTapped,
           maxChipsToShow: maxChipsToShow,
-          showAllChip: showAllButton,
+          showAllChip: showAllButton && onTagTapped == null,
           onOverflowPressed: _shouldShowOverflow(tags.length)
               ? () => _showAllTagsDialog(context)
               : null,


### PR DESCRIPTION
## Summary
- allow tag chips in the media library to toggle tags when selection mode is active
- add selection-aware tag helpers and toggling support to the media grid view model
- extend reusable tag chip components to support delegated tap handling

## Testing
- Not run (tooling unavailable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69269bb4fee08320ac414b2c4f2e9080)