### PR TITLE
Add macOS Cmd+A shortcut to select all media items

### DIFF
--- a/lib/features/media_library/presentation/screens/media_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/media_grid_screen.dart
@@ -55,6 +55,8 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
   Set<String> _mediaLastMarqueeSelection = <String>{};
   Map<String, Rect> _mediaCachedItemRects = <String, Rect>{};
 
+  bool get _isMacOS => !kIsWeb && defaultTargetPlatform == TargetPlatform.macOS;
+
   @override
   Widget build(BuildContext context) {
     debugPrint(
@@ -96,6 +98,11 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
     return Shortcuts(
       shortcuts: <LogicalKeySet, Intent>{
         LogicalKeySet(LogicalKeyboardKey.escape): _ClearMediaSelectionIntent(),
+        if (_isMacOS)
+          LogicalKeySet(
+            LogicalKeyboardKey.meta,
+            LogicalKeyboardKey.keyA,
+          ): const _SelectAllMediaIntent(),
       },
       child: Actions(
         actions: <Type, Action<Intent>>{
@@ -113,6 +120,18 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
                   return null;
                 },
               ),
+          if (_isMacOS)
+            _SelectAllMediaIntent:
+                CallbackAction<_SelectAllMediaIntent>(
+              onInvoke: (_) {
+                if (_viewModel == null || _visibleMediaCache.isEmpty) {
+                  return null;
+                }
+                _viewModel!
+                    .selectMediaRange(_visibleMediaCache.map((media) => media.id));
+                return null;
+              },
+            ),
         },
         child: Focus(
           autofocus: true,
@@ -904,4 +923,8 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
 
 class _ClearMediaSelectionIntent extends Intent {
   const _ClearMediaSelectionIntent();
+}
+
+class _SelectAllMediaIntent extends Intent {
+  const _SelectAllMediaIntent();
 }


### PR DESCRIPTION
## Summary
- add a macOS-only Cmd+A shortcut in the media grid to select all visible media items
- connect the shortcut to existing selection logic so it mirrors manual selection

## Testing
- not run (Dart/Flutter tooling not available in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692895c97dcc8320bbd7c1211479298c)