### PR TITLE
Add sibling directory navigation within media grid

### DIFF
--- a/lib/features/media_library/presentation/models/directory_navigation_target.dart
+++ b/lib/features/media_library/presentation/models/directory_navigation_target.dart
@@ -1,0 +1,12 @@
+/// Represents a directory that can be navigated to from the media grid.
+class DirectoryNavigationTarget {
+  const DirectoryNavigationTarget({
+    required this.path,
+    required this.name,
+    this.bookmarkData,
+  });
+
+  final String path;
+  final String name;
+  final String? bookmarkData;
+}

--- a/lib/features/media_library/presentation/screens/directory_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/directory_grid_screen.dart
@@ -24,6 +24,7 @@ import '../../../tagging/presentation/widgets/tag_creation_dialog.dart';
 import '../../../tagging/presentation/widgets/tag_filter_dialog.dart';
 import '../../../favorites/presentation/view_models/favorites_view_model.dart';
 import '../../domain/entities/directory_entity.dart';
+import '../models/directory_navigation_target.dart';
 import '../view_models/directory_grid_view_model.dart';
 import '../widgets/directory_grid_item.dart';
 import '../widgets/directory_search_bar.dart';
@@ -508,7 +509,12 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
         return DirectoryGridItem(
           key: itemKey,
           directory: directory,
-          onTap: () => _navigateToMediaGrid(context, directory),
+          onTap: () => _navigateToMediaGrid(
+            context,
+            directory,
+            directories,
+            index,
+          ),
           onDelete: () =>
               _showDeleteConfirmation(context, directory, viewModel),
           onAssignTags: (tagIds) => _assignTagsToDirectory(directory, tagIds),
@@ -589,7 +595,12 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
                     directory: directory,
                     onTap: isInaccessible
                         ? () {}
-                        : () => _navigateToMediaGrid(context, directory),
+                        : () => _navigateToMediaGrid(
+                              context,
+                              directory,
+                              allDirectories,
+                              index,
+                            ),
                     onDelete: () =>
                         _showDeleteConfirmation(context, directory, viewModel),
                     onAssignTags: (tagIds) =>
@@ -675,7 +686,12 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
                     directory: directory,
                     onTap: isInvalid
                         ? () {}
-                        : () => _navigateToMediaGrid(context, directory),
+                        : () => _navigateToMediaGrid(
+                              context,
+                              directory,
+                              allDirectories,
+                              index,
+                            ),
                     onDelete: () =>
                         _showDeleteConfirmation(context, directory, viewModel),
                     onAssignTags: (tagIds) =>
@@ -1007,13 +1023,36 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
     );
   }
 
-  void _navigateToMediaGrid(BuildContext context, DirectoryEntity directory) {
+  List<DirectoryNavigationTarget> _mapDirectoriesToNavigationTargets(
+    List<DirectoryEntity> directories,
+  ) {
+    return directories
+        .map(
+          (directory) => DirectoryNavigationTarget(
+            path: directory.path,
+            name: directory.name,
+            bookmarkData: directory.bookmarkData,
+          ),
+        )
+        .toList();
+  }
+
+  void _navigateToMediaGrid(
+    BuildContext context,
+    DirectoryEntity directory,
+    List<DirectoryEntity> siblingDirectories,
+    int currentIndex,
+  ) {
+    final navigationTargets =
+        _mapDirectoriesToNavigationTargets(siblingDirectories);
     Navigator.of(context).push(
       MaterialPageRoute(
         builder: (context) => MediaGridScreen(
           directoryPath: directory.path,
           directoryName: directory.name,
           bookmarkData: directory.bookmarkData,
+          siblingDirectories: navigationTargets,
+          currentDirectoryIndex: currentIndex,
         ),
       ),
     );

--- a/lib/features/media_library/presentation/screens/media_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/media_grid_screen.dart
@@ -122,7 +122,7 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
       bookmarkData: widget.bookmarkData,
       navigateToDirectory:
           (path, name, bookmarkData, siblingDirectories, currentIndex) {
-        Navigator.of(context).push(
+        Navigator.of(context).pushReplacement(
           MaterialPageRoute(
             builder: (context) => MediaGridScreen(
               directoryPath: path,

--- a/lib/features/media_library/presentation/view_models/media_grid_view_model.dart
+++ b/lib/features/media_library/presentation/view_models/media_grid_view_model.dart
@@ -16,6 +16,7 @@ import '../../data/isar/isar_media_data_source.dart';
 import '../../data/models/media_model.dart';
 import '../../../../core/services/logging_service.dart';
 import '../../../favorites/presentation/view_models/favorites_view_model.dart';
+import '../models/directory_navigation_target.dart';
 
 /// Defines the available sort options for media items.
 enum MediaSortOption {
@@ -643,11 +644,15 @@ class MediaViewModel extends StateNotifier<MediaState> {
     String directoryPath,
     String directoryName, {
     String? bookmarkData,
+    List<DirectoryNavigationTarget>? siblingDirectories,
+    int? currentIndex,
   }) async {
     _params.navigateToDirectory?.call(
       directoryPath,
       directoryName,
       bookmarkData,
+      siblingDirectories,
+      currentIndex,
     );
   }
 
@@ -1014,7 +1019,13 @@ class MediaViewModelParams {
   final String directoryPath;
   final String directoryName;
   final String? bookmarkData;
-  final void Function(String path, String name, String? bookmarkData)?
+  final void Function(
+    String path,
+    String name,
+    String? bookmarkData,
+    List<DirectoryNavigationTarget>? siblingDirectories,
+    int? currentIndex,
+  )?
   navigateToDirectory;
   final Future<String?> Function()? onPermissionRecoveryNeeded;
 

--- a/test/screens/media_grid_screen_test.dart
+++ b/test/screens/media_grid_screen_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:media_fast_view/features/media_library/presentation/screens/media_grid_screen.dart';
+import 'package:media_fast_view/features/media_library/presentation/models/directory_navigation_target.dart';
 
 void main() {
   group('MediaGridScreen', () {
@@ -59,6 +60,34 @@ void main() {
       // Verify basic UI structure
       expect(find.byType(Column), findsWidgets);
       expect(find.byType(Container), findsWidgets);
+    });
+
+    testWidgets('shows navigation arrows when sibling directories are provided',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(
+            home: MediaGridScreen(
+              directoryPath: testDirectoryPath,
+              directoryName: testDirectoryName,
+              siblingDirectories: [
+                DirectoryNavigationTarget(
+                  path: '/test/directory',
+                  name: 'Test Directory',
+                ),
+                DirectoryNavigationTarget(
+                  path: '/test/second',
+                  name: 'Second Directory',
+                ),
+              ],
+              currentDirectoryIndex: 0,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.chevron_left), findsOneWidget);
+      expect(find.byIcon(Icons.chevron_right), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Summary
- add sibling directory navigation context and controls so users can move between peer directories with arrows or swipes
- propagate sibling lists from the directory grid via a reusable navigation target model
- cover the navigation UI with a widget test

## Testing
- flutter test *(fails: command not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69294bff2b588320a8ba82bdd79504ad)