### PR TITLE
Handle tag batch updates without clearing caches

### DIFF
--- a/lib/features/media_library/data/repositories/directory_repository_impl.dart
+++ b/lib/features/media_library/data/repositories/directory_repository_impl.dart
@@ -206,46 +206,7 @@ class DirectoryRepositoryImpl implements DirectoryRepository {
   Future<BatchUpdateResult> updateDirectoryTagsBatch(
     Map<String, List<String>> directoryTags,
   ) async {
-    if (directoryTags.isEmpty) {
-      return BatchUpdateResult.empty;
-    }
-
-    final models = await _isarDirectoryDataSource.getDirectories();
-    final indexById = {
-      for (var i = 0; i < models.length; i++) models[i].id: i,
-    };
-
-    final successes = <String>[];
-    final failures = <String, String>{};
-
-    for (final entry in directoryTags.entries) {
-      final index = indexById[entry.key];
-      if (index == null) {
-        failures[entry.key] = 'Directory not found';
-        continue;
-      }
-
-      models[index] = models[index].copyWith(tagIds: entry.value);
-      successes.add(entry.key);
-    }
-
-    if (successes.isNotEmpty) {
-      await _isarDirectoryDataSource.saveDirectories(models);
-      LoggingService.instance.info(
-        'Updated tags for ${successes.length} directories in a single batch.',
-      );
-    }
-
-    if (failures.isNotEmpty) {
-      LoggingService.instance.warning(
-        'Failed to update tags for directories: ${failures.keys.join(', ')}',
-      );
-    }
-
-    return BatchUpdateResult(
-      successfulIds: successes,
-      failureReasons: failures,
-    );
+    return _isarDirectoryDataSource.updateDirectoryTagsBatch(directoryTags);
   }
 
   @override

--- a/lib/features/media_library/data/repositories/filesystem_media_repository_impl.dart
+++ b/lib/features/media_library/data/repositories/filesystem_media_repository_impl.dart
@@ -254,37 +254,7 @@ class FilesystemMediaRepositoryImpl implements MediaRepository {
   Future<BatchUpdateResult> updateMediaTagsBatch(
     Map<String, List<String>> mediaTags,
   ) async {
-    if (mediaTags.isEmpty) {
-      return BatchUpdateResult.empty;
-    }
-
-    final models = await _mediaDataSource.getMedia();
-    final indexById = {
-      for (var i = 0; i < models.length; i++) models[i].id: i,
-    };
-
-    final successes = <String>[];
-    final failures = <String, String>{};
-
-    for (final entry in mediaTags.entries) {
-      final index = indexById[entry.key];
-      if (index == null) {
-        failures[entry.key] = 'Media not found';
-        continue;
-      }
-
-      models[index] = models[index].copyWith(tagIds: entry.value);
-      successes.add(entry.key);
-    }
-
-    if (successes.isNotEmpty) {
-      await _mediaDataSource.saveMedia(models);
-    }
-
-    return BatchUpdateResult(
-      successfulIds: successes,
-      failureReasons: failures,
-    );
+    return _mediaDataSource.updateMediaTagsBatch(mediaTags);
   }
 
   /// Merges tags from local storage with filesystem-scanned media.

--- a/lib/features/media_library/data/repositories/media_repository_impl.dart
+++ b/lib/features/media_library/data/repositories/media_repository_impl.dart
@@ -84,46 +84,7 @@ class MediaRepositoryImpl implements MediaRepository {
   Future<BatchUpdateResult> updateMediaTagsBatch(
     Map<String, List<String>> mediaTags,
   ) async {
-    if (mediaTags.isEmpty) {
-      return BatchUpdateResult.empty;
-    }
-
-    final models = await _mediaDataSource.getMedia();
-    final indexById = {
-      for (var i = 0; i < models.length; i++) models[i].id: i,
-    };
-
-    final successes = <String>[];
-    final failures = <String, String>{};
-
-    for (final entry in mediaTags.entries) {
-      final index = indexById[entry.key];
-      if (index == null) {
-        failures[entry.key] = 'Media not found';
-        continue;
-      }
-
-      models[index] = models[index].copyWith(tagIds: entry.value);
-      successes.add(entry.key);
-    }
-
-    if (successes.isNotEmpty) {
-      await _mediaDataSource.saveMedia(models);
-      LoggingService.instance.info(
-        'Updated tags for ${successes.length} media items in a single batch.',
-      );
-    }
-
-    if (failures.isNotEmpty) {
-      LoggingService.instance.warning(
-        'Failed to update tags for media: ${failures.keys.join(', ')}',
-      );
-    }
-
-    return BatchUpdateResult(
-      successfulIds: successes,
-      failureReasons: failures,
-    );
+    return _mediaDataSource.updateMediaTagsBatch(mediaTags);
   }
 
   @override


### PR DESCRIPTION
## Summary
- add targeted batch tag update operations in Isar media and directory data sources to avoid clearing unrelated records
- update repositories to delegate batch tag writes to the new data source methods
- add coverage ensuring batch tag updates touch only requested entries

## Testing
- dart run test test/features/media_library/data/isar/isar_media_data_source_test.dart *(fails: `dart` command not available in container)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b44c021208320ab4e5853fa8de496)