### PR TITLE
Show all tag chips in library filters

### DIFF
--- a/lib/core/constants/ui_constants.dart
+++ b/lib/core/constants/ui_constants.dart
@@ -126,9 +126,6 @@ class UiGrid {
   /// Maximum cross-axis extent for responsive grid
   static const double maxCrossAxisExtent = 160.0;
 
-  /// Maximum number of filter chips to show
-  static const int maxFilterChips = 8;
-
   /// Flex ratios for grid items
   static const int thumbnailFlex = 3;
   static const int infoFlex = 2;

--- a/lib/features/media_library/presentation/screens/directory_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/directory_grid_screen.dart
@@ -21,7 +21,6 @@ import '../../../tagging/presentation/view_models/tag_management_view_model.dart
 import '../../../tagging/presentation/widgets/bulk_tag_assignment_dialog.dart';
 import '../../../tagging/presentation/widgets/selectable_tag_chip_strip.dart';
 import '../../../tagging/presentation/widgets/tag_creation_dialog.dart';
-import '../../../tagging/presentation/widgets/tag_filter_dialog.dart';
 import '../../../favorites/presentation/view_models/favorites_view_model.dart';
 import '../../domain/entities/directory_entity.dart';
 import '../models/directory_navigation_target.dart';
@@ -468,17 +467,6 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
         );
         viewModel.filterByTags(newSelection);
       },
-      maxChipsToShow: UiGrid.maxFilterChips,
-      onOverflowPressed: () => TagFilterDialog.show(
-        context,
-        selectedTagIds: selectedTagIds,
-        onSelectionChanged: (newSelection) {
-          debugPrint(
-            'DirectoryGridScreen: Tag selection changed via dialog: $newSelection',
-          );
-          viewModel.filterByTags(newSelection);
-        },
-      ),
     );
   }
 

--- a/lib/features/media_library/presentation/screens/media_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/media_grid_screen.dart
@@ -470,7 +470,6 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
                 isSelectionMode ? (_) {} : viewModel.filterByTags,
             onTagTapped:
                 isSelectionMode ? (tag, _) => viewModel.toggleTagForSelection(tag) : null,
-            maxChipsToShow: UiGrid.maxFilterChips,
             showAllButton: !isSelectionMode,
           ),
         ],


### PR DESCRIPTION
## Summary
- display all tag chips in library tag filters instead of limiting the visible count
- remove overflow handling and related constant now that tags scroll horizontally

## Testing
- flutter analyze *(fails: flutter not available in container)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b4772cdec832093fcddf2ee7bd060)