### PR TITLE
Enable sibling directory navigation in full-screen viewer

### DIFF
--- a/lib/features/full_screen/presentation/models/full_screen_exit_result.dart
+++ b/lib/features/full_screen/presentation/models/full_screen_exit_result.dart
@@ -1,0 +1,15 @@
+import '../../../media_library/presentation/models/directory_navigation_target.dart';
+
+/// Result returned when leaving the full-screen viewer so the caller can
+/// synchronize the currently active directory.
+class FullScreenExitResult {
+  const FullScreenExitResult({
+    required this.currentDirectory,
+    required this.currentDirectoryIndex,
+    required this.siblingDirectories,
+  });
+
+  final DirectoryNavigationTarget currentDirectory;
+  final int currentDirectoryIndex;
+  final List<DirectoryNavigationTarget> siblingDirectories;
+}

--- a/lib/features/tagging/presentation/screens/tags_screen.dart
+++ b/lib/features/tagging/presentation/screens/tags_screen.dart
@@ -515,6 +515,7 @@ class _TagsScreenState extends ConsumerState<TagsScreen> {
         MaterialPageRoute(
           builder: (context) => FullScreenViewerScreen(
             directoryPath: media.path,
+            directoryName: media.name,
             bookmarkData: media.bookmarkData,
           ),
         ),
@@ -527,6 +528,7 @@ class _TagsScreenState extends ConsumerState<TagsScreen> {
       MaterialPageRoute(
         builder: (context) => FullScreenViewerScreen(
           directoryPath: directoryPath,
+          directoryName: p.basename(directoryPath),
           initialMediaId: media.id,
           mediaList: mediaList,
         ),
@@ -539,6 +541,7 @@ class _TagsScreenState extends ConsumerState<TagsScreen> {
       MaterialPageRoute(
         builder: (context) => FullScreenViewerScreen(
           directoryPath: directoryContent.directory.path,
+          directoryName: directoryContent.directory.name,
           bookmarkData: directoryContent.directory.bookmarkData,
           initialMediaId: directoryContent.media.isNotEmpty
               ? directoryContent.media.first.id


### PR DESCRIPTION
## Summary
- add exit result payload so the media grid can keep directory context after full-screen sessions
- allow full-screen navigation controls to prompt for and load sibling directories at list boundaries
- keep media grid and tagging flows aware of directory names and siblings when opening full-screen

## Testing
- not run (environment missing `dart` tool for formatting)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b4b8cd3e88320a97ac0858e69474a)