### PR TITLE
Add tag clearing settings

### DIFF
--- a/lib/features/media_library/data/repositories/filesystem_media_repository_impl.dart
+++ b/lib/features/media_library/data/repositories/filesystem_media_repository_impl.dart
@@ -160,6 +160,12 @@ class FilesystemMediaRepositoryImpl implements MediaRepository {
     return _modelToEntity(localMedia);
   }
 
+  @override
+  Future<List<MediaEntity>> getAllMedia() async {
+    final models = await _mediaDataSource.getMedia();
+    return models.map(_modelToEntity).toList();
+  }
+
   /// Gets media by ID from a specific directory.
   Future<MediaEntity?> getMediaByIdFromDirectory(
     String id,

--- a/lib/features/media_library/data/repositories/media_repository_impl.dart
+++ b/lib/features/media_library/data/repositories/media_repository_impl.dart
@@ -43,6 +43,12 @@ class MediaRepositoryImpl implements MediaRepository {
   }
 
   @override
+  Future<List<MediaEntity>> getAllMedia() async {
+    final models = await _mediaDataSource.getMedia();
+    return models.map(_modelToEntity).toList();
+  }
+
+  @override
   Future<List<MediaEntity>> filterMediaByTags(List<String> tagIds) async {
     if (tagIds.isEmpty) {
       final allMedia = await _mediaDataSource.getMedia();

--- a/lib/features/media_library/data/repositories/tag_repository_impl.dart
+++ b/lib/features/media_library/data/repositories/tag_repository_impl.dart
@@ -38,6 +38,11 @@ class TagRepositoryImpl implements TagRepository {
     return _tagDataSource.removeTag(id);
   }
 
+  @override
+  Future<void> clearTags() {
+    return _tagDataSource.clearTags();
+  }
+
   TagEntity _modelToEntity(TagModel model) {
     return TagEntity(
       id: model.id,

--- a/lib/features/media_library/domain/repositories/media_repository.dart
+++ b/lib/features/media_library/domain/repositories/media_repository.dart
@@ -14,6 +14,9 @@ abstract class MediaRepository {
   /// @deprecated Use getMediaForDirectoryPath instead for path-aware operations.
   Future<List<MediaEntity>> getMediaForDirectory(String directoryId);
 
+  /// Retrieves all persisted media entries without touching the filesystem.
+  Future<List<MediaEntity>> getAllMedia();
+
   /// Retrieves a media item by its ID.
   Future<MediaEntity?> getMediaById(String id);
 

--- a/lib/features/media_library/domain/repositories/tag_repository.dart
+++ b/lib/features/media_library/domain/repositories/tag_repository.dart
@@ -16,4 +16,7 @@ abstract interface class TagRepository {
 
   /// Deletes the tag identified by [id].
   Future<void> deleteTag(String id);
+
+  /// Removes all persisted tags.
+  Future<void> clearTags();
 }

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../features/media_library/presentation/view_models/directory_grid_view_model.dart';
 import '../../../../features/favorites/presentation/view_models/favorites_view_model.dart';
 import '../../../../shared/providers/delete_from_source_provider.dart';
+import '../../../../shared/providers/repository_providers.dart';
 import '../../../../shared/providers/theme_provider.dart';
 import '../../../../shared/providers/thumbnail_caching_provider.dart';
 import '../../../../shared/providers/video_playback_settings_provider.dart';
@@ -57,6 +58,8 @@ class SettingsScreen extends ConsumerWidget {
           ),
           _buildClearCacheTile(context, ref),
           _buildClearFavoritesTile(context, ref),
+          _buildClearTagAssignmentsTile(context, ref),
+          _buildClearTagsTile(context, ref),
           const Divider(),
           _buildSectionHeader('About'),
           _buildAboutTile(context),
@@ -182,6 +185,26 @@ class SettingsScreen extends ConsumerWidget {
     );
   }
 
+  Widget _buildClearTagAssignmentsTile(BuildContext context, WidgetRef ref) {
+    return ListTile(
+      title: const Text('Clear All Assigned Tags'),
+      subtitle: const Text(
+        'Remove tag assignments from all media and directories',
+      ),
+      trailing: const Icon(Icons.label_off, color: Colors.red),
+      onTap: () => _showClearTagAssignmentsDialog(context, ref),
+    );
+  }
+
+  Widget _buildClearTagsTile(BuildContext context, WidgetRef ref) {
+    return ListTile(
+      title: const Text('Clear All Tags'),
+      subtitle: const Text('Delete all tags and their assignments'),
+      trailing: const Icon(Icons.delete_sweep, color: Colors.red),
+      onTap: () => _showClearTagsDialog(context, ref),
+    );
+  }
+
   Widget _buildAboutTile(BuildContext context) {
     return ListTile(
       title: const Text('About Media Fast View'),
@@ -271,6 +294,96 @@ class SettingsScreen extends ConsumerWidget {
                   ScaffoldMessenger.of(context).showSnackBar(
                     SnackBar(
                       content: Text('Failed to clear favorites: $e'),
+                      backgroundColor: Colors.red,
+                    ),
+                  );
+                }
+              }
+            },
+            child: const Text('Clear', style: TextStyle(color: Colors.red)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showClearTagAssignmentsDialog(BuildContext context, WidgetRef ref) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Clear All Assigned Tags'),
+        content: const Text(
+          'This will remove tag assignments from all media items and '
+          'directories while keeping your tags. This action cannot be undone.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () async {
+              Navigator.of(context).pop();
+              try {
+                await ref.read(clearTagAssignmentsUseCaseProvider)();
+                if (context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('All tag assignments cleared successfully'),
+                      backgroundColor: Colors.green,
+                    ),
+                  );
+                }
+              } catch (e) {
+                if (context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text('Failed to clear tag assignments: $e'),
+                      backgroundColor: Colors.red,
+                    ),
+                  );
+                }
+              }
+            },
+            child: const Text('Clear', style: TextStyle(color: Colors.red)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showClearTagsDialog(BuildContext context, WidgetRef ref) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Clear All Tags'),
+        content: const Text(
+          'This will delete all tags and remove their assignments from your '
+          'library. This action cannot be undone.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () async {
+              Navigator.of(context).pop();
+              try {
+                await ref.read(clearTagsUseCaseProvider)();
+                if (context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('All tags cleared successfully'),
+                      backgroundColor: Colors.green,
+                    ),
+                  );
+                }
+              } catch (e) {
+                if (context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text('Failed to clear tags: $e'),
                       backgroundColor: Colors.red,
                     ),
                   );

--- a/lib/features/tagging/data/isar/isar_tag_data_source.dart
+++ b/lib/features/tagging/data/isar/isar_tag_data_source.dart
@@ -99,6 +99,15 @@ class IsarTagDataSource {
     }, 'Failed to remove tag');
   }
 
+  /// Removes all tags and leaves tag assignments empty.
+  Future<void> clearTags() async {
+    await _executeSafely(() async {
+      await _tagStore.writeTxn(() async {
+        await _tagStore.clear();
+      });
+    }, 'Failed to clear tags');
+  }
+
   /// Resolves the tags assigned to the media entry identified by [mediaId].
   Future<List<TagModel>> getTagsForMedia(String mediaId) async {
     await _ensureReady();

--- a/lib/features/tagging/domain/use_cases/clear_tag_assignments_use_case.dart
+++ b/lib/features/tagging/domain/use_cases/clear_tag_assignments_use_case.dart
@@ -14,22 +14,22 @@ class ClearTagAssignmentsUseCase {
   /// Clears all tag assignments while leaving tag definitions intact.
   Future<void> call() async {
     final directories = await directoryRepository.getDirectories();
-    if (directories.isEmpty) {
+    if (directories.isNotEmpty) {
+      final directoryPayload = {
+        for (final directory in directories) directory.id: const <String>[],
+      };
+      await directoryRepository.updateDirectoryTagsBatch(directoryPayload);
+    }
+
+    final mediaItems = await mediaRepository.getAllMedia();
+    if (mediaItems.isEmpty) {
       return;
     }
 
-    final directoryPayload = {
-      for (final directory in directories) directory.id: const <String>[],
-    };
-    await directoryRepository.updateDirectoryTagsBatch(directoryPayload);
-
     final mediaPayload = <String, List<String>>{};
-    for (final directory in directories) {
-      final mediaItems = await mediaRepository.getMediaForDirectory(directory.id);
-      for (final media in mediaItems) {
-        if (media.tagIds.isNotEmpty) {
-          mediaPayload[media.id] = const <String>[];
-        }
+    for (final media in mediaItems) {
+      if (media.tagIds.isNotEmpty) {
+        mediaPayload[media.id] = const <String>[];
       }
     }
 

--- a/lib/features/tagging/domain/use_cases/clear_tag_assignments_use_case.dart
+++ b/lib/features/tagging/domain/use_cases/clear_tag_assignments_use_case.dart
@@ -1,0 +1,40 @@
+import '../../../media_library/domain/repositories/directory_repository.dart';
+import '../../../media_library/domain/repositories/media_repository.dart';
+
+/// Use case for removing tag assignments from all directories and media items.
+class ClearTagAssignmentsUseCase {
+  const ClearTagAssignmentsUseCase({
+    required this.directoryRepository,
+    required this.mediaRepository,
+  });
+
+  final DirectoryRepository directoryRepository;
+  final MediaRepository mediaRepository;
+
+  /// Clears all tag assignments while leaving tag definitions intact.
+  Future<void> call() async {
+    final directories = await directoryRepository.getDirectories();
+    if (directories.isEmpty) {
+      return;
+    }
+
+    final directoryPayload = {
+      for (final directory in directories) directory.id: const <String>[],
+    };
+    await directoryRepository.updateDirectoryTagsBatch(directoryPayload);
+
+    final mediaPayload = <String, List<String>>{};
+    for (final directory in directories) {
+      final mediaItems = await mediaRepository.getMediaForDirectory(directory.id);
+      for (final media in mediaItems) {
+        if (media.tagIds.isNotEmpty) {
+          mediaPayload[media.id] = const <String>[];
+        }
+      }
+    }
+
+    if (mediaPayload.isNotEmpty) {
+      await mediaRepository.updateMediaTagsBatch(mediaPayload);
+    }
+  }
+}

--- a/lib/features/tagging/domain/use_cases/clear_tags_use_case.dart
+++ b/lib/features/tagging/domain/use_cases/clear_tags_use_case.dart
@@ -1,0 +1,20 @@
+import '../../../media_library/domain/repositories/tag_repository.dart';
+
+import 'clear_tag_assignments_use_case.dart';
+
+/// Use case for removing all tags and their assignments.
+class ClearTagsUseCase {
+  const ClearTagsUseCase({
+    required this.tagRepository,
+    required this.clearTagAssignmentsUseCase,
+  });
+
+  final TagRepository tagRepository;
+  final ClearTagAssignmentsUseCase clearTagAssignmentsUseCase;
+
+  /// Removes every tag definition and clears related assignments.
+  Future<void> call() async {
+    await clearTagAssignmentsUseCase();
+    await tagRepository.clearTags();
+  }
+}

--- a/lib/shared/providers/repository_providers.dart
+++ b/lib/shared/providers/repository_providers.dart
@@ -34,6 +34,8 @@ import '../../features/tagging/domain/use_cases/get_tags_use_case.dart';
 import '../../features/tagging/domain/use_cases/assign_tag_use_case.dart';
 import '../../features/tagging/domain/use_cases/create_tag_use_case.dart';
 import '../../features/tagging/domain/use_cases/filter_by_tags_use_case.dart';
+import '../../features/tagging/domain/use_cases/clear_tag_assignments_use_case.dart';
+import '../../features/tagging/domain/use_cases/clear_tags_use_case.dart';
 import '../../features/favorites/domain/use_cases/get_favorites_use_case.dart';
 import '../../features/favorites/domain/use_cases/toggle_favorite_use_case.dart';
 import '../../features/favorites/domain/use_cases/start_slideshow_use_case.dart';
@@ -229,6 +231,21 @@ final getTagsUseCaseProvider = Provider<GetTagsUseCase>((ref) {
 
 final createTagUseCaseProvider = Provider<CreateTagUseCase>((ref) {
   return CreateTagUseCase(ref.watch(tagRepositoryProvider));
+});
+
+final clearTagAssignmentsUseCaseProvider =
+    Provider<ClearTagAssignmentsUseCase>((ref) {
+  return ClearTagAssignmentsUseCase(
+    directoryRepository: ref.watch(directoryRepositoryProvider),
+    mediaRepository: ref.watch(mediaRepositoryProvider),
+  );
+});
+
+final clearTagsUseCaseProvider = Provider<ClearTagsUseCase>((ref) {
+  return ClearTagsUseCase(
+    tagRepository: ref.watch(tagRepositoryProvider),
+    clearTagAssignmentsUseCase: ref.watch(clearTagAssignmentsUseCaseProvider),
+  );
 });
 
 final assignTagUseCaseProvider = Provider<AssignTagUseCase>((ref) {


### PR DESCRIPTION
## Summary
- add use cases to clear tag assignments and to remove all tags via the repository layer
- expose new providers and data source support for clearing tag data
- add data management settings to clear assigned tags or all tags with confirmation dialogs

## Testing
- Not run (environment not configured for Flutter/Dart tooling)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b51b11fd48320bca644728f61ddd8)