### PR TITLE
Use collision-resistant tag IDs and clean up legacy records

### DIFF
--- a/lib/features/tagging/data/isar/isar_tag_data_source.dart
+++ b/lib/features/tagging/data/isar/isar_tag_data_source.dart
@@ -1,6 +1,3 @@
-import 'dart:convert';
-
-import 'package:crypto/crypto.dart';
 import 'package:isar/isar.dart';
 
 import '../../../../core/error/app_error.dart';
@@ -92,9 +89,13 @@ class IsarTagDataSource {
   Future<void> removeTag(String id) async {
     await _executeSafely(() async {
       await _tagStore.writeTxn(() async {
-        final hash = sha256.convert(utf8.encode(id)).bytes;
-        final hashedId = hash.fold<int>(0, (prev, element) => prev + element);
-        await _tagStore.deleteById(hashedId);
+        final primaryId = computeTagCollectionId(id);
+        final legacyId = computeLegacyTagCollectionId(id);
+
+        await _tagStore.deleteById(primaryId);
+        if (legacyId != primaryId) {
+          await _tagStore.deleteById(legacyId);
+        }
       });
     }, 'Failed to remove tag');
   }

--- a/test/features/tagging/data/isar/tag_collection_test.dart
+++ b/test/features/tagging/data/isar/tag_collection_test.dart
@@ -20,7 +20,7 @@ void main() {
       expect(collection.name, model.name);
       expect(collection.color, model.color);
       expect(collection.createdAt, model.createdAt);
-      expect(collection.id, isarIdForString(model.id));
+      expect(collection.id, tagIdForString(model.id));
 
       final roundTrip = collection.toModel();
 

--- a/test/helpers/isar_id.dart
+++ b/test/helpers/isar_id.dart
@@ -2,9 +2,20 @@ import 'dart:convert';
 
 import 'package:crypto/crypto.dart';
 import 'package:isar/isar.dart';
+import 'package:media_fast_view/features/tagging/data/isar/tag_collection.dart';
 
 /// Mimics the hashing logic used by Isar collection id getters.
 Id isarIdForString(String value) {
   final hash = sha256.convert(utf8.encode(value)).bytes;
   return hash.fold<int>(0, (previousValue, element) => previousValue + element);
+}
+
+/// Mirrors the collision-resistant ID mapping used for tags.
+Id tagIdForString(String tagId) {
+  return computeTagCollectionId(tagId);
+}
+
+/// Helper for cleaning up legacy tag records persisted with the previous hash.
+Id legacyTagIdForString(String tagId) {
+  return computeLegacyTagCollectionId(tagId);
 }


### PR DESCRIPTION
## Summary
- derive tag primary keys from a 64-bit slice of the SHA-256 digest for better collision resistance
- ensure tag removal targets both the new identifier mapping and legacy hash ids to avoid orphaned records
- update helpers and tests to reflect the new deterministic id strategy and legacy cleanup path

## Testing
- Not run (Flutter/Dart SDK unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b582304148320a5d3df174fb69ff5)