### PR TITLE
Fix media id collisions when storing media records

### DIFF
--- a/lib/features/media_library/data/isar/isar_media_data_source.dart
+++ b/lib/features/media_library/data/isar/isar_media_data_source.dart
@@ -346,9 +346,7 @@ class IsarMediaCollectionStore implements MediaCollectionStore {
 
   @override
   Future<MediaCollection?> getByMediaId(String mediaId) {
-    final hash = sha256.convert(utf8.encode(mediaId)).bytes;
-    final id = hash.fold<int>(0, (prev, element) => prev + element);
-    return _collection.get(id);
+    return _collection.get(mediaCollectionIdFromMediaId(mediaId));
   }
 
   @override

--- a/lib/features/media_library/data/isar/media_collection.dart
+++ b/lib/features/media_library/data/isar/media_collection.dart
@@ -26,8 +26,7 @@ class MediaCollection {
 
   /// Unique hash-based identifier used by Isar for this record.
   Id get id {
-    final hash = sha256.convert(utf8.encode(mediaId)).bytes;
-    return hash.fold<int>(0, (prev, element) => prev + element);
+    return mediaCollectionIdFromMediaId(mediaId);
   }
   set id(Id value) {}
 
@@ -65,6 +64,16 @@ class MediaCollection {
 
   /// Link to the parent directory record.
   final IsarLink<DirectoryCollection> directory = IsarLink<DirectoryCollection>();
+}
+
+/// Generates a stable numeric identifier for a media record based on [mediaId].
+///
+/// The implementation uses the first 8 bytes of the SHA-256 digest to build a
+/// 64-bit integer, drastically reducing collision risk compared to summing the
+/// digest bytes.
+int mediaCollectionIdFromMediaId(String mediaId) {
+  final hash = sha256.convert(utf8.encode(mediaId)).bytes;
+  return hash.take(8).fold<int>(0, (value, byte) => (value << 8) | byte);
 }
 
 extension MediaCollectionMapper on MediaCollection {


### PR DESCRIPTION
## Summary
- generate stable 64-bit identifiers for media collections from SHA-256 digests to avoid collisions when many items are present
- reuse the shared identifier helper when looking up media records by ID in the Isar data source

## Testing
- `flutter test` *(fails: flutter not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b744e2b0083209e8a5b0124c68df2)