### PR TITLE
Add auto navigation option for sibling directories

### DIFF
--- a/lib/features/full_screen/presentation/screens/full_screen_viewer_screen.dart
+++ b/lib/features/full_screen/presentation/screens/full_screen_viewer_screen.dart
@@ -20,6 +20,7 @@ import '../../../../shared/widgets/media_playback_controls.dart';
 import '../../../../shared/widgets/media_progress_indicator.dart';
 import '../../../../shared/widgets/permission_issue_panel.dart';
 import '../../../../shared/widgets/favorite_toggle_button.dart';
+import '../../../../shared/providers/auto_navigate_sibling_directories_provider.dart';
 
 /// Full-screen media viewer screen
 class FullScreenViewerScreen extends ConsumerStatefulWidget {
@@ -635,7 +636,7 @@ class _FullScreenViewerScreenState
     if (!navigationResult.mediaAdvanced &&
         navigationResult.hasDirectoryOption &&
         navigationResult.directoryTarget != null) {
-      await _promptDirectoryNavigation(
+      await _handleSiblingDirectoryNavigation(
         navigationResult.directoryTarget!,
         forward: true,
       );
@@ -647,11 +648,30 @@ class _FullScreenViewerScreenState
     if (!navigationResult.mediaAdvanced &&
         navigationResult.hasDirectoryOption &&
         navigationResult.directoryTarget != null) {
-      await _promptDirectoryNavigation(
+      await _handleSiblingDirectoryNavigation(
         navigationResult.directoryTarget!,
         forward: false,
       );
     }
+  }
+
+  Future<void> _handleSiblingDirectoryNavigation(
+    DirectoryNavigationTarget target, {
+    required bool forward,
+  }) async {
+    final autoNavigate = ref.read(autoNavigateSiblingDirectoriesProvider);
+    if (autoNavigate) {
+      await _viewModel.navigateToDirectoryTarget(
+        target,
+        startAtEnd: !forward,
+      );
+      return;
+    }
+
+    await _promptDirectoryNavigation(
+      target,
+      forward: forward,
+    );
   }
 
   void _popWithResult() {

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -7,6 +7,7 @@ import '../../../../shared/providers/delete_from_source_provider.dart';
 import '../../../../shared/providers/repository_providers.dart';
 import '../../../../shared/providers/theme_provider.dart';
 import '../../../../shared/providers/thumbnail_caching_provider.dart';
+import '../../../../shared/providers/auto_navigate_sibling_directories_provider.dart';
 import '../../../../shared/providers/video_playback_settings_provider.dart';
 import '../../../../shared/widgets/app_bar.dart';
 
@@ -26,6 +27,10 @@ class SettingsScreen extends ConsumerWidget {
     final deleteFromSourceEnabled = ref.watch(deleteFromSourceProvider);
     final deleteFromSourceNotifier =
         ref.read(deleteFromSourceProvider.notifier);
+    final autoNavigateSiblingDirectories =
+        ref.watch(autoNavigateSiblingDirectoriesProvider);
+    final autoNavigateSiblingDirectoriesNotifier =
+        ref.read(autoNavigateSiblingDirectoriesProvider.notifier);
 
     return Scaffold(
       appBar: const CustomAppBar(
@@ -45,6 +50,12 @@ class SettingsScreen extends ConsumerWidget {
           _buildLoopSetting(
             playbackSettings.loopVideos,
             playbackSettingsNotifier,
+          ),
+          const Divider(),
+          _buildSectionHeader('Navigation'),
+          _buildSiblingNavigationSetting(
+            autoNavigateSiblingDirectories,
+            autoNavigateSiblingDirectoriesNotifier,
           ),
           const Divider(),
           _buildSectionHeader('Data Management'),
@@ -162,6 +173,24 @@ class SettingsScreen extends ConsumerWidget {
         value: isEnabled,
         onChanged: (bool value) {
           notifier.setLoopVideos(value);
+        },
+      ),
+    );
+  }
+
+  Widget _buildSiblingNavigationSetting(
+    bool isEnabled,
+    AutoNavigateSiblingDirectoriesNotifier notifier,
+  ) {
+    return ListTile(
+      title: const Text('Auto-Navigate Sibling Directories'),
+      subtitle: const Text(
+        'Skip confirmation prompts when moving between sibling directories in full-screen view.',
+      ),
+      trailing: Switch(
+        value: isEnabled,
+        onChanged: (bool value) {
+          notifier.setAutoNavigateSiblingDirectories(value);
         },
       ),
     );

--- a/lib/shared/providers/auto_navigate_sibling_directories_provider.dart
+++ b/lib/shared/providers/auto_navigate_sibling_directories_provider.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Provider that controls whether the app should auto-navigate to sibling
+/// directories without asking for confirmation when browsing in full-screen.
+final autoNavigateSiblingDirectoriesProvider =
+    StateNotifierProvider<AutoNavigateSiblingDirectoriesNotifier, bool>((ref) {
+  return AutoNavigateSiblingDirectoriesNotifier();
+});
+
+/// Manages the persisted preference for automatically navigating between
+/// sibling directories.
+class AutoNavigateSiblingDirectoriesNotifier extends StateNotifier<bool> {
+  AutoNavigateSiblingDirectoriesNotifier() : super(false) {
+    _loadPreference();
+  }
+
+  static const _preferenceKey = 'auto_navigate_sibling_directories';
+
+  Future<void> _loadPreference() async {
+    final prefs = await SharedPreferences.getInstance();
+    state = prefs.getBool(_preferenceKey) ?? false;
+  }
+
+  Future<void> setAutoNavigateSiblingDirectories(bool enabled) async {
+    debugPrint(
+      'AutoNavigateSiblingDirectories: Updating preference from $state to $enabled',
+    );
+    state = enabled;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_preferenceKey, enabled);
+  }
+}


### PR DESCRIPTION
## Summary
- add a persisted preference to auto-navigate between sibling directories in full-screen view
- expose the new toggle in the settings screen under a Navigation section
- honor the preference during full-screen sibling navigation by skipping confirmation prompts when enabled

## Testing
- Not run (Flutter/Dart tooling unavailable in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b77cbbf6c8320b61359c64f8d08bb)