### PR TITLE
Add option to cascade directory actions to contained media

### DIFF
--- a/lib/features/media_library/presentation/screens/directory_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/directory_grid_screen.dart
@@ -14,6 +14,7 @@ import '../../../../core/constants/ui_constants.dart';
 
 import '../../../../shared/providers/grid_columns_provider.dart';
 import '../../../../shared/providers/repository_providers.dart';
+import '../../../../shared/providers/recursive_directory_actions_provider.dart';
 import '../../../../shared/widgets/permission_issue_panel.dart';
 import '../../domain/entities/tag_entity.dart';
 import '../../../tagging/presentation/states/tag_state.dart';
@@ -1150,7 +1151,11 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
     final assignTagUseCase = ref.read(assignTagUseCaseProvider);
 
     try {
-      await assignTagUseCase.setTagsForDirectory(directory.id, tagIds);
+      await assignTagUseCase.setTagsForDirectory(
+        directory.id,
+        tagIds,
+        applyToMediaRecursively: ref.read(recursiveDirectoryActionsProvider),
+      );
       await ref.read(directoryViewModelProvider.notifier).loadDirectories();
     } catch (e) {
       if (mounted) {

--- a/lib/features/media_library/presentation/view_models/directory_grid_view_model.dart
+++ b/lib/features/media_library/presentation/view_models/directory_grid_view_model.dart
@@ -9,6 +9,7 @@ import '../../../../core/services/logging_service.dart';
 import '../../../../core/services/permission_service.dart';
 import '../../../../shared/providers/grid_columns_provider.dart';
 import '../../../../shared/providers/repository_providers.dart';
+import '../../../../shared/providers/recursive_directory_actions_provider.dart';
 import '../../data/data_sources/local_directory_data_source.dart';
 import '../../domain/entities/directory_entity.dart';
 import '../../domain/use_cases/add_directory_use_case.dart';
@@ -366,6 +367,8 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
     final result = await assignTagUseCase.setTagsForDirectories(
       _selectedDirectoryIds.toList(),
       sanitizedTags,
+      applyToMediaRecursively:
+          _ref.read(recursiveDirectoryActionsProvider),
     );
 
     if (result.successfulIds.isNotEmpty) {

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -8,6 +8,7 @@ import '../../../../shared/providers/repository_providers.dart';
 import '../../../../shared/providers/theme_provider.dart';
 import '../../../../shared/providers/thumbnail_caching_provider.dart';
 import '../../../../shared/providers/auto_navigate_sibling_directories_provider.dart';
+import '../../../../shared/providers/recursive_directory_actions_provider.dart';
 import '../../../../shared/providers/video_playback_settings_provider.dart';
 import '../../../../shared/widgets/app_bar.dart';
 
@@ -31,6 +32,10 @@ class SettingsScreen extends ConsumerWidget {
         ref.watch(autoNavigateSiblingDirectoriesProvider);
     final autoNavigateSiblingDirectoriesNotifier =
         ref.read(autoNavigateSiblingDirectoriesProvider.notifier);
+    final recursiveDirectoryActions =
+        ref.watch(recursiveDirectoryActionsProvider);
+    final recursiveDirectoryActionsNotifier =
+        ref.read(recursiveDirectoryActionsProvider.notifier);
 
     return Scaffold(
       appBar: const CustomAppBar(
@@ -62,6 +67,10 @@ class SettingsScreen extends ConsumerWidget {
           _buildThumbnailCachingSetting(
             isThumbnailCachingEnabled,
             thumbnailCachingNotifier,
+          ),
+          _buildRecursiveDirectoryActionsSetting(
+            recursiveDirectoryActions,
+            recursiveDirectoryActionsNotifier,
           ),
           _buildDeleteFromSourceSetting(
             deleteFromSourceEnabled,
@@ -122,6 +131,25 @@ class SettingsScreen extends ConsumerWidget {
         value: isEnabled,
         onChanged: (bool value) {
           notifier.setThumbnailCaching(value);
+        },
+      ),
+    );
+  }
+
+  Widget _buildRecursiveDirectoryActionsSetting(
+    bool isEnabled,
+    RecursiveDirectoryActionsNotifier notifier,
+  ) {
+    return ListTile(
+      title: const Text('Cascade directory actions to media'),
+      subtitle: const Text(
+        'When tagging or adding a directory to favorites, also apply the action to '
+        'all media inside that directory and its subdirectories.',
+      ),
+      trailing: Switch(
+        value: isEnabled,
+        onChanged: (bool value) {
+          notifier.setRecursiveDirectoryActions(value);
         },
       ),
     );

--- a/lib/shared/providers/recursive_directory_actions_provider.dart
+++ b/lib/shared/providers/recursive_directory_actions_provider.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Controls whether directory-level actions should cascade to contained media.
+///
+/// When enabled, tagging or favoriting a directory will also apply the action to
+/// every media item inside that directory and its subdirectories.
+final recursiveDirectoryActionsProvider =
+    StateNotifierProvider<RecursiveDirectoryActionsNotifier, bool>((ref) {
+  return RecursiveDirectoryActionsNotifier();
+});
+
+class RecursiveDirectoryActionsNotifier extends StateNotifier<bool> {
+  RecursiveDirectoryActionsNotifier() : super(false) {
+    _loadPreference();
+  }
+
+  static const _preferenceKey = 'recursive_directory_actions_enabled';
+
+  Future<void> _loadPreference() async {
+    final prefs = await SharedPreferences.getInstance();
+    state = prefs.getBool(_preferenceKey) ?? false;
+  }
+
+  Future<void> setRecursiveDirectoryActions(bool enabled) async {
+    debugPrint(
+      'RecursiveDirectoryActions: Updating preference from $state to $enabled',
+    );
+    state = enabled;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_preferenceKey, enabled);
+  }
+}


### PR DESCRIPTION
## Summary
- add a settings toggle to persist whether directory actions should cascade to nested media
- propagate directory favorites and tag assignments to contained media when the new option is enabled
- cover the recursive behavior with updated unit tests

## Testing
- flutter test *(fails: flutter not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693110468f988320a9799014d9cbe3ad)