### PR TITLE
Add untagged-only filter to the media grid

### DIFF
--- a/lib/features/media_library/presentation/screens/media_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/media_grid_screen.dart
@@ -466,6 +466,9 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
     final showFavoritesOnly = state is MediaLoaded
         ? state.showFavoritesOnly
         : viewModel.showFavoritesOnly;
+    final showUntaggedOnly = state is MediaLoaded
+        ? state.showUntaggedOnly
+        : viewModel.showUntaggedOnly;
     final visibleMediaTypes = state is MediaLoaded
         ? state.visibleMediaTypes
         : viewModel.visibleMediaTypes;
@@ -513,6 +516,14 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
                     viewModel.setShowFavoritesOnly(value);
                   },
                 ),
+              FilterChip(
+                label: const Text('Untagged'),
+                avatar: const Icon(Icons.label_off),
+                selected: showUntaggedOnly,
+                onSelected: (value) async {
+                  await viewModel.setShowUntaggedOnly(value);
+                },
+              ),
             ],
           ),
           const SizedBox(height: 12),


### PR DESCRIPTION
### Motivation
- Provide a library filter to show only media items that have no tags (untagged) so users can find and tag them easily.
- Keep the new filter consistent with existing favorites and media-type filters so it composes with other filters.
- Ensure selecting tag filters clears the untagged-only mode to avoid contradictory filters.

### Description
- Add a `showUntaggedOnly` flag to the `MediaLoaded` state and a `_showUntaggedOnly` field with a `showUntaggedOnly` getter on `MediaViewModel` to track the UI state.
- Implement `setShowUntaggedOnly` on the view model and a private `_applyUntaggedFilter` that filters `MediaEntity` items with empty `tagIds` and integrate it into `_applySearchFilters`.
- Update `filterByTags` to clear `_showUntaggedOnly` when tag filters are applied and ensure state is emitted with the new flag in all `MediaLoaded` constructors.
- Add an `Untagged` `FilterChip` to `media_grid_screen.dart` and wire its `onSelected` to `viewModel.setShowUntaggedOnly` so users can toggle the filter from the UI.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69461c21039c832088ba3b04ffa7a840)