### PR TITLE
Add hybrid tag filtering mode

### DIFF
--- a/lib/features/tagging/domain/enums/tag_filter_mode.dart
+++ b/lib/features/tagging/domain/enums/tag_filter_mode.dart
@@ -1,8 +1,24 @@
 enum TagFilterMode {
   any,
   all,
+  hybrid,
 }
 
 extension TagFilterModeX on TagFilterMode {
   bool get matchesAll => this == TagFilterMode.all;
+
+  bool get isHybrid => this == TagFilterMode.hybrid;
+
+  String get label => switch (this) {
+        TagFilterMode.any => 'Any tags',
+        TagFilterMode.all => 'All tags',
+        TagFilterMode.hybrid => 'Hybrid',
+      };
+
+  String get helperText => switch (this) {
+        TagFilterMode.any => 'Show items matching any selected tag.',
+        TagFilterMode.all => 'Show items matching every selected tag.',
+        TagFilterMode.hybrid =>
+          'Combine must-include and match-any tags in one query.',
+      };
 }


### PR DESCRIPTION
### Motivation
- Provide a more expressive tag query combining required (must-include), optional (match-any), and excluded tags in one flow. 
- Improve UX by exposing a clear toggle between `any`, `all`, and the new `hybrid` matching modes. 
- Let users mark tag chips as required/optional/excluded to craft mixed queries without needing multiple screens.

### Description
- Added a new `TagFilterMode.hybrid` with `label` and `helperText` in `tag_filter_mode.dart` and an `isHybrid` helper. 
- Introduced `TagSelectionMode` (`required`, `optional`, `excluded`) and track `optionalTagIds` alongside existing `selectedTagIds` and `excludedTagIds` in `TagsViewModel`; updated state and syncing logic. 
- Updated filtering logic in `TagsScreen`/`TagsViewModel` to merge/scan required and optional sections and return items that satisfy hybrid rules (must include all required tags and at least one optional tag), while respecting exclusions. 
- Enhanced UI: tag matching now uses `ChoiceChip` options for `Any/All/Hybrid`, a selection-mode chooser when `hybrid` is active, and visual styling/labels for optional/excluded tag chips; modified summary text to reflect required/optional/excluded counts.

### Testing
- No automated tests were executed against the modified code in this environment. 
- Attempted to run formatter via `dart format ...` but the `dart` tool was not available in the environment. 
- Local repository status and changes were inspected with `git status` and `git diff`, and the change was committed (`git commit`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a2ea10f688320b9bdcdc599c191b6)