### PR TITLE
Add hybrid tag filter mode with include/exclude selection UI

### DIFF
--- a/lib/features/tagging/domain/enums/tag_filter_mode.dart
+++ b/lib/features/tagging/domain/enums/tag_filter_mode.dart
@@ -1,8 +1,11 @@
 enum TagFilterMode {
   any,
   all,
+  hybrid,
 }
 
 extension TagFilterModeX on TagFilterMode {
-  bool get matchesAll => this == TagFilterMode.all;
+  bool get matchesAll => this == TagFilterMode.all || this == TagFilterMode.hybrid;
+
+  bool get isHybrid => this == TagFilterMode.hybrid;
 }


### PR DESCRIPTION
### Motivation
- Provide a richer tag-filtering experience that lets users both require and exclude tags in a single flow (a hybrid of `any`/`all`).
- Surface the new mode in the Tags UI so users can build "must include" and "must not include" tag lists without complex gestures.
- Improve clarity of helper text and selection summaries when hybrid behavior is active.

### Description
- Added a new enum value `TagFilterMode.hybrid` and extended `TagFilterModeX` with `isHybrid` and updated `matchesAll` to treat hybrid as requiring inclusion checks where appropriate (`lib/features/tagging/domain/enums/tag_filter_mode.dart`).
- Reworked the tags screen to expose a `Filter mode` control (ChoiceChips for `Any`/`All`/`Hybrid`) and a new `Selection mode` toggle (`TagSelectionIntent`) that switches between `Include` and `Exclude` in hybrid mode (`lib/features/tagging/presentation/screens/tags_screen.dart`).
- Updated chip interaction logic so taps in hybrid mode respect the current intent (tapping marks as included or excluded), adjusted helper copy in the selection placeholder, and updated the selection summary copy to reflect hybrid semantics.
- Kept existing long-press/right-click exclusion behavior but added explicit UI to reduce discovery friction and restored non-hybrid behavior when switching modes.

### Testing
- No automated tests were executed as part of this change.
- Basic compile-time checks were performed by committing and building the modified files locally (no unit or widget tests run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a2ea10f688320b9bdcdc599c191b6)