### PR TITLE
Add configurable auto-hide for slideshow controls

### DIFF
--- a/lib/core/config/app_config.dart
+++ b/lib/core/config/app_config.dart
@@ -15,6 +15,8 @@ class AppConfig {
   static const String _cacheExpirationKey = 'cacheExpiration';
   static const String _slideshowMinDurationKey = 'slideshowMinDuration';
   static const String _slideshowMaxDurationKey = 'slideshowMaxDuration';
+  static const String _slideshowControlsHideDelayKey =
+      'slideshowControlsHideDelay';
 
   // Default values
   static const int defaultGridColumns = 3;
@@ -26,6 +28,8 @@ class AppConfig {
   static const Duration defaultCacheExpiration = Duration(days: 1);
   static const Duration defaultSlideshowMinDuration = Duration(seconds: 2);
   static const Duration defaultSlideshowMaxDuration = Duration(seconds: 15);
+  static const Duration defaultSlideshowControlsHideDelay =
+      Duration(seconds: 5);
 
   // File size formatting constants
   static const int kbBytes = 1024;
@@ -145,6 +149,18 @@ class AppConfig {
     _prefs?.setInt(_slideshowMaxDurationKey, value.inMilliseconds);
   }
 
+  /// Get the slideshow controls auto-hide delay.
+  static Duration get slideshowControlsHideDelay {
+    final ms = _prefs?.getInt(_slideshowControlsHideDelayKey) ??
+        defaultSlideshowControlsHideDelay.inMilliseconds;
+    return Duration(milliseconds: ms);
+  }
+
+  /// Set the slideshow controls auto-hide delay.
+  static set slideshowControlsHideDelay(Duration value) {
+    _prefs?.setInt(_slideshowControlsHideDelayKey, value.inMilliseconds);
+  }
+
   /// Reset all configuration values to defaults.
   static void resetToDefaults() {
     gridColumns = defaultGridColumns;
@@ -156,5 +172,6 @@ class AppConfig {
     cacheExpiration = defaultCacheExpiration;
     slideshowMinDuration = defaultSlideshowMinDuration;
     slideshowMaxDuration = defaultSlideshowMaxDuration;
+    slideshowControlsHideDelay = defaultSlideshowControlsHideDelay;
   }
 }

--- a/lib/features/favorites/presentation/screens/slideshow_screen.dart
+++ b/lib/features/favorites/presentation/screens/slideshow_screen.dart
@@ -37,10 +37,6 @@ class _SlideshowScreenState extends ConsumerState<SlideshowScreen> {
     // Enable fullscreen mode
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
     _controlsHideDelay = ref.read(slideshowControlsHideDelayProvider);
-    ref.listen<Duration>(slideshowControlsHideDelayProvider, (previous, next) {
-      _controlsHideDelay = next;
-      _restartControlsHideTimer();
-    });
     _restartControlsHideTimer();
   }
 
@@ -59,6 +55,10 @@ class _SlideshowScreenState extends ConsumerState<SlideshowScreen> {
     final slideshowViewModel = ref.read(
       slideshowViewModelProvider(widget.mediaList).notifier,
     );
+    ref.listen<Duration>(slideshowControlsHideDelayProvider, (previous, next) {
+      _controlsHideDelay = next;
+      _restartControlsHideTimer();
+    });
 
     return Scaffold(
       backgroundColor: Colors.black,
@@ -104,9 +104,7 @@ class _SlideshowScreenState extends ConsumerState<SlideshowScreen> {
       onTap: _toggleControlsVisibility,
       child: Container(
         color: Colors.black,
-        child: Center(
-          child: _buildMediaContent(currentMedia, viewModel),
-        ),
+        child: Center(child: _buildMediaContent(currentMedia, viewModel)),
       ),
     );
   }
@@ -156,10 +154,7 @@ class _SlideshowScreenState extends ConsumerState<SlideshowScreen> {
           gradient: LinearGradient(
             begin: Alignment.bottomCenter,
             end: Alignment.topCenter,
-            colors: [
-              Colors.black.withValues(alpha: 0.8),
-              Colors.transparent,
-            ],
+            colors: [Colors.black.withValues(alpha: 0.8), Colors.transparent],
           ),
         ),
         child: SafeArea(
@@ -188,10 +183,8 @@ class _SlideshowScreenState extends ConsumerState<SlideshowScreen> {
                 isPlaying: viewModel.isPlaying,
                 isLooping: viewModel.isLooping,
                 isShuffleEnabled: switch (state) {
-                  SlideshowPlaying(:final isShuffleEnabled) =>
-                    isShuffleEnabled,
-                  SlideshowPaused(:final isShuffleEnabled) =>
-                    isShuffleEnabled,
+                  SlideshowPlaying(:final isShuffleEnabled) => isShuffleEnabled,
+                  SlideshowPaused(:final isShuffleEnabled) => isShuffleEnabled,
                   _ => false,
                 },
                 isMuted: viewModel.isMuted,
@@ -225,8 +218,7 @@ class _SlideshowScreenState extends ConsumerState<SlideshowScreen> {
                       viewModel.currentMedia?.type == MediaType.video,
                 ),
                 style: MediaPlaybackControlStyle(
-                  progressBackgroundColor:
-                      Colors.white.withValues(alpha: 0.3),
+                  progressBackgroundColor: Colors.white.withValues(alpha: 0.3),
                 ),
               ),
 

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -8,6 +8,7 @@ import '../../../../shared/providers/repository_providers.dart';
 import '../../../../shared/providers/theme_provider.dart';
 import '../../../../shared/providers/thumbnail_caching_provider.dart';
 import '../../../../shared/providers/auto_navigate_sibling_directories_provider.dart';
+import '../../../../shared/providers/slideshow_controls_hide_delay_provider.dart';
 import '../../../../shared/providers/video_playback_settings_provider.dart';
 import '../../../../shared/widgets/app_bar.dart';
 
@@ -31,6 +32,10 @@ class SettingsScreen extends ConsumerWidget {
         ref.watch(autoNavigateSiblingDirectoriesProvider);
     final autoNavigateSiblingDirectoriesNotifier =
         ref.read(autoNavigateSiblingDirectoriesProvider.notifier);
+    final slideshowControlsHideDelay =
+        ref.watch(slideshowControlsHideDelayProvider);
+    final slideshowControlsHideDelayNotifier =
+        ref.read(slideshowControlsHideDelayProvider.notifier);
 
     return Scaffold(
       appBar: const CustomAppBar(
@@ -50,6 +55,10 @@ class SettingsScreen extends ConsumerWidget {
           _buildLoopSetting(
             playbackSettings.loopVideos,
             playbackSettingsNotifier,
+          ),
+          _buildSlideshowControlsHideDelaySetting(
+            slideshowControlsHideDelay,
+            slideshowControlsHideDelayNotifier,
           ),
           const Divider(),
           _buildSectionHeader('Navigation'),
@@ -175,6 +184,45 @@ class SettingsScreen extends ConsumerWidget {
           notifier.setLoopVideos(value);
         },
       ),
+    );
+  }
+
+  Widget _buildSlideshowControlsHideDelaySetting(
+    Duration delay,
+    SlideshowControlsHideDelayNotifier notifier,
+  ) {
+    final seconds = delay.inSeconds;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ListTile(
+          title: const Text('Slideshow controls auto-hide'),
+          subtitle: Text(
+            'Hide slideshow controls after $seconds second${seconds == 1 ? '' : 's'} '
+            'of inactivity.',
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Slider(
+            value: seconds
+                .clamp(
+                  slideshowControlsHideDelayMinSeconds,
+                  slideshowControlsHideDelayMaxSeconds,
+                )
+                .toDouble(),
+            min: slideshowControlsHideDelayMinSeconds.toDouble(),
+            max: slideshowControlsHideDelayMaxSeconds.toDouble(),
+            divisions: slideshowControlsHideDelayMaxSeconds -
+                slideshowControlsHideDelayMinSeconds,
+            label: '$seconds s',
+            onChanged: (value) => notifier.setDelay(
+              Duration(seconds: value.round()),
+            ),
+          ),
+        ),
+      ],
     );
   }
 

--- a/lib/shared/providers/slideshow_controls_hide_delay_provider.dart
+++ b/lib/shared/providers/slideshow_controls_hide_delay_provider.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../core/config/app_config.dart';
+
+const int slideshowControlsHideDelayMinSeconds = 1;
+const int slideshowControlsHideDelayMaxSeconds = 30;
+const String _slideshowControlsHideDelayKey = 'slideshowControlsHideDelay';
+
+class SlideshowControlsHideDelayNotifier extends StateNotifier<Duration> {
+  SlideshowControlsHideDelayNotifier()
+      : super(AppConfig.defaultSlideshowControlsHideDelay) {
+    _loadDelay();
+  }
+
+  Future<void> _loadDelay() async {
+    final prefs = await SharedPreferences.getInstance();
+    final storedSeconds =
+        prefs.getInt(_slideshowControlsHideDelayKey) ??
+        AppConfig.defaultSlideshowControlsHideDelay.inSeconds;
+    state = Duration(seconds: storedSeconds);
+  }
+
+  Future<void> setDelay(Duration delay) async {
+    final clampedSeconds = delay.inSeconds
+        .clamp(
+          slideshowControlsHideDelayMinSeconds,
+          slideshowControlsHideDelayMaxSeconds,
+        )
+        .toInt();
+    if (state.inSeconds == clampedSeconds) {
+      return;
+    }
+    state = Duration(seconds: clampedSeconds);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_slideshowControlsHideDelayKey, clampedSeconds);
+  }
+}
+
+final slideshowControlsHideDelayProvider =
+    StateNotifierProvider<SlideshowControlsHideDelayNotifier, Duration>((ref) {
+      return SlideshowControlsHideDelayNotifier();
+    });


### PR DESCRIPTION
### Motivation
- Provide a configurable timeout so slideshow controls are hidden after a period of inactivity, matching the requested Slideshow behaviour.
- Make the timeout user-configurable from Settings with a sensible default of 5 seconds.
- Ensure controls reappear when the user moves the mouse inside the slideshow area.

### Description
- Added a persistent configuration entry and accessors `AppConfig.slideshowControlsHideDelay` with default `Duration(seconds: 5)`.
- Introduced a `SlideshowControlsHideDelayNotifier` and `slideshowControlsHideDelayProvider` in `lib/shared/providers/slideshow_controls_hide_delay_provider.dart` to expose and persist the delay value.
- Exposed the setting in the Settings screen under Playback via a slider (`_buildSlideshowControlsHideDelaySetting`) and hooked it to `slideshowControlsHideDelayProvider`.
- Implemented auto-hide logic in `SlideshowScreen`: wrapped the content in a `MouseRegion` to detect pointer activity, use a `Timer` to hide controls after the configured delay, and `ref.listen` to update the delay live.

### Testing
- No automated tests were executed during this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a44a6fcf08320a509bdd6b34bcf38)