### PR TITLE
Hide mouse cursor in slideshow when controls are hidden on desktop

### DIFF
--- a/lib/features/favorites/presentation/screens/slideshow_screen.dart
+++ b/lib/features/favorites/presentation/screens/slideshow_screen.dart
@@ -67,6 +67,9 @@ class _SlideshowScreenState extends ConsumerState<SlideshowScreen> {
         autofocus: true,
         onKeyEvent: _handleKeyEvent,
         child: MouseRegion(
+          cursor: _shouldHideMouse
+              ? SystemMouseCursors.none
+              : SystemMouseCursors.basic,
           onEnter: (_) => _handlePointerActivity(),
           onHover: (_) => _handlePointerActivity(),
           child: Stack(
@@ -255,6 +258,10 @@ class _SlideshowScreenState extends ConsumerState<SlideshowScreen> {
     }
     _restartControlsHideTimer();
   }
+
+  bool get _shouldHideMouse =>
+      !_areControlsVisible &&
+      (Platform.isMacOS || Platform.isWindows || Platform.isLinux);
 
   void _restartControlsHideTimer() {
     _controlsHideTimer?.cancel();


### PR DESCRIPTION
### Motivation
- Improve immersion in slideshow mode by hiding the mouse cursor when the layout/controls are hidden on desktop devices.
- Keep the cursor visible when controls are shown so users can interact with playback controls.
- Restrict cursor hiding to desktop platforms to avoid unexpected behavior on mobile/touch devices.

### Description
- Added a `cursor` property to the `MouseRegion` in `SlideshowScreen` to select between `SystemMouseCursors.none` and `SystemMouseCursors.basic` based on state.
- Implemented a `_shouldHideMouse` getter that returns `true` when controls are hidden and the platform is `macOS`, `Windows`, or `Linux` by checking `Platform.isMacOS || Platform.isWindows || Platform.isLinux`.
- Kept existing pointer activity handlers (`onEnter` / `onHover`) and control visibility timers so pointer movement still restores controls as before.
- Modified file: `lib/features/favorites/presentation/screens/slideshow_screen.dart`.

### Testing
- No automated tests were executed for this change.
- Existing pointer handlers and timers were left intact so existing slideshow behavior remains unchanged during manual inspection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a5455e5a88320a3f9eb384cb21997)