### PR TITLE
Clamp directory IDs to prevent overflow

### DIFF
--- a/lib/features/media_library/data/isar/isar_directory_data_source.dart
+++ b/lib/features/media_library/data/isar/isar_directory_data_source.dart
@@ -247,9 +247,7 @@ class IsarDirectoryCollectionStore implements DirectoryCollectionStore {
 
   @override
   Future<DirectoryCollection?> getByDirectoryId(String directoryId) {
-    final hash = sha256.convert(utf8.encode(directoryId)).bytes;
-    final id = hash.fold<int>(0, (prev, element) => prev + element);
-    return _collection.get(id);
+    return _collection.get(computeDirectoryCollectionId(directoryId));
   }
 
   @override


### PR DESCRIPTION
## Summary
- mask computed directory collection IDs to the signed 64-bit range to avoid format exceptions when parsing hashes
- ensure Isar directory lookups reuse the shared ID computation helper
- update directory ID tests to cover the masked hash behavior and overflow guard

## Testing
- Not run (flutter not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69521d6d38d88320b8ad92fcf8eb75fe)