### PR TITLE
Add reusable tag overlays for slideshow

### DIFF
--- a/lib/features/favorites/presentation/widgets/slideshow_overlay.dart
+++ b/lib/features/favorites/presentation/widgets/slideshow_overlay.dart
@@ -1,0 +1,216 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:media_fast_view/shared/widgets/media_playback_controls.dart';
+import 'package:media_fast_view/shared/widgets/media_progress_indicator.dart';
+
+import '../../../../core/config/app_config.dart';
+import '../../../../shared/providers/slideshow_controls_hide_delay_provider.dart';
+import '../../../../shared/providers/repository_providers.dart';
+import '../../../../shared/widgets/tag_overlay.dart';
+import '../../../media_library/domain/entities/media_entity.dart';
+import '../../../tagging/domain/entities/tag_entity.dart';
+import '../view_models/slideshow_view_model.dart';
+
+final _slideshowTagsProvider = FutureProvider.autoDispose<List<TagEntity>>((ref) {
+  final lookup = ref.watch(tagLookupProvider);
+  return lookup.getAllTags();
+});
+
+class SlideshowOverlay extends ConsumerWidget {
+  const SlideshowOverlay({
+    super.key,
+    required this.state,
+    required this.viewModel,
+    required this.onClose,
+    required this.onPlayPause,
+  });
+
+  final SlideshowState state;
+  final SlideshowViewModel viewModel;
+  final VoidCallback onClose;
+  final VoidCallback onPlayPause;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final controlsHideDelay = ref.watch(slideshowControlsHideDelayProvider);
+    final sections = <Widget>[
+      _ProgressSection(viewModel: viewModel),
+      if (viewModel.currentMedia != null)
+        _TagSection(media: viewModel.currentMedia!),
+      _PlaybackSection(state: state, viewModel: viewModel, onPlayPause: onPlayPause),
+      _CloseSection(onClose: onClose),
+    ];
+
+    return Positioned(
+      bottom: 0,
+      left: 0,
+      right: 0,
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.bottomCenter,
+            end: Alignment.topCenter,
+            colors: [Colors.black.withValues(alpha: 0.8), Colors.transparent],
+          ),
+        ),
+        child: SafeArea(
+          top: false,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ..._buildSectionsWithSpacing(sections),
+              const SizedBox(height: 8),
+              _ControlsHint(delay: controlsHideDelay),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  List<Widget> _buildSectionsWithSpacing(List<Widget> sections) {
+    final builtSections = <Widget>[];
+    for (var i = 0; i < sections.length; i++) {
+      builtSections.add(sections[i]);
+      if (i != sections.length - 1) {
+        builtSections.add(const SizedBox(height: 16));
+      }
+    }
+    return builtSections;
+  }
+}
+
+class _ProgressSection extends StatelessWidget {
+  const _ProgressSection({required this.viewModel});
+
+  final SlideshowViewModel viewModel;
+
+  @override
+  Widget build(BuildContext context) {
+    return MediaProgressIndicator(
+      currentIndex: viewModel.currentIndex,
+      totalItems: viewModel.totalItems,
+      progress: viewModel.totalItems > 0
+          ? (viewModel.currentIndex + 1) / viewModel.totalItems
+          : 0,
+      counterTextStyle: const TextStyle(
+        color: Colors.white,
+        fontSize: 14,
+        fontWeight: FontWeight.w500,
+      ),
+      progressColor: Colors.white,
+      backgroundColor: Colors.white.withValues(alpha: 0.3),
+    );
+  }
+}
+
+class _TagSection extends ConsumerWidget {
+  const _TagSection({required this.media});
+
+  final MediaEntity media;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final tagsAsync = ref.watch(_slideshowTagsProvider);
+    return tagsAsync.when(
+      data: (tags) => TagOverlay(
+        tags: tags,
+        selectedTagIds: media.tagIds.toSet(),
+        onTagTapped: null,
+      ),
+      loading: () => const SizedBox.shrink(),
+      error: (_, __) => const SizedBox.shrink(),
+    );
+  }
+}
+
+class _PlaybackSection extends StatelessWidget {
+  const _PlaybackSection({
+    required this.state,
+    required this.viewModel,
+    required this.onPlayPause,
+  });
+
+  final SlideshowState state;
+  final SlideshowViewModel viewModel;
+  final VoidCallback onPlayPause;
+
+  @override
+  Widget build(BuildContext context) {
+    return MediaPlaybackControls(
+      isPlaying: viewModel.isPlaying,
+      isLooping: viewModel.isLooping,
+      isShuffleEnabled: switch (state) {
+        SlideshowPlaying(:final isShuffleEnabled) => isShuffleEnabled,
+        SlideshowPaused(:final isShuffleEnabled) => isShuffleEnabled,
+        _ => false,
+      },
+      isMuted: viewModel.isMuted,
+      isVideoLooping: viewModel.isVideoLooping,
+      progress: switch (state) {
+        SlideshowPlaying(:final progress) => progress,
+        SlideshowPaused(:final progress) => progress,
+        _ => 0.0,
+      },
+      minDuration: AppConfig.slideshowMinDuration,
+      maxDuration: AppConfig.slideshowMaxDuration,
+      currentItemDuration: switch (state) {
+        SlideshowPlaying(:final imageDisplayDuration) => imageDisplayDuration,
+        SlideshowPaused(:final imageDisplayDuration) => imageDisplayDuration,
+        _ => const Duration(seconds: 5),
+      },
+      onPlayPause: onPlayPause,
+      onNext: viewModel.nextItem,
+      onPrevious: viewModel.previousItem,
+      onToggleLoop: viewModel.toggleLoop,
+      onToggleShuffle: viewModel.toggleShuffle,
+      onToggleMute: viewModel.toggleMute,
+      onToggleVideoLoop: viewModel.toggleVideoLoop,
+      onDurationSelected: viewModel.setImageDisplayDuration,
+      visibility: MediaPlaybackControlVisibility(
+        showProgressBar: viewModel.currentMedia?.type == MediaType.video,
+        showVideoLoop: viewModel.currentMedia?.type == MediaType.video,
+      ),
+      style: MediaPlaybackControlStyle(
+        progressBackgroundColor: Colors.white.withValues(alpha: 0.3),
+      ),
+    );
+  }
+}
+
+class _CloseSection extends StatelessWidget {
+  const _CloseSection({required this.onClose});
+
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.centerRight,
+      child: IconButton(
+        icon: const Icon(Icons.close, color: Colors.white),
+        onPressed: onClose,
+        tooltip: 'Close slideshow',
+      ),
+    );
+  }
+}
+
+class _ControlsHint extends StatelessWidget {
+  const _ControlsHint({required this.delay});
+
+  final Duration delay;
+
+  @override
+  Widget build(BuildContext context) {
+    final seconds = delay.inSeconds;
+    return Text(
+      'Controls hide after $seconds second${seconds == 1 ? '' : 's'} of inactivity',
+      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+            color: Colors.white70,
+          ),
+    );
+  }
+}
+

--- a/lib/features/full_screen/presentation/screens/full_screen_viewer_screen.dart
+++ b/lib/features/full_screen/presentation/screens/full_screen_viewer_screen.dart
@@ -9,7 +9,6 @@ import '../../../media_library/domain/entities/media_entity.dart';
 import '../../../media_library/presentation/models/directory_navigation_target.dart';
 import '../../../tagging/domain/entities/tag_entity.dart';
 import '../../../tagging/presentation/view_models/tags_view_model.dart';
-import '../../../tagging/presentation/widgets/tag_chip.dart';
 import '../../domain/entities/viewer_state_entity.dart';
 import '../models/full_screen_exit_result.dart';
 import '../view_models/full_screen_view_model.dart';
@@ -21,6 +20,7 @@ import '../../../../shared/widgets/media_progress_indicator.dart';
 import '../../../../shared/widgets/permission_issue_panel.dart';
 import '../../../../shared/widgets/favorite_toggle_button.dart';
 import '../../../../shared/providers/auto_navigate_sibling_directories_provider.dart';
+import '../../../../shared/widgets/tag_overlay.dart';
 
 /// Full-screen media viewer screen
 class FullScreenViewerScreen extends ConsumerStatefulWidget {
@@ -162,7 +162,11 @@ class _FullScreenViewerScreenState
                 child: SafeArea(
                   top: true,
                   bottom: false,
-                  child: _buildTagOverlay(state),
+                  child: TagOverlay(
+                    tags: state.allTags,
+                    selectedTagIds: state.currentMedia.tagIds.toSet(),
+                    onTagTapped: _handleTagChipTapped,
+                  ),
                 ),
               ),
 
@@ -353,64 +357,6 @@ class _FullScreenViewerScreenState
           },
         ),
       ],
-    );
-  }
-
-  Widget _buildTagOverlay(FullScreenLoaded state) {
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-
-    final chipWidgets = <Widget>[];
-    if (state.allTags.isEmpty) {
-      chipWidgets.add(
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 4),
-          child: Text(
-            'No tags available',
-            style: theme.textTheme.bodyMedium?.copyWith(
-              color: colorScheme.onSurfaceVariant,
-            ),
-          ),
-        ),
-      );
-    } else {
-      for (final tag in state.allTags) {
-        chipWidgets.add(
-          TagChip(
-            key: ValueKey('fullscreen_tag_${tag.id}'),
-            tag: tag,
-            selected: state.currentMedia.tagIds.contains(tag.id),
-            compact: true,
-            onTap: () => _handleTagChipTapped(tag),
-          ),
-        );
-        chipWidgets.add(const SizedBox(width: 8));
-      }
-      if (chipWidgets.isNotEmpty) {
-        chipWidgets.removeLast();
-      }
-    }
-
-    return Material(
-      color: Colors.transparent,
-      child: Container(
-        decoration: BoxDecoration(
-          color: Colors.black.withOpacity(0.45),
-          borderRadius: BorderRadius.circular(12),
-          border: Border.all(color: Colors.white24),
-        ),
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-        child: Row(
-          children: [
-            Expanded(
-              child: SingleChildScrollView(
-                scrollDirection: Axis.horizontal,
-                child: Row(children: chipWidgets),
-              ),
-            ),
-          ],
-        ),
-      ),
     );
   }
 

--- a/lib/shared/widgets/tag_overlay.dart
+++ b/lib/shared/widgets/tag_overlay.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+
+import '../../features/tagging/domain/entities/tag_entity.dart';
+import '../../features/tagging/presentation/widgets/tag_chip.dart';
+
+/// Overlay widget that renders tag chips with a semi-transparent backdrop.
+///
+/// The overlay mirrors the appearance used by the full-screen viewer and can
+/// be composed into other displays (e.g., slideshows) to surface available
+/// tags alongside media controls.
+class TagOverlay extends StatelessWidget {
+  const TagOverlay({
+    super.key,
+    required this.tags,
+    required this.selectedTagIds,
+    this.onTagTapped,
+    this.emptyLabel = 'No tags available',
+    this.compact = true,
+  });
+
+  final List<TagEntity> tags;
+  final Set<String> selectedTagIds;
+  final ValueChanged<TagEntity>? onTagTapped;
+  final String emptyLabel;
+  final bool compact;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Material(
+      color: Colors.transparent,
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.black.withOpacity(0.45),
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: Colors.white24),
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        child: Row(
+          children: [
+            Expanded(
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: Row(children: _buildChips(theme, colorScheme)),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  List<Widget> _buildChips(ThemeData theme, ColorScheme colorScheme) {
+    if (tags.isEmpty) {
+      return [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 4),
+          child: Text(
+            emptyLabel,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
+      ];
+    }
+
+    final chipWidgets = <Widget>[];
+    for (final tag in tags) {
+      chipWidgets.add(
+        TagChip(
+          key: ValueKey('tag_overlay_${tag.id}'),
+          tag: tag,
+          selected: selectedTagIds.contains(tag.id),
+          compact: compact,
+          onTap: onTagTapped != null ? () => onTagTapped!(tag) : null,
+        ),
+      );
+      chipWidgets.add(const SizedBox(width: 8));
+    }
+
+    if (chipWidgets.isNotEmpty) {
+      chipWidgets.removeLast();
+    }
+
+    return chipWidgets;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add a reusable TagOverlay widget shared between viewers
- refactor the slideshow overlay into modular sections and include tag chips
- update the full-screen viewer to use the shared overlay component

## Testing
- flutter test *(fails: Flutter SDK not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954329f5940832080eaf7d7a6b81804)