### PR TITLE
Refactor slideshow overlay displays

### DIFF
--- a/lib/features/favorites/presentation/widgets/slideshow_overlay.dart
+++ b/lib/features/favorites/presentation/widgets/slideshow_overlay.dart
@@ -48,8 +48,10 @@ class SlideshowOverlay extends ConsumerWidget {
           media: viewModel.currentMedia,
           onClose: onClose,
         ),
+        if (viewModel.currentMedia != null)
+          _TagSection(media: viewModel.currentMedia!),
       ],
-      sectionSpacing: 0,
+      sectionSpacing: 12,
     );
 
     final bottomDisplay = _SlideshowOverlayDisplay(
@@ -63,8 +65,6 @@ class SlideshowOverlay extends ConsumerWidget {
       safeAreaBottom: true,
       sections: [
         _ProgressSection(viewModel: viewModel),
-        if (viewModel.currentMedia != null)
-          _TagSection(media: viewModel.currentMedia!),
         _PlaybackSection(
           state: state,
           viewModel: viewModel,


### PR DESCRIPTION
## Summary
- add a header overlay for slideshows that mirrors full-screen controls with a favorite toggle and close button
- refactor overlay composition into reusable display sections with configurable headers, body, and footer content
- retain existing playback, tag, and progress controls while keeping the controls hint in the footer

## Testing
- Not run (flutter command unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69543f5d71608320a69fcc9704a88cdf)