### PR TITLE
Refactor settings toggles and media grid components

### DIFF
--- a/lib/features/media_library/presentation/controllers/media_marquee_controller.dart
+++ b/lib/features/media_library/presentation/controllers/media_marquee_controller.dart
@@ -1,0 +1,184 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../domain/entities/media_entity.dart';
+import '../view_models/media_grid_view_model.dart';
+
+class MediaMarqueeController {
+  MediaMarqueeController();
+
+  final GlobalKey overlayKey = GlobalKey();
+  final Map<String, GlobalKey> mediaItemKeys = <String, GlobalKey>{};
+  final ValueNotifier<Rect?> selectionRectNotifier = ValueNotifier<Rect?>(null);
+
+  Offset? _dragStart;
+  bool _appendMode = false;
+  bool _isActive = false;
+  Set<String> _baseSelection = <String>{};
+  Set<String> _lastSelection = <String>{};
+  Map<String, Rect> _cachedItemRects = <String, Rect>{};
+
+  void pruneMediaItemKeys(Iterable<MediaEntity> media) {
+    final validIds = media.map((item) => item.id).toSet();
+    mediaItemKeys.removeWhere((id, _) => !validIds.contains(id));
+  }
+
+  RenderBox? get overlayBox {
+    final context = overlayKey.currentContext;
+    final renderObject = context?.findRenderObject();
+    if (renderObject is RenderBox && renderObject.attached) {
+      return renderObject;
+    }
+    return null;
+  }
+
+  void dispose() {
+    selectionRectNotifier.dispose();
+  }
+
+  void cacheItemRects() {
+    final overlay = overlayBox;
+    if (overlay == null) {
+      _cachedItemRects = <String, Rect>{};
+      return;
+    }
+
+    final rects = <String, Rect>{};
+    final staleKeys = <String>[];
+
+    mediaItemKeys.forEach((id, key) {
+      final context = key.currentContext;
+      final renderObject = context?.findRenderObject();
+      if (renderObject is! RenderBox || !renderObject.attached) {
+        staleKeys.add(id);
+        return;
+      }
+      final topLeft = renderObject.localToGlobal(
+        Offset.zero,
+        ancestor: overlay,
+      );
+      rects[id] = Rect.fromLTWH(
+        topLeft.dx,
+        topLeft.dy,
+        renderObject.size.width,
+        renderObject.size.height,
+      );
+    });
+
+    for (final id in staleKeys) {
+      mediaItemKeys.remove(id);
+    }
+
+    _cachedItemRects = rects;
+  }
+
+  bool handlePointerDown(
+    PointerDownEvent event,
+    MediaViewModel viewModel,
+  ) {
+    if (event.kind != PointerDeviceKind.mouse ||
+        (event.buttons & kPrimaryMouseButton) == 0) {
+      return false;
+    }
+
+    cacheItemRects();
+    final overlay = overlayBox;
+    if (overlay == null) {
+      return false;
+    }
+
+    final localPosition = overlay.globalToLocal(event.position);
+    if (_isPointInsideAnyRect(localPosition, _cachedItemRects.values)) {
+      return false;
+    }
+
+    _baseSelection = Set<String>.from(viewModel.selectedMediaIds);
+    _lastSelection = Set<String>.from(viewModel.selectedMediaIds);
+    _appendMode = _isMultiSelectModifierPressed();
+    _isActive = true;
+    _dragStart = localPosition;
+
+    selectionRectNotifier.value =
+        Rect.fromPoints(localPosition, localPosition);
+    _updateSelection(viewModel);
+    return true;
+  }
+
+  void handlePointerMove(
+    PointerMoveEvent event,
+    MediaViewModel viewModel,
+  ) {
+    if (!_isActive || _dragStart == null) {
+      return;
+    }
+
+    final overlay = overlayBox;
+    if (overlay == null) {
+      return;
+    }
+
+    final localPosition = overlay.globalToLocal(event.position);
+    selectionRectNotifier.value =
+        Rect.fromPoints(_dragStart!, localPosition);
+    _updateSelection(viewModel);
+  }
+
+  void endSelection() {
+    _isActive = false;
+    _dragStart = null;
+    _appendMode = false;
+    _baseSelection = <String>{};
+    _lastSelection = <String>{};
+    selectionRectNotifier.value = null;
+  }
+
+  bool _isPointInsideAnyRect(Offset point, Iterable<Rect> rects) {
+    for (final rect in rects) {
+      if (rect.contains(point)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void _updateSelection(MediaViewModel viewModel) {
+    if (!_isActive) {
+      return;
+    }
+
+    final selectionRect = selectionRectNotifier.value;
+    final intersectingIds = <String>{};
+
+    if (selectionRect != null) {
+      for (final entry in _cachedItemRects.entries) {
+        if (entry.value.overlaps(selectionRect)) {
+          intersectingIds.add(entry.key);
+        }
+      }
+    }
+
+    final desiredSelection = _appendMode
+        ? {..._baseSelection, ...intersectingIds}
+        : intersectingIds;
+
+    if (setEquals(desiredSelection, _lastSelection)) {
+      return;
+    }
+
+    _lastSelection = desiredSelection;
+    viewModel.selectMediaRange(desiredSelection, append: false);
+  }
+
+  bool _isMultiSelectModifierPressed() {
+    final pressed = HardwareKeyboard.instance.logicalKeysPressed;
+    return pressed.contains(LogicalKeyboardKey.shiftLeft) ||
+        pressed.contains(LogicalKeyboardKey.shiftRight) ||
+        pressed.contains(LogicalKeyboardKey.controlLeft) ||
+        pressed.contains(LogicalKeyboardKey.controlRight) ||
+        pressed.contains(LogicalKeyboardKey.metaLeft) ||
+        pressed.contains(LogicalKeyboardKey.metaRight) ||
+        pressed.contains(LogicalKeyboardKey.altLeft) ||
+        pressed.contains(LogicalKeyboardKey.altRight);
+  }
+}

--- a/lib/features/media_library/presentation/controllers/media_navigation_handler.dart
+++ b/lib/features/media_library/presentation/controllers/media_navigation_handler.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+
+import '../models/directory_navigation_target.dart';
+import '../screens/media_grid_screen.dart';
+
+class MediaNavigationHandler {
+  MediaNavigationHandler({
+    List<DirectoryNavigationTarget>? siblings,
+    int? currentIndex,
+  }) {
+    updateNavigationContext(siblings, currentIndex);
+  }
+
+  List<DirectoryNavigationTarget> _siblingNavigationTargets = const [];
+  int _currentDirectoryNavigationIndex = 0;
+
+  List<DirectoryNavigationTarget> get siblingNavigationTargets =>
+      _siblingNavigationTargets;
+  int get currentDirectoryNavigationIndex => _currentDirectoryNavigationIndex;
+  bool get hasSiblingNavigation => _siblingNavigationTargets.length > 1;
+  bool get canNavigateToPrevious => _currentDirectoryNavigationIndex > 0;
+  bool get canNavigateToNext =>
+      _currentDirectoryNavigationIndex < _siblingNavigationTargets.length - 1;
+
+  void updateNavigationContext(
+    List<DirectoryNavigationTarget>? siblings,
+    int? currentIndex,
+  }) {
+    _siblingNavigationTargets = List<DirectoryNavigationTarget>.from(
+      siblings ?? const [],
+    );
+    if (_siblingNavigationTargets.isEmpty) {
+      _currentDirectoryNavigationIndex = 0;
+      return;
+    }
+
+    final maxIndex = _siblingNavigationTargets.length - 1;
+    final safeIndex = (currentIndex ?? 0).clamp(0, maxIndex);
+    _currentDirectoryNavigationIndex = safeIndex;
+  }
+
+  void navigateToSibling(
+    BuildContext context,
+    int offset,
+    void Function(DirectoryNavigationTarget target, int targetIndex) onNavigate,
+  ) {
+    if (_siblingNavigationTargets.length < 2) {
+      return;
+    }
+
+    final targetIndex = _currentDirectoryNavigationIndex + offset;
+    if (targetIndex < 0 || targetIndex >= _siblingNavigationTargets.length) {
+      return;
+    }
+
+    final target = _siblingNavigationTargets[targetIndex];
+    onNavigate(target, targetIndex);
+  }
+
+  void handleSwipe(
+    DragEndDetails details,
+    BuildContext context,
+    void Function(DirectoryNavigationTarget target, int targetIndex) onNavigate,
+  ) {
+    final velocity = details.primaryVelocity ?? 0;
+    if (velocity < -100) {
+      navigateToSibling(context, 1, onNavigate);
+    } else if (velocity > 100) {
+      navigateToSibling(context, -1, onNavigate);
+    }
+  }
+
+  PageRouteBuilder<dynamic> buildNavigationRoute({
+    required MediaGridScreen destination,
+    required bool isBackwardNavigation,
+  }) {
+    final beginOffset = isBackwardNavigation
+        ? const Offset(-1, 0)
+        : const Offset(1, 0);
+
+    return PageRouteBuilder(
+      transitionDuration: const Duration(milliseconds: 250),
+      reverseTransitionDuration: const Duration(milliseconds: 250),
+      pageBuilder: (context, animation, secondaryAnimation) => destination,
+      transitionsBuilder: (context, animation, secondaryAnimation, child) {
+        final tween = Tween(
+          begin: beginOffset,
+          end: Offset.zero,
+        ).chain(CurveTween(curve: Curves.easeInOutCubic));
+
+        return SlideTransition(
+          position: animation.drive(tween),
+          child: child,
+        );
+      },
+    );
+  }
+
+  bool isBackwardNavigation(int? targetIndex) {
+    if (!hasSiblingNavigation) {
+      return false;
+    }
+    return (targetIndex ?? _currentDirectoryNavigationIndex) <
+        _currentDirectoryNavigationIndex;
+  }
+}

--- a/lib/features/media_library/presentation/widgets/media_filter_bar.dart
+++ b/lib/features/media_library/presentation/widgets/media_filter_bar.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/constants/ui_constants.dart';
+import '../../../favorites/presentation/view_models/favorites_view_model.dart';
+import '../../../tagging/presentation/widgets/tag_filter_chips.dart';
+import '../../domain/entities/media_entity.dart';
+import '../view_models/media_grid_view_model.dart';
+
+class MediaFilterBar extends StatelessWidget {
+  const MediaFilterBar({
+    super.key,
+    required this.viewModel,
+    required this.state,
+    required this.favoritesState,
+    required this.isSelectionMode,
+  });
+
+  final MediaViewModel viewModel;
+  final MediaState state;
+  final FavoritesState favoritesState;
+  final bool isSelectionMode;
+
+  @override
+  Widget build(BuildContext context) {
+    final selectedTagIds = state is MediaLoaded
+        ? state.selectedTagIds
+        : const <String>[];
+    final showFavoritesOnly = state is MediaLoaded
+        ? state.showFavoritesOnly
+        : viewModel.showFavoritesOnly;
+    final showUntaggedOnly = state is MediaLoaded
+        ? state.showUntaggedOnly
+        : viewModel.showUntaggedOnly;
+    final visibleMediaTypes = state is MediaLoaded
+        ? state.visibleMediaTypes
+        : viewModel.visibleMediaTypes;
+    final hasFavoriteMedia = switch (favoritesState) {
+      FavoritesLoaded(:final favorites) => favorites.isNotEmpty,
+      _ => false,
+    };
+    final shouldShowFavoritesChip = hasFavoriteMedia || showFavoritesOnly;
+
+    return Container(
+      padding: UiSpacing.tagFilterPadding,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Wrap(
+            spacing: 12,
+            runSpacing: 8,
+            children: [
+              for (final type in [
+                MediaType.image,
+                MediaType.video,
+                MediaType.directory,
+              ])
+                FilterChip(
+                  label: Text(type.label),
+                  avatar: Icon(_iconForType(type)),
+                  selected: visibleMediaTypes.contains(type),
+                  onSelected: (selected) => _onMediaTypeSelected(
+                    type,
+                    selected,
+                    visibleMediaTypes,
+                  ),
+                ),
+              if (shouldShowFavoritesChip)
+                FilterChip(
+                  label: const Text('Favorites'),
+                  avatar: const Icon(Icons.star, color: Colors.amber),
+                  selected: showFavoritesOnly,
+                  onSelected: (value) {
+                    if (!hasFavoriteMedia && value) {
+                      return;
+                    }
+                    viewModel.setShowFavoritesOnly(value);
+                  },
+                ),
+              FilterChip(
+                label: const Text('Untagged'),
+                avatar: const Icon(Icons.label_off),
+                selected: showUntaggedOnly,
+                onSelected: (value) async {
+                  await viewModel.setShowUntaggedOnly(value);
+                },
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          TagFilterChips(
+            selectedTagIds:
+                isSelectionMode ? viewModel.tagIdsInSelection() : selectedTagIds,
+            onSelectionChanged:
+                isSelectionMode ? (_) {} : viewModel.filterByTags,
+            onTagTapped: isSelectionMode
+                ? (tag, _) => viewModel.toggleTagForSelection(tag)
+                : null,
+            showAllButton: !isSelectionMode,
+          ),
+        ],
+      ),
+    );
+  }
+
+  IconData _iconForType(MediaType type) => switch (type) {
+        MediaType.image => Icons.image_outlined,
+        MediaType.video => Icons.movie_creation_outlined,
+        MediaType.directory => Icons.folder,
+        MediaType.text => Icons.description_outlined,
+      };
+
+  void _onMediaTypeSelected(
+    MediaType type,
+    bool isSelected,
+    Set<MediaType> currentSelection,
+  ) {
+    final updatedSelection = Set<MediaType>.from(currentSelection);
+    if (isSelected) {
+      updatedSelection.add(type);
+    } else {
+      if (updatedSelection.length == 1) {
+        return; // Prevent clearing all types
+      }
+      updatedSelection.remove(type);
+    }
+
+    viewModel.setVisibleMediaTypes(updatedSelection);
+  }
+}

--- a/lib/features/media_library/presentation/widgets/media_grid_view.dart
+++ b/lib/features/media_library/presentation/widgets/media_grid_view.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+import '../../../../core/constants/ui_constants.dart';
+import '../../domain/entities/media_entity.dart';
+import '../controllers/media_marquee_controller.dart';
+import '../view_models/media_grid_view_model.dart';
+import 'media_grid_item.dart';
+
+class MediaGridView extends StatelessWidget {
+  const MediaGridView({
+    super.key,
+    required this.media,
+    required this.columns,
+    required this.viewModel,
+    required this.selectedMediaIds,
+    required this.isSelectionMode,
+    required this.marqueeController,
+    required this.onMediaTap,
+    required this.onMediaDoubleTap,
+    required this.onMediaLongPress,
+    required this.onMediaSecondaryTap,
+  });
+
+  final List<MediaEntity> media;
+  final int columns;
+  final MediaViewModel viewModel;
+  final Set<String> selectedMediaIds;
+  final bool isSelectionMode;
+  final MediaMarqueeController marqueeController;
+  final void Function(MediaEntity media) onMediaTap;
+  final void Function(MediaEntity media) onMediaDoubleTap;
+  final void Function(MediaEntity media) onMediaLongPress;
+  final void Function(MediaEntity media) onMediaSecondaryTap;
+
+  @override
+  Widget build(BuildContext context) {
+    marqueeController.pruneMediaItemKeys(media);
+    final gridView = GridView.builder(
+      padding: UiSpacing.gridPadding,
+      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: columns,
+        crossAxisSpacing: UiGrid.crossAxisSpacing,
+        mainAxisSpacing: UiGrid.mainAxisSpacing,
+        childAspectRatio: UiGrid.childAspectRatio,
+      ),
+      itemCount: media.length,
+      itemBuilder: (context, index) {
+        final mediaItem = media[index];
+        final isSelected = selectedMediaIds.contains(mediaItem.id);
+        final itemKey = marqueeController.mediaItemKeys.putIfAbsent(
+          mediaItem.id,
+          () => GlobalKey(),
+        );
+        return MediaGridItem(
+          key: itemKey,
+          media: mediaItem,
+          onTap: () => onMediaTap(mediaItem),
+          onDoubleTap: () => onMediaDoubleTap(mediaItem),
+          onLongPress: () => onMediaLongPress(mediaItem),
+          onSecondaryTap: () => onMediaSecondaryTap(mediaItem),
+          onOperationComplete: () => viewModel.loadMedia(),
+          onSelectionToggle: () => viewModel.toggleMediaSelection(mediaItem.id),
+          isSelected: isSelected,
+          isSelectionMode: isSelectionMode,
+        );
+      },
+    );
+
+    return Listener(
+      behavior: HitTestBehavior.translucent,
+      onPointerDown: (event) =>
+          marqueeController.handlePointerDown(event, viewModel),
+      onPointerMove: (event) {
+        if (event is PointerMoveEvent) {
+          marqueeController.handlePointerMove(event, viewModel);
+        }
+      },
+      onPointerUp: (_) => marqueeController.endSelection(),
+      onPointerCancel: (_) => marqueeController.endSelection(),
+      child: Stack(
+        key: marqueeController.overlayKey,
+        children: [
+          Positioned.fill(child: gridView),
+          ValueListenableBuilder<Rect?>(
+            valueListenable: marqueeController.selectionRectNotifier,
+            builder: (context, selectionRect, _) {
+              if (selectionRect == null) {
+                return const SizedBox.shrink();
+              }
+              return Positioned.fromRect(
+                rect: selectionRect,
+                child: IgnorePointer(
+                  child: Container(
+                    decoration: BoxDecoration(
+                      color: Theme.of(context)
+                          .colorScheme
+                          .primary
+                          .withOpacity(0.12),
+                      border: Border.all(
+                        color: Theme.of(context).colorScheme.primary,
+                        width: UiSizing.borderWidth,
+                      ),
+                    ),
+                  ),
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/settings/presentation/widgets/destructive_confirmation_dialog.dart
+++ b/lib/features/settings/presentation/widgets/destructive_confirmation_dialog.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+Future<void> showDestructiveConfirmationDialog(
+  BuildContext context, {
+  required String title,
+  required String content,
+  required String confirmLabel,
+  required Future<void> Function() onConfirm,
+  String successMessage = 'Action completed successfully',
+  String errorPrefix = 'Action failed',
+}) async {
+  return showDialog(
+    context: context,
+    builder: (dialogContext) => AlertDialog(
+      title: Text(title),
+      content: Text(content),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(dialogContext).pop(),
+          child: const Text('Cancel'),
+        ),
+        TextButton(
+          onPressed: () async {
+            Navigator.of(dialogContext).pop();
+            try {
+              await onConfirm();
+              if (!context.mounted) return;
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text(successMessage),
+                  backgroundColor: Colors.green,
+                ),
+              );
+            } catch (e) {
+              if (!context.mounted) return;
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text('$errorPrefix: $e'),
+                  backgroundColor: Colors.red,
+                ),
+              );
+            }
+          },
+          child: Text(confirmLabel, style: const TextStyle(color: Colors.red)),
+        ),
+      ],
+    ),
+  );
+}

--- a/lib/features/settings/presentation/widgets/settings_switch_tile.dart
+++ b/lib/features/settings/presentation/widgets/settings_switch_tile.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class SettingsSwitchTile extends StatelessWidget {
+  const SettingsSwitchTile({
+    super.key,
+    required this.title,
+    required this.subtitle,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final String title;
+  final String subtitle;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(title),
+      subtitle: Text(subtitle),
+      trailing: Switch(
+        value: value,
+        onChanged: onChanged,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable settings toggle tile and shared destructive confirmation dialog
- update settings screen to use shared widgets for toggles and confirmations
- extract media grid filtering, navigation, marquee selection, and grid rendering into dedicated components

## Testing
- Not run (environment not configured for Flutter tooling)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695449e398e8832091a9e6165fb536e7)