### PR TITLE
Add media cache cleanup option in settings

### DIFF
--- a/lib/features/media_library/data/isar/isar_media_data_source.dart
+++ b/lib/features/media_library/data/isar/isar_media_data_source.dart
@@ -239,6 +239,14 @@ class IsarMediaDataSource {
     }, 'Failed to migrate media directory references');
   }
 
+  /// Removes every persisted media entry.
+  Future<void> clearMedia() async {
+    await _executeSafely(
+      () async => _mediaStore.clear(),
+      'Failed to clear media cache',
+    );
+  }
+
   Future<void> _executeSafely(
     Future<void> Function() action,
     String errorMessage,

--- a/lib/features/media_library/data/repositories/filesystem_media_repository_impl.dart
+++ b/lib/features/media_library/data/repositories/filesystem_media_repository_impl.dart
@@ -344,6 +344,11 @@ class FilesystemMediaRepositoryImpl implements MediaRepository {
   }
 
   @override
+  Future<void> removeMediaNotInDirectories(List<String> directoryIds) {
+    return _mediaDataSource.removeMediaNotInDirectories(directoryIds);
+  }
+
+  @override
   Future<void> clearAllMedia() {
     return _mediaDataSource.clearMedia();
   }

--- a/lib/features/media_library/data/repositories/filesystem_media_repository_impl.dart
+++ b/lib/features/media_library/data/repositories/filesystem_media_repository_impl.dart
@@ -343,6 +343,11 @@ class FilesystemMediaRepositoryImpl implements MediaRepository {
     await _mediaDataSource.removeMediaForDirectory(directoryId);
   }
 
+  @override
+  Future<void> clearAllMedia() {
+    return _mediaDataSource.clearMedia();
+  }
+
   Future<MediaEntity?> _scanDirectoriesForMedia(String id) async {
     final directories = await _directoryRepository.getDirectories();
     for (final directory in directories) {

--- a/lib/features/media_library/data/repositories/media_repository_impl.dart
+++ b/lib/features/media_library/data/repositories/media_repository_impl.dart
@@ -98,6 +98,11 @@ class MediaRepositoryImpl implements MediaRepository {
     await _mediaDataSource.removeMediaForDirectory(directoryId);
   }
 
+  @override
+  Future<void> removeMediaNotInDirectories(List<String> directoryIds) {
+    return _mediaDataSource.removeMediaNotInDirectories(directoryIds);
+  }
+
   /// Converts MediaModel to MediaEntity.
   MediaEntity _modelToEntity(MediaModel model) {
     return MediaEntity(

--- a/lib/features/media_library/domain/repositories/media_repository.dart
+++ b/lib/features/media_library/domain/repositories/media_repository.dart
@@ -43,4 +43,8 @@ abstract class MediaRepository {
 
   /// Removes all cached media entries for a directory.
   Future<void> removeMediaForDirectory(String directoryId);
+
+  /// Removes every persisted media entry, clearing cached results across
+  /// directories.
+  Future<void> clearAllMedia();
 }

--- a/lib/features/media_library/domain/repositories/media_repository.dart
+++ b/lib/features/media_library/domain/repositories/media_repository.dart
@@ -44,6 +44,10 @@ abstract class MediaRepository {
   /// Removes all cached media entries for a directory.
   Future<void> removeMediaForDirectory(String directoryId);
 
+  /// Removes cached media whose directories are no longer present in the
+  /// library, preserving entries (and their tags) for existing directories.
+  Future<void> removeMediaNotInDirectories(List<String> directoryIds);
+
   /// Removes every persisted media entry, clearing cached results across
   /// directories.
   Future<void> clearAllMedia();

--- a/lib/features/media_library/domain/use_cases/clear_media_cache_use_case.dart
+++ b/lib/features/media_library/domain/use_cases/clear_media_cache_use_case.dart
@@ -1,0 +1,13 @@
+import '../repositories/media_repository.dart';
+
+/// Use case for clearing all persisted media cache entries.
+class ClearMediaCacheUseCase {
+  const ClearMediaCacheUseCase(this._mediaRepository);
+
+  final MediaRepository _mediaRepository;
+
+  /// Executes the use case to wipe cached media across directories.
+  Future<void> call() {
+    return _mediaRepository.clearAllMedia();
+  }
+}

--- a/lib/features/media_library/domain/use_cases/clear_media_cache_use_case.dart
+++ b/lib/features/media_library/domain/use_cases/clear_media_cache_use_case.dart
@@ -1,13 +1,23 @@
+import '../repositories/directory_repository.dart';
 import '../repositories/media_repository.dart';
 
 /// Use case for clearing all persisted media cache entries.
 class ClearMediaCacheUseCase {
-  const ClearMediaCacheUseCase(this._mediaRepository);
+  const ClearMediaCacheUseCase(
+    this._mediaRepository,
+    this._directoryRepository,
+  );
 
   final MediaRepository _mediaRepository;
+  final DirectoryRepository _directoryRepository;
 
-  /// Executes the use case to wipe cached media across directories.
-  Future<void> call() {
-    return _mediaRepository.clearAllMedia();
+  /// Executes the use case to remove cached media that no longer belongs to
+  /// directories in the library without touching tag assignments for current
+  /// media.
+  Future<void> call() async {
+    final directories = await _directoryRepository.getDirectories();
+    final directoryIds = directories.map((directory) => directory.id).toList();
+
+    await _mediaRepository.removeMediaNotInDirectories(directoryIds);
   }
 }

--- a/lib/shared/providers/repository_providers.dart
+++ b/lib/shared/providers/repository_providers.dart
@@ -215,7 +215,10 @@ final clearDirectoriesUseCaseProvider = Provider<ClearDirectoriesUseCase>((ref) 
 });
 
 final clearMediaCacheUseCaseProvider = Provider<ClearMediaCacheUseCase>((ref) {
-  return ClearMediaCacheUseCase(ref.watch(mediaRepositoryProvider));
+  return ClearMediaCacheUseCase(
+    ref.watch(mediaRepositoryProvider),
+    ref.watch(directoryRepositoryProvider),
+  );
 });
 
 final deleteFileUseCaseProvider = Provider<DeleteFileUseCase>((ref) {

--- a/lib/shared/providers/repository_providers.dart
+++ b/lib/shared/providers/repository_providers.dart
@@ -24,6 +24,7 @@ import '../../features/media_library/domain/use_cases/add_directory_use_case.dar
 import '../../features/media_library/domain/use_cases/clear_directories_use_case.dart';
 import '../../features/media_library/domain/use_cases/delete_directory_use_case.dart';
 import '../../features/media_library/domain/use_cases/delete_file_use_case.dart';
+import '../../features/media_library/domain/use_cases/clear_media_cache_use_case.dart';
 import '../../features/media_library/domain/use_cases/get_directories_use_case.dart';
 import '../../features/media_library/domain/use_cases/get_media_use_case.dart';
 import '../../features/media_library/domain/use_cases/remove_directory_use_case.dart';
@@ -211,6 +212,10 @@ final updateDirectoryAccessUseCaseProvider =
 
 final clearDirectoriesUseCaseProvider = Provider<ClearDirectoriesUseCase>((ref) {
   return ClearDirectoriesUseCase(ref.watch(directoryRepositoryProvider));
+});
+
+final clearMediaCacheUseCaseProvider = Provider<ClearMediaCacheUseCase>((ref) {
+  return ClearMediaCacheUseCase(ref.watch(mediaRepositoryProvider));
 });
 
 final deleteFileUseCaseProvider = Provider<DeleteFileUseCase>((ref) {


### PR DESCRIPTION
## Summary
- add a clear media cache use case and repository hook to purge persisted media entries
- expose a Settings action that cleans cached media and refreshes tag state to remove stale items
- wire the media data source to support full cache clearing

## Testing
- not run (Dart SDK not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954ac426e008320b75faec2744fcb7b)