### PR TITLE
Add directory filtering to Tags screen

### DIFF
--- a/lib/features/tagging/presentation/widgets/tag_directory_chip.dart
+++ b/lib/features/tagging/presentation/widgets/tag_directory_chip.dart
@@ -12,11 +12,15 @@ class TagDirectoryChip extends ConsumerStatefulWidget {
     required this.directory,
     required this.mediaCount,
     required this.onTap,
+    this.togglable = false,
+    this.selected = false,
   });
 
   final DirectoryEntity directory;
   final int mediaCount;
   final VoidCallback onTap;
+  final bool togglable;
+  final bool selected;
 
   @override
   ConsumerState<TagDirectoryChip> createState() => _TagDirectoryChipState();
@@ -93,14 +97,24 @@ class _TagDirectoryChipState extends ConsumerState<TagDirectoryChip> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final chip = ActionChip(
-      onPressed: () {
-        _removeOverlay();
-        widget.onTap();
-      },
-      avatar: Icon(Icons.folder, color: theme.colorScheme.primary),
-      label: Text('${widget.directory.name} (${widget.mediaCount})'),
-    );
+    final chip = widget.togglable
+        ? FilterChip(
+            selected: widget.selected,
+            onSelected: (_) {
+              _removeOverlay();
+              widget.onTap();
+            },
+            avatar: Icon(Icons.folder, color: theme.colorScheme.primary),
+            label: Text('${widget.directory.name} (${widget.mediaCount})'),
+          )
+        : ActionChip(
+            onPressed: () {
+              _removeOverlay();
+              widget.onTap();
+            },
+            avatar: Icon(Icons.folder, color: theme.colorScheme.primary),
+            label: Text('${widget.directory.name} (${widget.mediaCount})'),
+          );
 
     return MouseRegion(
       onEnter: (_) => _showOverlay(),


### PR DESCRIPTION
## Summary
- add a directory filter section to the Tags screen with hover previews
- track directory filter selections in the tags view model and apply them to displayed media
- allow directory chips to toggle selection while reusing the existing preview overlay

## Testing
- Not run (environment missing Flutter/Dart tooling)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954d7659b1483208b4e8f754dea2847)