### PR TITLE
Fix directory-only tag directory filter

### DIFF
--- a/lib/features/tagging/presentation/widgets/tag_directory_chip.dart
+++ b/lib/features/tagging/presentation/widgets/tag_directory_chip.dart
@@ -12,11 +12,13 @@ class TagDirectoryChip extends ConsumerStatefulWidget {
     required this.directory,
     required this.mediaCount,
     required this.onTap,
+    this.isSelected = false,
   });
 
   final DirectoryEntity directory;
   final int mediaCount;
   final VoidCallback onTap;
+  final bool isSelected;
 
   @override
   ConsumerState<TagDirectoryChip> createState() => _TagDirectoryChipState();
@@ -93,8 +95,10 @@ class _TagDirectoryChipState extends ConsumerState<TagDirectoryChip> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final chip = ActionChip(
-      onPressed: () {
+    final chip = FilterChip(
+      selected: widget.isSelected,
+      showCheckmark: false,
+      onSelected: (_) {
         _removeOverlay();
         widget.onTap();
       },


### PR DESCRIPTION
## Summary
- ensure directory selection filters media after tag aggregation so directory-only filtering shows results
- keep directory sections visible when directory filters are active without tag selections
- add helper to constrain media lists to selected directories

## Testing
- not run (environment not configured for Flutter/Dart tools)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954d7659b1483208b4e8f754dea2847)