### PR TITLE
Update widget smoke tests for current navigation

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -23,7 +23,7 @@ void main() {
     // Verify that our app shows the main navigation elements
     expect(find.byType(BottomNavigationBar), findsOneWidget);
     expect(find.text('Library'), findsOneWidget);
-    expect(find.text('Favorites'), findsOneWidget);
+    expect(find.text('Tags'), findsOneWidget);
     expect(find.text('Settings'), findsOneWidget);
   });
 
@@ -32,8 +32,9 @@ void main() {
       const ProviderScope(child: MyApp()),
     );
 
-    // Wait for any async operations to complete
-    await tester.pumpAndSettle();
+    // Wait for the first frame; avoid long pumpAndSettle loops because providers
+    // may schedule background work during initialization.
+    await tester.pump();
 
     // Verify the app is still functional after async operations
     expect(find.byType(MaterialApp), findsOneWidget);


### PR DESCRIPTION
## Summary
- align the widget smoke test with the current bottom navigation labels
- reduce settling in initialization test to avoid unnecessary wait loops

## Testing
- not run (dependency resolution issues prevented flutter test from completing in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954ebf36fb8832093858d397a92ba41)