### PR TITLE
Enable tag creation from carousel view

### DIFF
--- a/lib/shared/widgets/tag_overlay.dart
+++ b/lib/shared/widgets/tag_overlay.dart
@@ -16,6 +16,7 @@ class TagOverlay extends StatelessWidget {
     this.onTagTapped,
     this.emptyLabel = 'No tags available',
     this.compact = true,
+    this.trailing,
   });
 
   final List<TagEntity> tags;
@@ -23,6 +24,7 @@ class TagOverlay extends StatelessWidget {
   final ValueChanged<TagEntity>? onTagTapped;
   final String emptyLabel;
   final bool compact;
+  final Widget? trailing;
 
   @override
   Widget build(BuildContext context) {
@@ -46,6 +48,10 @@ class TagOverlay extends StatelessWidget {
                 child: Row(children: _buildChips(theme, colorScheme)),
               ),
             ),
+            if (trailing != null) ...[
+              const SizedBox(width: 8),
+              trailing!,
+            ],
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- add a tag header action in the full-screen carousel to open the tag editor
- reuse the shared tag selection dialog to create and assign tags to the current media
- allow the tag overlay widget to host trailing controls like the new add button

## Testing
- flutter test *(fails: flutter is not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954f251955883209c3c27d1a1071c92)