### PR TITLE
Run favorite refreshes asynchronously after toggles

### DIFF
--- a/lib/features/favorites/presentation/view_models/favorites_view_model.dart
+++ b/lib/features/favorites/presentation/view_models/favorites_view_model.dart
@@ -359,8 +359,8 @@ class FavoritesViewModel extends StateNotifier<FavoritesState> {
         await loadFavorites();
       } catch (e, stackTrace) {
         LoggingService.instance.error(
-          'Failed to refresh favorites: $e',
-          stackTrace: stackTrace,
+          'Failed to refresh favorites: $e', 
+
         );
       }
     }());

--- a/lib/features/favorites/presentation/view_models/favorites_view_model.dart
+++ b/lib/features/favorites/presentation/view_models/favorites_view_model.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../domain/entities/favorite_entity.dart';
@@ -271,7 +273,7 @@ class FavoritesViewModel extends StateNotifier<FavoritesState> {
       }
 
       if (additions.isNotEmpty || removals.isNotEmpty) {
-        await loadFavorites();
+        _refreshFavoritesInBackground();
       }
 
       return FavoritesBatchResult(
@@ -336,7 +338,7 @@ class FavoritesViewModel extends StateNotifier<FavoritesState> {
       }
 
       if (additions.isNotEmpty || removals.isNotEmpty) {
-        await loadFavorites();
+        _refreshFavoritesInBackground();
       }
 
       return FavoritesBatchResult(
@@ -349,6 +351,19 @@ class FavoritesViewModel extends StateNotifier<FavoritesState> {
       }
       return const FavoritesBatchResult.empty();
     }
+  }
+
+  void _refreshFavoritesInBackground() {
+    unawaited(() async {
+      try {
+        await loadFavorites();
+      } catch (e, stackTrace) {
+        LoggingService.instance.error(
+          'Failed to refresh favorites: $e',
+          stackTrace: stackTrace,
+        );
+      }
+    }());
   }
 
   /// Checks if a media item is favorited.

--- a/lib/features/media_library/data/isar/isar_media_data_source.dart
+++ b/lib/features/media_library/data/isar/isar_media_data_source.dart
@@ -365,7 +365,7 @@ class IsarMediaCollectionStore implements MediaCollectionStore {
 
   @override
   Future<void> clear() async {
-    await _collection.clear();
+    await _isar.writeTxn(() async => _collection.clear());
   }
 
   @override

--- a/lib/features/media_library/data/repositories/media_repository_impl.dart
+++ b/lib/features/media_library/data/repositories/media_repository_impl.dart
@@ -116,5 +116,10 @@ class MediaRepositoryImpl implements MediaRepository {
       directoryId: model.directoryId,
     );
   }
+  
+  @override
+  Future<void> clearAllMedia() {
+    return _mediaDataSource.clearMedia();
+  }
 
 }


### PR DESCRIPTION
## Summary
- trigger favorites reloads in the background after toggle operations instead of blocking
- keep refresh failure logging so issues are still captured while toggles stay responsive

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954f9ef726883208a8f3dffb2250caa)