### PR TITLE
Add favorites filter option to library tab

### DIFF
--- a/lib/features/media_library/presentation/screens/media_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/media_grid_screen.dart
@@ -472,13 +472,6 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
     final visibleMediaTypes = state is MediaLoaded
         ? state.visibleMediaTypes
         : viewModel.visibleMediaTypes;
-    final favoritesState = ref.watch(favoritesViewModelProvider);
-    final hasFavoriteMedia = switch (favoritesState) {
-      FavoritesLoaded(:final favorites) => favorites.isNotEmpty,
-      _ => false,
-    };
-    final shouldShowFavoritesChip = hasFavoriteMedia || showFavoritesOnly;
-
     return Container(
       padding: UiSpacing.tagFilterPadding,
       child: Column(
@@ -504,18 +497,12 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
                     viewModel,
                   ),
                 ),
-              if (shouldShowFavoritesChip)
-                FilterChip(
-                  label: const Text('Favorites'),
-                  avatar: const Icon(Icons.star, color: Colors.amber),
-                  selected: showFavoritesOnly,
-                  onSelected: (value) {
-                    if (!hasFavoriteMedia && value) {
-                      return;
-                    }
-                    viewModel.setShowFavoritesOnly(value);
-                  },
-                ),
+              FilterChip(
+                label: const Text('Favorites'),
+                avatar: const Icon(Icons.star, color: Colors.amber),
+                selected: showFavoritesOnly,
+                onSelected: viewModel.setShowFavoritesOnly,
+              ),
               FilterChip(
                 label: const Text('Untagged'),
                 avatar: const Icon(Icons.label_off),

--- a/lib/features/media_library/presentation/view_models/media_grid_view_model.dart
+++ b/lib/features/media_library/presentation/view_models/media_grid_view_model.dart
@@ -160,11 +160,6 @@ class MediaViewModel extends StateNotifier<MediaState> {
         };
         if (!listEquals(favorites, _favoriteMediaIds)) {
           _favoriteMediaIds = favorites;
-          if (_showFavoritesOnly && _favoriteMediaIds.isEmpty) {
-            _showFavoritesOnly = false;
-            _emitLoadedStateFromCache();
-            return;
-          }
           if (_showFavoritesOnly) {
             _emitLoadedStateFromCache();
           }
@@ -625,9 +620,6 @@ class MediaViewModel extends StateNotifier<MediaState> {
   /// Filters media to only show favorites when [value] is true.
   void setShowFavoritesOnly(bool value) {
     if (_showFavoritesOnly == value) {
-      return;
-    }
-    if (value && _favoriteMediaIds.isEmpty) {
       return;
     }
     _showFavoritesOnly = value;


### PR DESCRIPTION
## Summary
- add a Favorites filter chip alongside existing media type filters in the Library tab
- allow favorites-only filtering even when favorites are not yet loaded

## Testing
- not run (environment lacks Dart/Flutter tooling)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69550accfc688320b130b41893cbcf0a)