### PR TITLE
Make tag chips hover-scrollable across views

### DIFF
--- a/lib/features/tagging/presentation/widgets/selectable_tag_chip_strip.dart
+++ b/lib/features/tagging/presentation/widgets/selectable_tag_chip_strip.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../../shared/widgets/hover_scroll_view.dart';
 import '../../domain/entities/tag_entity.dart';
 import 'tag_chip.dart';
 
@@ -60,8 +61,9 @@ class SelectableTagChipStrip extends StatelessWidget {
     final remainingCount =
         showOverflowChip ? tags.length - maxChipsToShow! : 0;
 
-    return SingleChildScrollView(
+    return HoverScrollView(
       scrollDirection: Axis.horizontal,
+      physics: const ClampingScrollPhysics(),
       child: Row(
         children: [
           if (showAllChip) ...[

--- a/lib/shared/widgets/hover_scroll_view.dart
+++ b/lib/shared/widgets/hover_scroll_view.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+/// A scroll view that responds to hover wheel events on desktop.
+///
+/// This widget forwards pointer scroll signals (e.g., mouse wheel or middle
+/// button scrolling) to the provided [ScrollController] so that horizontal chip
+/// lists remain scrollable without requiring drag gestures.
+class HoverScrollView extends StatefulWidget {
+  const HoverScrollView({
+    super.key,
+    required this.scrollDirection,
+    required this.child,
+    this.controller,
+    this.physics,
+    this.scrollAmountMultiplier = 1.0,
+  });
+
+  final Axis scrollDirection;
+  final Widget child;
+  final ScrollController? controller;
+  final ScrollPhysics? physics;
+
+  /// Scales the pointer scroll delta before applying it to the scroll offset.
+  final double scrollAmountMultiplier;
+
+  @override
+  State<HoverScrollView> createState() => _HoverScrollViewState();
+}
+
+class _HoverScrollViewState extends State<HoverScrollView> {
+  late final ScrollController _controller =
+      widget.controller ?? ScrollController();
+
+  @override
+  void dispose() {
+    if (widget.controller == null) {
+      _controller.dispose();
+    }
+    super.dispose();
+  }
+
+  void _handlePointerSignal(PointerSignalEvent event) {
+    if (event is! PointerScrollEvent) {
+      return;
+    }
+
+    final delta = switch (widget.scrollDirection) {
+          Axis.horizontal => event.scrollDelta.dy != 0
+              ? event.scrollDelta.dy
+              : event.scrollDelta.dx,
+          Axis.vertical => event.scrollDelta.dy,
+        } *
+        widget.scrollAmountMultiplier;
+
+    if (delta == 0 || !_controller.hasClients) {
+      return;
+    }
+
+    final position = _controller.position;
+    final targetOffset = (_controller.offset + delta)
+        .clamp(position.minScrollExtent, position.maxScrollExtent);
+
+    if (targetOffset != _controller.offset) {
+      _controller.jumpTo(targetOffset);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(
+      onPointerSignal: _handlePointerSignal,
+      child: SingleChildScrollView(
+        scrollDirection: widget.scrollDirection,
+        controller: _controller,
+        physics: widget.physics,
+        child: widget.child,
+      ),
+    );
+  }
+}

--- a/lib/shared/widgets/tag_overlay.dart
+++ b/lib/shared/widgets/tag_overlay.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../features/tagging/domain/entities/tag_entity.dart';
 import '../../features/tagging/presentation/widgets/tag_chip.dart';
+import 'hover_scroll_view.dart';
 
 /// Overlay widget that renders tag chips with a semi-transparent backdrop.
 ///
@@ -43,8 +44,9 @@ class TagOverlay extends StatelessWidget {
         child: Row(
           children: [
             Expanded(
-              child: SingleChildScrollView(
+              child: HoverScrollView(
                 scrollDirection: Axis.horizontal,
+                physics: const ClampingScrollPhysics(),
                 child: Row(children: _buildChips(theme, colorScheme)),
               ),
             ),


### PR DESCRIPTION
## Summary
- add a reusable HoverScrollView to translate mouse wheel events into scrollable chip rows
- update tag overlay and tag selection strips to use hover scrolling for desktop usability

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695651d980408320b7e97aa948036082)