### PR TITLE
Add favorites use case and widget tests

### DIFF
--- a/test/features/favorites/domain/use_cases/get_favorites_use_case_test.dart
+++ b/test/features/favorites/domain/use_cases/get_favorites_use_case_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import 'package:media_fast_view/features/favorites/domain/repositories/favorites_repository.dart';
+import 'package:media_fast_view/features/favorites/domain/use_cases/get_favorites_use_case.dart';
+
+class _MockFavoritesRepository extends Mock implements FavoritesRepository {}
+
+void main() {
+  late _MockFavoritesRepository repository;
+  late GetFavoritesUseCase useCase;
+
+  setUp(() {
+    repository = _MockFavoritesRepository();
+    useCase = GetFavoritesUseCase(repository);
+  });
+
+  test('returns ids from repository', () async {
+    when(repository.getFavoriteMediaIds())
+        .thenAnswer((_) async => ['one', 'two']);
+
+    final result = await useCase.execute();
+
+    expect(result, ['one', 'two']);
+    verify(repository.getFavoriteMediaIds()).called(1);
+  });
+}

--- a/test/features/favorites/domain/use_cases/start_slideshow_use_case_test.dart
+++ b/test/features/favorites/domain/use_cases/start_slideshow_use_case_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:media_fast_view/features/favorites/domain/use_cases/start_slideshow_use_case.dart';
+import 'package:media_fast_view/features/media_library/domain/entities/media_entity.dart';
+
+void main() {
+  const useCase = StartSlideshowUseCase();
+
+  final media = [
+    MediaEntity(
+      id: '1',
+      path: '/a',
+      name: 'a',
+      type: MediaType.image,
+      size: 1,
+      lastModified: DateTime(2024, 1, 1),
+      tagIds: const [],
+      directoryId: 'dir',
+      bookmarkData: null,
+    ),
+    MediaEntity(
+      id: '2',
+      path: '/b',
+      name: 'b',
+      type: MediaType.video,
+      size: 2,
+      lastModified: DateTime(2024, 1, 2),
+      tagIds: const [],
+      directoryId: 'dir',
+      bookmarkData: null,
+    ),
+  ];
+
+  test('returns media unchanged in provided order', () async {
+    final result = await useCase.execute(media);
+
+    expect(result, media);
+  });
+}

--- a/test/features/favorites/domain/use_cases/toggle_favorite_use_case_test.dart
+++ b/test/features/favorites/domain/use_cases/toggle_favorite_use_case_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import 'package:media_fast_view/features/favorites/domain/repositories/favorites_repository.dart';
+import 'package:media_fast_view/features/favorites/domain/use_cases/toggle_favorite_use_case.dart';
+
+class _MockFavoritesRepository extends Mock implements FavoritesRepository {}
+
+void main() {
+  late _MockFavoritesRepository repository;
+  late ToggleFavoriteUseCase useCase;
+
+  const mediaId = 'media-123';
+
+  setUp(() {
+    repository = _MockFavoritesRepository();
+    useCase = ToggleFavoriteUseCase(repository);
+  });
+
+  test('adds media to favorites when currently not favorited', () async {
+    when(repository.isFavorite(mediaId)).thenAnswer((_) async => false);
+    when(repository.addFavorite(mediaId)).thenAnswer((_) async {});
+
+    await useCase.execute(mediaId);
+
+    verify(repository.isFavorite(mediaId)).called(1);
+    verify(repository.addFavorite(mediaId)).called(1);
+    verifyNever(repository.removeFavorite(any));
+  });
+
+  test('removes media from favorites when already favorited', () async {
+    when(repository.isFavorite(mediaId)).thenAnswer((_) async => true);
+    when(repository.removeFavorite(mediaId)).thenAnswer((_) async {});
+
+    await useCase.execute(mediaId);
+
+    verify(repository.isFavorite(mediaId)).called(1);
+    verify(repository.removeFavorite(mediaId)).called(1);
+    verifyNever(repository.addFavorite(any));
+  });
+}

--- a/test/features/favorites/presentation/view_models/slideshow_view_model_test.dart
+++ b/test/features/favorites/presentation/view_models/slideshow_view_model_test.dart
@@ -1,0 +1,124 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import 'package:media_fast_view/features/favorites/presentation/view_models/slideshow_view_model.dart';
+import 'package:media_fast_view/features/media_library/domain/entities/media_entity.dart';
+import 'package:media_fast_view/features/tagging/domain/entities/tag_entity.dart';
+import 'package:media_fast_view/shared/utils/tag_mutation_service.dart';
+
+class _MockTagMutationService extends Mock implements TagMutationService {}
+
+void main() {
+  late _MockTagMutationService tagMutationService;
+  late List<MediaEntity> media;
+
+  setUp(() {
+    tagMutationService = _MockTagMutationService();
+    media = [
+      MediaEntity(
+        id: 'image-1',
+        path: '/image.jpg',
+        name: 'Image',
+        type: MediaType.image,
+        size: 1,
+        lastModified: DateTime(2024, 1, 1),
+        tagIds: const [],
+        directoryId: 'dir',
+        bookmarkData: null,
+      ),
+      MediaEntity(
+        id: 'video-1',
+        path: '/video.mp4',
+        name: 'Video',
+        type: MediaType.video,
+        size: 2,
+        lastModified: DateTime(2024, 1, 1),
+        tagIds: const [],
+        directoryId: 'dir',
+        bookmarkData: null,
+      ),
+    ];
+  });
+
+  test('initializes paused state when media exist', () {
+    final viewModel = SlideshowViewModel(
+      media,
+      tagMutationService: tagMutationService,
+    );
+
+    expect(viewModel.state, isA<SlideshowPaused>());
+    expect(viewModel.currentIndex, 0);
+    expect(viewModel.totalItems, media.length);
+  });
+
+  test('start, pause, and resume slideshow transitions', () {
+    final viewModel = SlideshowViewModel(
+      media,
+      tagMutationService: tagMutationService,
+    );
+
+    viewModel.startSlideshow();
+    expect(viewModel.state, isA<SlideshowPlaying>());
+
+    viewModel.pauseSlideshow();
+    expect(viewModel.state, isA<SlideshowPaused>());
+
+    viewModel.resumeSlideshow();
+    expect(viewModel.state, isA<SlideshowPlaying>());
+  });
+
+  test('advances and finishes slideshow respecting looping', () {
+    fakeAsync((async) {
+      final viewModel = SlideshowViewModel(
+        media,
+        tagMutationService: tagMutationService,
+      );
+
+      viewModel.startSlideshow();
+      viewModel.toggleLoop();
+      viewModel.nextItem();
+      expect(viewModel.currentIndex, 1);
+
+      viewModel.toggleLoop();
+      viewModel.nextItem();
+      expect(viewModel.state, isA<SlideshowFinished>());
+
+      async.flushTimers();
+    });
+  });
+
+  test('updateProgress clamps values and keeps state consistent', () {
+    final viewModel = SlideshowViewModel(
+      media,
+      tagMutationService: tagMutationService,
+    );
+
+    viewModel.startSlideshow();
+    viewModel.updateProgress(1.5);
+
+    final state = viewModel.state as SlideshowPlaying;
+    expect(state.progress, 1.0);
+  });
+
+  test('toggleTag updates media and emits state change', () async {
+    final tag = TagEntity(id: 't1', name: 'Tag');
+    final updatedMedia = media.first.copyWith(tagIds: const ['t1']);
+    when(tagMutationService.toggleTagForMedia(media.first, tag)).thenAnswer(
+      (_) async => TagMutationResult(
+        outcome: TagMutationOutcome.added,
+        updatedMedia: updatedMedia,
+      ),
+    );
+
+    final viewModel = SlideshowViewModel(
+      media,
+      tagMutationService: tagMutationService,
+    );
+
+    final result = await viewModel.toggleTag(tag);
+
+    expect(result.outcome, TagMutationOutcome.added);
+    expect(viewModel.currentMedia?.tagIds, contains(tag.id));
+  });
+}

--- a/test/features/favorites/presentation/widgets/slideshow_overlay_test.dart
+++ b/test/features/favorites/presentation/widgets/slideshow_overlay_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:media_fast_view/features/favorites/presentation/view_models/slideshow_view_model.dart';
+import 'package:media_fast_view/features/favorites/presentation/widgets/slideshow_overlay.dart';
+import 'package:media_fast_view/features/media_library/domain/entities/media_entity.dart';
+import 'package:media_fast_view/shared/providers/repository_providers.dart';
+import 'package:media_fast_view/shared/utils/tag_cache_refresher.dart';
+import 'package:media_fast_view/shared/utils/tag_lookup.dart';
+import 'package:media_fast_view/shared/utils/tag_mutation_service.dart';
+import 'package:media_fast_view/features/tagging/domain/entities/tag_entity.dart';
+import 'package:media_fast_view/features/tagging/domain/repositories/tag_repository.dart';
+import 'package:media_fast_view/features/tagging/domain/use_cases/assign_tag_use_case.dart';
+
+class _FakeTagLookup extends TagLookup {
+  _FakeTagLookup() : super(_FakeTagRepository());
+
+  @override
+  Future<List<TagEntity>> getAllTags() async => const [];
+}
+
+class _FakeTagRepository implements TagRepository {
+  @override
+  Future<List<TagEntity>> getTags() async => const [];
+
+  @override
+  Future<TagEntity?> getTagById(String id) async => null;
+
+  @override
+  Future<void> createTag(TagEntity tag) async {}
+
+  @override
+  Future<void> deleteTag(String id) async {}
+
+  @override
+  Future<void> clearTags() async {}
+
+  @override
+  Future<void> updateTag(TagEntity tag) async {}
+}
+
+void main() {
+  final media = MediaEntity(
+    id: 'id',
+    path: '/image.jpg',
+    name: 'Image',
+    type: MediaType.image,
+    size: 1,
+    lastModified: DateTime(2024, 1, 1),
+    tagIds: const [],
+    directoryId: 'dir',
+    bookmarkData: null,
+  );
+
+  testWidgets('invokes callbacks for playback controls', (tester) async {
+    final viewModel = SlideshowViewModel(
+      [media],
+      tagMutationService: TagMutationService(
+        assignTagUseCase: const _FakeAssignTagUseCase(),
+        tagLookup: _FakeTagLookup(),
+        tagCacheRefresher: const _FakeTagCacheRefresher(),
+      ),
+    );
+
+    var playPauseTapped = false;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          tagLookupProvider.overrideWithValue(_FakeTagLookup()),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: SlideshowOverlay(
+              state: viewModel.state,
+              viewModel: viewModel,
+              onClose: () {},
+              onPlayPause: () {
+                playPauseTapped = true;
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byTooltip('Play'));
+    await tester.pump();
+
+    await tester.tap(find.byTooltip('Enable loop'));
+    await tester.pump();
+
+    await tester.tap(find.byTooltip('Enable shuffle'));
+    await tester.pump();
+
+    expect(viewModel.isLooping, isTrue);
+    expect(viewModel.isPlaying, isFalse);
+    expect(playPauseTapped, isTrue);
+  });
+}
+
+class _FakeAssignTagUseCase implements AssignTagUseCase {
+  const _FakeAssignTagUseCase();
+
+  @override
+  Future<void> assignTagToMedia(String mediaId, TagEntity tag) async {}
+
+  @override
+  Future<void> removeTagFromMedia(String mediaId, TagEntity tag) async {}
+}
+
+class _FakeTagCacheRefresher implements TagCacheRefresher {
+  const _FakeTagCacheRefresher();
+
+  @override
+  Future<void> refresh() async {}
+}

--- a/test/features/favorites/presentation/widgets/slideshow_video_player_test.dart
+++ b/test/features/favorites/presentation/widgets/slideshow_video_player_test.dart
@@ -1,0 +1,132 @@
+import 'dart:async';
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:video_player/video_player.dart';
+import 'package:video_player_platform_interface/video_player_platform_interface.dart';
+
+import 'package:media_fast_view/features/favorites/presentation/widgets/slideshow_video_player.dart';
+import 'package:media_fast_view/features/media_library/domain/entities/media_entity.dart';
+
+class _FakeVideoPlayerPlatform extends VideoPlayerPlatform {
+  _FakeVideoPlayerPlatform();
+
+  final StreamController<VideoEvent> _eventController =
+      StreamController<VideoEvent>.broadcast();
+  int _textureCounter = 1;
+  bool playCalled = false;
+  bool pauseCalled = false;
+  double lastVolume = 1;
+  double lastSpeed = 1;
+  bool loopingEnabled = false;
+
+  @override
+  Future<int?> create(DataSource dataSource) async {
+    final textureId = _textureCounter++;
+    _eventController.add(
+      VideoEvent(
+        eventType: VideoEventType.initialized,
+        duration: const Duration(seconds: 1),
+        size: const Size(1, 1),
+      ),
+    );
+    return textureId;
+  }
+
+  @override
+  Future<void> dispose(int textureId) async {
+  }
+
+  @override
+  Stream<VideoEvent> videoEventsFor(int textureId) {
+    return _eventController.stream;
+  }
+
+  @override
+  Future<void> setLooping(int textureId, bool looping) async {
+    loopingEnabled = looping;
+  }
+
+  @override
+  Future<void> play(int textureId) async {
+    playCalled = true;
+  }
+
+  @override
+  Future<void> pause(int textureId) async {
+    pauseCalled = true;
+  }
+
+  @override
+  Future<void> setVolume(int textureId, double volume) async {
+    lastVolume = volume;
+  }
+
+  @override
+  Future<void> setPlaybackSpeed(int textureId, double speed) async {
+    lastSpeed = speed;
+  }
+
+  @override
+  Future<void> seekTo(int textureId, Duration position) async {}
+
+  @override
+  Future<Duration> getPosition(int textureId) async {
+    return const Duration();
+  }
+
+  @override
+  Future<void> setMixWithOthers(bool mixWithOthers) async {}
+}
+
+void main() {
+  final media = MediaEntity(
+    id: 'video',
+    path: '/tmp/video.mp4',
+    name: 'video.mp4',
+    type: MediaType.video,
+    size: 10,
+    lastModified: DateTime(2024, 1, 1),
+    tagIds: const [],
+    directoryId: 'dir',
+    bookmarkData: null,
+  );
+
+  testWidgets('configures controller based on props', (tester) async {
+    final platform = _FakeVideoPlayerPlatform();
+    VideoPlayerPlatform.instance = platform;
+
+    var completed = false;
+    var progress = 0.0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SlideshowVideoPlayer(
+          media: media,
+          isPlaying: true,
+          isMuted: true,
+          isVideoLooping: true,
+          playbackSpeed: 2.0,
+          onProgress: (value) => progress = value,
+          onCompleted: () => completed = true,
+        ),
+      ),
+    );
+
+    await tester.pump();
+
+    expect(platform.playCalled, isTrue);
+    expect(platform.lastVolume, 0.0);
+    expect(platform.loopingEnabled, isTrue);
+    expect(platform.lastSpeed, 2.0);
+
+    platform._eventController.add(
+      VideoEvent(eventType: VideoEventType.completed),
+    );
+    await tester.pump();
+
+    expect(completed, isTrue);
+    expect(progress, greaterThanOrEqualTo(0));
+  });
+}


### PR DESCRIPTION
## Summary
- add unit tests covering favorites use cases repository interactions
- expand slideshow view model coverage for state transitions and tag handling
- add widget tests for slideshow overlay controls and video player configuration

## Testing
- Not run (Flutter SDK not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69570b5530f08320b758ebf950215cd0)