### PR TITLE
Add tests for media library use cases and widgets

### DIFF
--- a/test/features/media_library/domain/use_cases/add_remove_clear_use_cases_test.dart
+++ b/test/features/media_library/domain/use_cases/add_remove_clear_use_cases_test.dart
@@ -1,0 +1,198 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import 'package:media_fast_view/features/favorites/domain/repositories/favorites_repository.dart';
+import 'package:media_fast_view/features/media_library/domain/entities/directory_entity.dart';
+import 'package:media_fast_view/features/media_library/domain/entities/media_entity.dart';
+import 'package:media_fast_view/features/media_library/domain/repositories/directory_repository.dart';
+import 'package:media_fast_view/features/media_library/domain/repositories/media_repository.dart';
+import 'package:media_fast_view/features/media_library/domain/use_cases/add_directory_use_case.dart';
+import 'package:media_fast_view/features/media_library/domain/use_cases/clear_media_cache_use_case.dart';
+import 'package:media_fast_view/features/media_library/domain/use_cases/remove_directory_use_case.dart';
+import 'package:media_fast_view/shared/utils/directory_id_utils.dart';
+
+class _MockDirectoryRepository extends Mock implements DirectoryRepository {}
+
+class _MockMediaRepository extends Mock implements MediaRepository {}
+
+class _MockFavoritesRepository extends Mock implements FavoritesRepository {}
+
+void main() {
+  group('AddDirectoryUseCase', () {
+    late _MockDirectoryRepository directoryRepository;
+    late AddDirectoryUseCase useCase;
+
+    setUp(() {
+      directoryRepository = _MockDirectoryRepository();
+      useCase = AddDirectoryUseCase(directoryRepository);
+    });
+
+    test('creates directory entity from path and delegates to repository', () async {
+      const path = '/home/user/Videos';
+      final expectedId = generateDirectoryId(path);
+
+      when(directoryRepository.addDirectory(any, silent: anyNamed('silent')))
+          .thenAnswer((_) async {});
+
+      await useCase(path, silent: true);
+
+      final capturedEntity =
+          verify(directoryRepository.addDirectory(captureAny, silent: true))
+              .captured
+              .single as DirectoryEntity;
+
+      expect(capturedEntity.id, expectedId);
+      expect(capturedEntity.path, path);
+      expect(capturedEntity.name, 'Videos');
+      expect(capturedEntity.tagIds, isEmpty);
+      expect(capturedEntity.thumbnailPath, isNull);
+    });
+  });
+
+  group('RemoveDirectoryUseCase', () {
+    late _MockDirectoryRepository directoryRepository;
+    late _MockMediaRepository mediaRepository;
+    late _MockFavoritesRepository favoritesRepository;
+    late RemoveDirectoryUseCase useCase;
+
+    const directoryId = 'dir-1';
+    const directoryPath = '/library/dir-1';
+
+    setUp(() {
+      directoryRepository = _MockDirectoryRepository();
+      mediaRepository = _MockMediaRepository();
+      favoritesRepository = _MockFavoritesRepository();
+      useCase = RemoveDirectoryUseCase(
+        directoryRepository,
+        mediaRepository,
+        favoritesRepository,
+      );
+    });
+
+    test('removes directory and cascades favorite/tag cleanup', () async {
+      final media = [
+        const MediaEntity(
+          id: 'media-1',
+          directoryId: directoryId,
+          path: '/file-1.jpg',
+          name: 'file-1.jpg',
+          thumbnailPath: null,
+          tagIds: ['tag-1'],
+          lastModified: null,
+          duration: null,
+          width: null,
+          height: null,
+        ),
+        const MediaEntity(
+          id: 'media-2',
+          directoryId: directoryId,
+          path: '/file-2.jpg',
+          name: 'file-2.jpg',
+          thumbnailPath: null,
+          tagIds: [],
+          lastModified: null,
+          duration: null,
+          width: null,
+          height: null,
+        ),
+      ];
+
+      when(directoryRepository.getDirectoryById(directoryId)).thenAnswer(
+        (_) async => DirectoryEntity(
+          id: directoryId,
+          path: directoryPath,
+          name: 'dir-1',
+          thumbnailPath: null,
+          tagIds: const [],
+          lastModified: DateTime(2024, 1, 1),
+          bookmarkData: 'bookmark',
+        ),
+      );
+      when(
+        mediaRepository.getMediaForDirectoryPath(
+          any,
+          bookmarkData: anyNamed('bookmarkData'),
+        ),
+      ).thenAnswer((_) async => media);
+      when(favoritesRepository.isFavorite(any)).thenAnswer((_) async => true);
+      when(favoritesRepository.removeFavorite(any)).thenAnswer((_) async {});
+      when(mediaRepository.updateMediaTags(any, any))
+          .thenAnswer((_) async {});
+      when(directoryRepository.removeDirectory(directoryId))
+          .thenAnswer((_) async {});
+      when(mediaRepository.removeMediaForDirectory(directoryId))
+          .thenAnswer((_) async {});
+
+      await useCase(directoryId);
+
+      verify(directoryRepository.getDirectoryById(directoryId)).called(1);
+      verify(
+        mediaRepository.getMediaForDirectoryPath(
+          directoryPath,
+          bookmarkData: 'bookmark',
+        ),
+      ).called(1);
+      verify(favoritesRepository.removeFavorite('media-1')).called(1);
+      verify(mediaRepository.updateMediaTags('media-1', [])).called(1);
+      verify(favoritesRepository.removeFavorite('media-2')).called(1);
+      verifyNever(mediaRepository.updateMediaTags('media-2', any));
+      verify(directoryRepository.removeDirectory(directoryId)).called(1);
+      verify(mediaRepository.removeMediaForDirectory(directoryId)).called(1);
+    });
+
+    test('returns early when directory is missing', () async {
+      when(directoryRepository.getDirectoryById(directoryId))
+          .thenAnswer((_) async => null);
+
+      await useCase(directoryId);
+
+      verify(directoryRepository.getDirectoryById(directoryId)).called(1);
+      verifyNever(directoryRepository.removeDirectory(any));
+      verifyNever(mediaRepository.removeMediaForDirectory(any));
+    });
+  });
+
+  group('ClearMediaCacheUseCase', () {
+    late _MockDirectoryRepository directoryRepository;
+    late _MockMediaRepository mediaRepository;
+    late ClearMediaCacheUseCase useCase;
+
+    setUp(() {
+      directoryRepository = _MockDirectoryRepository();
+      mediaRepository = _MockMediaRepository();
+      useCase = ClearMediaCacheUseCase(mediaRepository, directoryRepository);
+    });
+
+    test('removes media not linked to current directories', () async {
+      const directories = [
+        DirectoryEntity(
+          id: 'dir-a',
+          path: '/a',
+          name: 'A',
+          thumbnailPath: null,
+          tagIds: [],
+          lastModified: DateTime(2024, 1, 1),
+        ),
+        DirectoryEntity(
+          id: 'dir-b',
+          path: '/b',
+          name: 'B',
+          thumbnailPath: null,
+          tagIds: [],
+          lastModified: DateTime(2024, 1, 1),
+        ),
+      ];
+
+      when(directoryRepository.getDirectories())
+          .thenAnswer((_) async => directories);
+      when(mediaRepository.removeMediaNotInDirectories(any))
+          .thenAnswer((_) async {});
+
+      await useCase();
+
+      verify(directoryRepository.getDirectories()).called(1);
+      verify(mediaRepository.removeMediaNotInDirectories(['dir-a', 'dir-b']))
+          .called(1);
+    });
+  });
+}

--- a/test/features/media_library/presentation/widgets/directory_search_and_grid_test.dart
+++ b/test/features/media_library/presentation/widgets/directory_search_and_grid_test.dart
@@ -1,0 +1,251 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import 'package:media_fast_view/features/favorites/domain/entities/favorite_toggle_result.dart';
+import 'package:media_fast_view/features/favorites/domain/repositories/favorites_repository.dart';
+import 'package:media_fast_view/features/favorites/presentation/view_models/favorites_view_model.dart';
+import 'package:media_fast_view/features/media_library/data/data_sources/local_directory_data_source.dart';
+import 'package:media_fast_view/features/media_library/data/isar/isar_media_data_source.dart';
+import 'package:media_fast_view/features/media_library/domain/entities/directory_entity.dart';
+import 'package:media_fast_view/features/media_library/domain/repositories/directory_repository.dart';
+import 'package:media_fast_view/features/media_library/domain/repositories/media_repository.dart';
+import 'package:media_fast_view/features/media_library/domain/use_cases/add_directory_use_case.dart';
+import 'package:media_fast_view/features/media_library/domain/use_cases/clear_directories_use_case.dart';
+import 'package:media_fast_view/features/media_library/domain/use_cases/get_directories_use_case.dart';
+import 'package:media_fast_view/features/media_library/domain/use_cases/remove_directory_use_case.dart';
+import 'package:media_fast_view/features/media_library/domain/use_cases/search_directories_use_case.dart';
+import 'package:media_fast_view/features/media_library/presentation/screens/directory_grid_screen.dart';
+import 'package:media_fast_view/features/media_library/presentation/view_models/directory_grid_view_model.dart';
+import 'package:media_fast_view/features/media_library/presentation/widgets/directory_grid_item.dart';
+import 'package:media_fast_view/features/media_library/presentation/widgets/directory_search_bar.dart';
+import 'package:media_fast_view/features/tagging/domain/entities/tag_entity.dart';
+import 'package:media_fast_view/features/tagging/domain/repositories/tag_repository.dart';
+import 'package:media_fast_view/features/tagging/presentation/states/tag_state.dart';
+import 'package:media_fast_view/features/tagging/presentation/view_models/tag_management_view_model.dart';
+import 'package:media_fast_view/shared/providers/grid_columns_provider.dart';
+import 'package:media_fast_view/shared/utils/directory_id_utils.dart';
+import 'package:media_fast_view/core/services/permission_service.dart';
+
+class _MockDirectoryRepository extends Mock implements DirectoryRepository {}
+
+class _MockMediaRepository extends Mock implements MediaRepository {}
+
+class _MockFavoritesRepository extends Mock implements FavoritesRepository {}
+
+class _MockLocalDirectoryDataSource extends Mock
+    implements LocalDirectoryDataSource {}
+
+class _MockPermissionService extends Mock implements PermissionService {}
+
+class _MockTagRepository extends Mock implements TagRepository {}
+
+class _MockIsarMediaDataSource extends Mock implements IsarMediaDataSource {}
+
+class _StubFavoritesViewModel extends FavoritesViewModel {
+  _StubFavoritesViewModel()
+      : super(
+          _MockFavoritesRepository(),
+          _MockIsarMediaDataSource(),
+          GetMediaUseCase(_MockMediaRepository()),
+        ) {
+    state = const FavoritesLoaded(
+      favorites: [],
+      media: [],
+      directoryFavorites: [],
+    );
+  }
+
+  @override
+  Future<void> loadFavorites() async {}
+
+  @override
+  Future<FavoriteToggleResult> toggleFavoritesForDirectories(
+    List<DirectoryEntity> directories,
+  ) async {
+    state = const FavoritesLoaded(
+      favorites: [],
+      media: [],
+      directoryFavorites: [],
+    );
+    return const FavoriteToggleResult(added: 0, removed: 0);
+  }
+}
+
+class _StubTagViewModel extends TagViewModel {
+  _StubTagViewModel()
+      : super(_MockTagRepository()) {
+    state = TagLoaded(tags: const [
+      TagEntity(id: 'tag-1', name: 'Tag 1', color: 0),
+    ]);
+  }
+}
+
+class _StubGridColumnsNotifier extends StateNotifier<int> {
+  _StubGridColumnsNotifier() : super(2);
+}
+
+class _StubDirectoryViewModel extends DirectoryViewModel {
+  _StubDirectoryViewModel(this._directories, Ref ref)
+      : super(
+          ref,
+          GetDirectoriesUseCase(_MockDirectoryRepository()),
+          const SearchDirectoriesUseCase(),
+          AddDirectoryUseCase(_MockDirectoryRepository()),
+          RemoveDirectoryUseCase(
+            _MockDirectoryRepository(),
+            _MockMediaRepository(),
+            _MockFavoritesRepository(),
+          ),
+          ClearDirectoriesUseCase(_MockDirectoryRepository()),
+          _MockLocalDirectoryDataSource(),
+          _MockPermissionService(),
+        );
+
+  final List<DirectoryEntity> _directories;
+  String? lastSearchQuery;
+  String? removedDirectoryId;
+
+  @override
+  Future<void> loadDirectories() async {
+    state = DirectoryLoaded(
+      directories: _directories,
+      searchQuery: lastSearchQuery ?? '',
+      selectedTagIds: const [],
+      columns: 2,
+      sortOption: DirectorySortOption.nameAscending,
+      selectedDirectoryIds: const {},
+      isSelectionMode: false,
+      showFavoritesOnly: false,
+    );
+  }
+
+  @override
+  void searchDirectories(String query) {
+    lastSearchQuery = query;
+    state = DirectoryLoaded(
+      directories: _directories,
+      searchQuery: query,
+      selectedTagIds: const [],
+      columns: 2,
+      sortOption: DirectorySortOption.nameAscending,
+      selectedDirectoryIds: const {},
+      isSelectionMode: false,
+      showFavoritesOnly: false,
+    );
+  }
+
+  @override
+  Future<void> removeDirectory(String id) async {
+    removedDirectoryId = id;
+  }
+}
+
+void main() {
+  group('DirectorySearchBar', () {
+    testWidgets('invokes search with entered query and clears on tap',
+        (tester) async {
+      final directories = [
+        DirectoryEntity(
+          id: generateDirectoryId('/movies'),
+          path: '/movies',
+          name: 'Movies',
+          thumbnailPath: null,
+          tagIds: const [],
+          lastModified: DateTime(2024, 1, 1),
+        ),
+      ];
+      late _StubDirectoryViewModel viewModel;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            gridColumnsProvider
+                .overrideWith((ref) => _StubGridColumnsNotifier()),
+            favoritesViewModelProvider.overrideWith(
+              (ref) => _StubFavoritesViewModel(),
+            ),
+            directoryViewModelProvider.overrideWith((ref) {
+              viewModel = _StubDirectoryViewModel(directories, ref);
+              return viewModel;
+            }),
+          ],
+          child: const MaterialApp(
+            home: Scaffold(body: DirectorySearchBar()),
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField), 'action');
+      expect(viewModel.lastSearchQuery, 'action');
+
+      await tester.tap(find.byIcon(Icons.clear));
+      await tester.pump();
+
+      expect(viewModel.lastSearchQuery, isEmpty);
+    });
+  });
+
+  group('DirectoryGrid interactions', () {
+    testWidgets('renders directories and confirms deletions', (tester) async {
+      final directories = [
+        DirectoryEntity(
+          id: generateDirectoryId('/music'),
+          path: '/music',
+          name: 'Music',
+          thumbnailPath: null,
+          tagIds: const ['tag-1'],
+          lastModified: DateTime(2024, 1, 1),
+        ),
+        DirectoryEntity(
+          id: generateDirectoryId('/pictures'),
+          path: '/pictures',
+          name: 'Pictures',
+          thumbnailPath: null,
+          tagIds: const [],
+          lastModified: DateTime(2024, 1, 2),
+        ),
+      ];
+      late _StubDirectoryViewModel viewModel;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            gridColumnsProvider
+                .overrideWith((ref) => _StubGridColumnsNotifier()),
+            favoritesViewModelProvider.overrideWith(
+              (ref) => _StubFavoritesViewModel(),
+            ),
+            tagViewModelProvider.overrideWith((ref) => _StubTagViewModel()),
+            directoryViewModelProvider.overrideWith((ref) {
+              viewModel = _StubDirectoryViewModel(directories, ref);
+              return viewModel;
+            }),
+          ],
+          child: const MaterialApp(
+            home: DirectoryGridScreen(),
+          ),
+        ),
+      );
+
+      expect(find.text('Music'), findsOneWidget);
+      expect(find.text('Pictures'), findsOneWidget);
+
+      await tester.tap(
+        find.descendant(
+          of: find.widgetWithText(DirectoryGridItem, 'Music'),
+          matching: find.byIcon(Icons.delete),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Delete Directory'), findsOneWidget);
+
+      await tester.tap(find.widgetWithText(TextButton, 'Delete'));
+      await tester.pumpAndSettle();
+
+      expect(viewModel.removedDirectoryId, directories.first.id);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add unit tests covering media-library use cases for directory management and cache clearing
- add widget tests for directory search bar and grid interactions including deletion flow

## Testing
- flutter test test/features/media_library/domain/use_cases/add_remove_clear_use_cases_test.dart test/features/media_library/presentation/widgets/directory_search_and_grid_test.dart *(fails: flutter not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69570b56dc00832097775c3f51954354)