### PR TITLE
Refactor favorites view model to use domain media use case

### DIFF
--- a/lib/features/favorites/domain/use_cases/favorite_media_use_case.dart
+++ b/lib/features/favorites/domain/use_cases/favorite_media_use_case.dart
@@ -1,0 +1,78 @@
+import '../../../media_library/domain/entities/media_entity.dart';
+import '../../../media_library/domain/repositories/media_repository.dart';
+import '../../../media_library/domain/use_cases/get_media_use_case.dart';
+import '../../../../core/services/logging_service.dart';
+
+/// Use case that resolves and persists media needed by favorites features.
+class FavoriteMediaUseCase {
+  const FavoriteMediaUseCase(this._mediaRepository, this._getMediaUseCase);
+
+  final MediaRepository _mediaRepository;
+  final GetMediaUseCase _getMediaUseCase;
+
+  /// Retrieves media entities for the given [favoriteIds], preferring cached
+  /// entries and falling back to repository lookups when necessary.
+  Future<List<MediaEntity>> resolveMediaForFavorites(List<String> favoriteIds) async {
+    LoggingService.instance.info(
+      'Loading media for ${favoriteIds.length} favorite IDs: $favoriteIds',
+    );
+
+    if (favoriteIds.isEmpty) {
+      LoggingService.instance.info('No favorite IDs provided, returning empty');
+      return const <MediaEntity>[];
+    }
+
+    final storedMedia = await _mediaRepository.getAllMedia();
+    LoggingService.instance.info(
+      'Found ${storedMedia.length} stored media items',
+    );
+
+    final storedMediaMap = {for (final media in storedMedia) media.id: media};
+    final resolvedMedia = <MediaEntity>[];
+    final missingIds = <String>[];
+
+    for (final id in favoriteIds) {
+      final stored = storedMediaMap[id];
+      if (stored != null) {
+        resolvedMedia.add(stored);
+        LoggingService.instance.debug(
+          'Successfully loaded cached media for ID $id: ${stored.name}, path: ${stored.path}',
+        );
+      } else {
+        missingIds.add(id);
+        LoggingService.instance.warning(
+          'No cached media found for favorite ID $id, will attempt repository lookup',
+        );
+      }
+    }
+
+    if (missingIds.isNotEmpty) {
+      LoggingService.instance.info(
+        'Attempting to resolve ${missingIds.length} missing favorites via repository',
+      );
+      for (final id in missingIds) {
+        final media = await _getMediaUseCase.byId(id);
+        if (media != null) {
+          resolvedMedia.add(media);
+          LoggingService.instance.debug(
+            'Resolved missing favorite $id via repository lookup',
+          );
+        } else {
+          LoggingService.instance.warning(
+            'Repository could not resolve favorite ID $id',
+          );
+        }
+      }
+    }
+
+    LoggingService.instance.info(
+      'Loaded ${resolvedMedia.length} valid media entities out of ${favoriteIds.length} favorites',
+    );
+    return resolvedMedia;
+  }
+
+  /// Persists [media] to the underlying repository for offline use.
+  Future<void> persistMedia(MediaEntity media) {
+    return _mediaRepository.upsertMedia([media]);
+  }
+}

--- a/lib/features/media_library/data/repositories/filesystem_media_repository_impl.dart
+++ b/lib/features/media_library/data/repositories/filesystem_media_repository_impl.dart
@@ -28,6 +28,20 @@ class FilesystemMediaRepositoryImpl implements MediaRepository {
   final FilesystemMediaDataSource _filesystemDataSource;
   final PermissionService _permissionService;
 
+  MediaModel _entityToModel(MediaEntity entity) {
+    return MediaModel(
+      id: entity.id,
+      path: entity.path,
+      name: entity.name,
+      type: entity.type,
+      size: entity.size,
+      lastModified: entity.lastModified,
+      tagIds: entity.tagIds,
+      directoryId: entity.directoryId,
+      bookmarkData: entity.bookmarkData,
+    );
+  }
+
   @override
   Future<List<MediaEntity>> getMediaForDirectory(String directoryId) async {
     final directory = await _directoryRepository.getDirectoryById(directoryId);
@@ -351,6 +365,17 @@ class FilesystemMediaRepositoryImpl implements MediaRepository {
   @override
   Future<void> clearAllMedia() {
     return _mediaDataSource.clearMedia();
+  }
+
+  @override
+  Future<void> upsertMedia(List<MediaEntity> media) async {
+    if (media.isEmpty) {
+      return;
+    }
+
+    await _mediaDataSource.upsertMedia(
+      media.map(_entityToModel).toList(growable: false),
+    );
   }
 
   Future<MediaEntity?> _scanDirectoriesForMedia(String id) async {

--- a/lib/features/media_library/data/repositories/media_repository_impl.dart
+++ b/lib/features/media_library/data/repositories/media_repository_impl.dart
@@ -14,6 +14,20 @@ class MediaRepositoryImpl implements MediaRepository {
 
   final IsarMediaDataSource _mediaDataSource;
 
+  MediaModel _entityToModel(MediaEntity entity) {
+    return MediaModel(
+      id: entity.id,
+      path: entity.path,
+      name: entity.name,
+      type: entity.type,
+      size: entity.size,
+      lastModified: entity.lastModified,
+      tagIds: entity.tagIds,
+      directoryId: entity.directoryId,
+      bookmarkData: entity.bookmarkData,
+    );
+  }
+
   @override
   Future<List<MediaEntity>> getMediaForDirectory(String directoryId) async {
     final models = await _mediaDataSource.getMediaForDirectory(directoryId);
@@ -114,12 +128,23 @@ class MediaRepositoryImpl implements MediaRepository {
       lastModified: model.lastModified,
       tagIds: model.tagIds,
       directoryId: model.directoryId,
+      bookmarkData: model.bookmarkData,
     );
   }
-  
+
   @override
   Future<void> clearAllMedia() {
     return _mediaDataSource.clearMedia();
   }
 
+  @override
+  Future<void> upsertMedia(List<MediaEntity> media) async {
+    if (media.isEmpty) {
+      return;
+    }
+
+    await _mediaDataSource.upsertMedia(
+      media.map(_entityToModel).toList(growable: false),
+    );
+  }
 }

--- a/lib/features/media_library/domain/repositories/media_repository.dart
+++ b/lib/features/media_library/domain/repositories/media_repository.dart
@@ -51,4 +51,7 @@ abstract class MediaRepository {
   /// Removes every persisted media entry, clearing cached results across
   /// directories.
   Future<void> clearAllMedia();
+
+  /// Inserts or updates media entries in persistence.
+  Future<void> upsertMedia(List<MediaEntity> media);
 }

--- a/lib/shared/providers/repository_providers.dart
+++ b/lib/shared/providers/repository_providers.dart
@@ -38,6 +38,7 @@ import '../../features/tagging/domain/use_cases/filter_by_tags_use_case.dart';
 import '../../features/tagging/domain/use_cases/clear_tag_assignments_use_case.dart';
 import '../../features/tagging/domain/use_cases/clear_tags_use_case.dart';
 import '../../features/favorites/domain/use_cases/get_favorites_use_case.dart';
+import '../../features/favorites/domain/use_cases/favorite_media_use_case.dart';
 import '../../features/favorites/domain/use_cases/toggle_favorite_use_case.dart';
 import '../../features/favorites/domain/use_cases/start_slideshow_use_case.dart';
 import '../../features/full_screen/data/repositories/media_viewer_repository_impl.dart';
@@ -322,6 +323,13 @@ final filterByTagsUseCaseProvider = Provider<FilterByTagsUseCase>((ref) {
 });
 
 // Favorites use case providers
+final favoriteMediaUseCaseProvider = Provider<FavoriteMediaUseCase>((ref) {
+  return FavoriteMediaUseCase(
+    ref.watch(mediaRepositoryProvider),
+    ref.watch(getMediaUseCaseProvider),
+  );
+});
+
 final getFavoritesUseCaseProvider = Provider<GetFavoritesUseCase>((ref) {
   return GetFavoritesUseCase(ref.watch(favoritesRepositoryProvider));
 });

--- a/test/features/media_library/presentation/widgets/directory_search_and_grid_test.dart
+++ b/test/features/media_library/presentation/widgets/directory_search_and_grid_test.dart
@@ -5,9 +5,9 @@ import 'package:mockito/mockito.dart';
 
 import 'package:media_fast_view/features/favorites/domain/entities/favorite_toggle_result.dart';
 import 'package:media_fast_view/features/favorites/domain/repositories/favorites_repository.dart';
+import 'package:media_fast_view/features/favorites/domain/use_cases/favorite_media_use_case.dart';
 import 'package:media_fast_view/features/favorites/presentation/view_models/favorites_view_model.dart';
 import 'package:media_fast_view/features/media_library/data/data_sources/local_directory_data_source.dart';
-import 'package:media_fast_view/features/media_library/data/isar/isar_media_data_source.dart';
 import 'package:media_fast_view/features/media_library/domain/entities/directory_entity.dart';
 import 'package:media_fast_view/features/media_library/domain/repositories/directory_repository.dart';
 import 'package:media_fast_view/features/media_library/domain/repositories/media_repository.dart';
@@ -34,6 +34,8 @@ class _MockMediaRepository extends Mock implements MediaRepository {}
 
 class _MockFavoritesRepository extends Mock implements FavoritesRepository {}
 
+class _MockFavoriteMediaUseCase extends Mock implements FavoriteMediaUseCase {}
+
 class _MockLocalDirectoryDataSource extends Mock
     implements LocalDirectoryDataSource {}
 
@@ -41,14 +43,11 @@ class _MockPermissionService extends Mock implements PermissionService {}
 
 class _MockTagRepository extends Mock implements TagRepository {}
 
-class _MockIsarMediaDataSource extends Mock implements IsarMediaDataSource {}
-
 class _StubFavoritesViewModel extends FavoritesViewModel {
   _StubFavoritesViewModel()
       : super(
           _MockFavoritesRepository(),
-          _MockIsarMediaDataSource(),
-          GetMediaUseCase(_MockMediaRepository()),
+          _MockFavoriteMediaUseCase(),
         ) {
     state = const FavoritesLoaded(
       favorites: [],


### PR DESCRIPTION
## Summary
- add a FavoriteMediaUseCase to resolve cached and missing media via domain abstractions
- update FavoritesViewModel and dependency providers to consume the new use case instead of data sources
- extend media repositories with media upsert support and refresh affected tests

## Testing
- Not run (environment missing Dart/Flutter SDK)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957121f18f883208ae021ecd67f2fa0)