### PR TITLE
Refactor directory scan to use isolate with progress updates

### DIFF
--- a/lib/features/media_library/data/data_sources/local_directory_data_source.dart
+++ b/lib/features/media_library/data/data_sources/local_directory_data_source.dart
@@ -9,10 +9,13 @@ import '../../../../core/services/bookmark_service.dart';
 import '../../../../core/services/logging_service.dart';
 import '../../../../shared/utils/directory_id_utils.dart';
 import '../../domain/entities/directory_entity.dart';
-
+/// Provides updates while scanning directories for media files.
+typedef DirectoryScanProgressCallback =
+    void Function(DirectoryScanProgress progress);
+    
 /// Data source for local directory operations on the file system.
 class LocalDirectoryDataSource {
-  const LocalDirectoryDataSource({
+   LocalDirectoryDataSource({
     required this.bookmarkService,
   });
 
@@ -23,10 +26,7 @@ class LocalDirectoryDataSource {
   static const _scanCancelledType = 'cancelled';
   static const _scanCancelMessage = 'cancel';
 
-  /// Provides updates while scanning directories for media files.
-  typedef DirectoryScanProgressCallback = void Function(
-    DirectoryScanProgress progress,
-  );
+  
 
   /// Supported media file extensions for directory scanning
   static const Set<String> _mediaExtensions = {

--- a/lib/features/media_library/data/data_sources/local_directory_data_source.dart
+++ b/lib/features/media_library/data/data_sources/local_directory_data_source.dart
@@ -1,4 +1,6 @@
+import 'dart:async';
 import 'dart:io';
+import 'dart:isolate';
 
 import 'package:path/path.dart' as path;
 
@@ -15,6 +17,16 @@ class LocalDirectoryDataSource {
   });
 
   final BookmarkService bookmarkService;
+
+  static const _scanProgressType = 'progress';
+  static const _scanCompleteType = 'complete';
+  static const _scanCancelledType = 'cancelled';
+  static const _scanCancelMessage = 'cancel';
+
+  /// Provides updates while scanning directories for media files.
+  typedef DirectoryScanProgressCallback = void Function(
+    DirectoryScanProgress progress,
+  );
 
   /// Supported media file extensions for directory scanning
   static const Set<String> _mediaExtensions = {
@@ -103,7 +115,11 @@ class LocalDirectoryDataSource {
 
   /// Scans a root directory for subdirectories containing media files.
   /// If the directory has bookmark data, starts accessing the bookmark.
-  Future<List<DirectoryEntity>> scanDirectoriesWithMedia(DirectoryEntity rootDirectory) async {
+  Future<List<DirectoryEntity>> scanDirectoriesWithMedia(
+    DirectoryEntity rootDirectory, {
+    DirectoryScanProgressCallback? onProgress,
+    DirectoryScanCancellationToken? cancellationToken,
+  }) async {
     String actualPath = rootDirectory.path;
     bool startedAccess = false;
 
@@ -128,10 +144,17 @@ class LocalDirectoryDataSource {
         throw DirectoryNotFoundError('Root directory does not exist: $actualPath');
       }
 
-      final directories = <DirectoryEntity>[];
-      await _scanDirectoryRecursive(rootDir, directories);
+      final directories = await _scanDirectoryInIsolate(
+        rootDir.path,
+        onProgress: onProgress,
+        cancellationToken: cancellationToken,
+      );
+
       return directories;
     } catch (e) {
+      if (e is AppError) {
+        rethrow;
+      }
       throw DirectoryScanError('Failed to scan directories: $e');
     } finally {
       // Stop accessing bookmark if we started it
@@ -143,77 +166,6 @@ class LocalDirectoryDataSource {
           // Don't throw - cleanup failure shouldn't break scanning
         }
       }
-    }
-  }
-
-  /// Recursively scans directories for those containing media files.
-  Future<void> _scanDirectoryRecursive(
-    Directory directory,
-    List<DirectoryEntity> directories,
-  ) async {
-    try {
-      await for (final entity in directory.list(
-        recursive: false,
-        followLinks: false,
-      )) {
-        if (entity is Directory) {
-          final dirName = path.basename(entity.path);
-
-          // Skip excluded directories
-          if (_excludedNames.contains(dirName) || dirName.startsWith('.')) {
-            continue;
-          }
-
-          // Check if this directory contains media files
-          if (await _directoryContainsMedia(entity)) {
-            final stat = await entity.stat();
-            final dirEntity = DirectoryEntity(
-              id: _generateId(entity.path),
-              path: entity.path,
-              name: dirName,
-              thumbnailPath: null,
-              tagIds: const [],
-              lastModified: stat.modified,
-            );
-            directories.add(dirEntity);
-          }
-
-          // Recursively scan subdirectories
-          await _scanDirectoryRecursive(entity, directories);
-        }
-      }
-    } catch (e) {
-      // Log permission errors for debugging
-      LoggingService.instance.error('Failed to scan directory ${directory.path}: $e');
-      if (e.toString().contains('Operation not permitted') || e.toString().contains('errno = 1')) {
-        LoggingService.instance.warning('Permission denied - security-scoped bookmark may have expired');
-      }
-      // Skip directories we can't access
-      return;
-    }
-  }
-
-  /// Checks if a directory contains any media files.
-  Future<bool> _directoryContainsMedia(Directory directory) async {
-    try {
-      await for (final entity in directory.list(
-        recursive: false,
-        followLinks: false,
-      )) {
-        if (entity is File) {
-          final extension = path
-              .extension(entity.path)
-              .toLowerCase()
-              .replaceFirst('.', '');
-
-          if (_mediaExtensions.contains(extension)) {
-            return true;
-          }
-        }
-      }
-      return false;
-    } catch (e) {
-      return false;
     }
   }
 
@@ -246,5 +198,315 @@ class LocalDirectoryDataSource {
   /// Generates a unique ID from directory path using a shared hash strategy.
   String _generateId(String directoryPath) {
     return generateDirectoryId(directoryPath);
+  }
+
+  Future<List<DirectoryEntity>> _scanDirectoryInIsolate(
+    String rootPath, {
+    DirectoryScanProgressCallback? onProgress,
+    DirectoryScanCancellationToken? cancellationToken,
+  }) async {
+    final receivePort = ReceivePort();
+    final errorPort = ReceivePort();
+
+    Isolate? isolate;
+    StreamSubscription<dynamic>? receiveSubscription;
+    StreamSubscription<dynamic>? errorSubscription;
+    final directories = <DirectoryEntity>[];
+    final completer = Completer<List<DirectoryEntity>>();
+    SendPort? controlPort;
+
+    void handleCompletion(
+      Map<dynamic, dynamic> payload, {
+      required bool cancelled,
+    }) {
+      final rawDirectories = (payload['directories'] as List?) ?? const [];
+      directories
+        ..clear()
+        ..addAll(
+          rawDirectories
+              .whereType<Map<dynamic, dynamic>>()
+              .map(_mapPayloadToDirectory),
+        );
+
+      final progress = DirectoryScanProgress(
+        scannedDirectories: (payload['scanned'] as int?) ?? 0,
+        directoriesWithMediaCount: (payload['found'] as int?) ?? directories.length,
+        currentPath: payload['currentPath'] as String?,
+        directories: List<DirectoryEntity>.from(directories),
+        isComplete: true,
+        isCancelled: cancelled,
+      );
+
+      onProgress?.call(progress);
+
+      if (!completer.isCompleted) {
+        completer.complete(List<DirectoryEntity>.from(directories));
+      }
+    }
+
+    void handleProgress(Map<dynamic, dynamic> payload) {
+      final progress = DirectoryScanProgress(
+        scannedDirectories: (payload['scanned'] as int?) ?? 0,
+        directoriesWithMediaCount: (payload['found'] as int?) ?? 0,
+        currentPath: payload['currentPath'] as String?,
+      );
+      onProgress?.call(progress);
+    }
+
+    try {
+      isolate = await Isolate.spawn<_DirectoryScanIsolateRequest>(
+        _scanDirectoryRecursiveIsolate,
+        _DirectoryScanIsolateRequest(
+          rootPath: rootPath,
+          mediaExtensions: _mediaExtensions.toList(),
+          excludedNames: _excludedNames.toList(),
+          sendPort: receivePort.sendPort,
+        ),
+        onError: errorPort.sendPort,
+      );
+
+      receiveSubscription = receivePort.listen((message) {
+        if (message is SendPort) {
+          controlPort = message;
+          if (cancellationToken?.isCancelled ?? false) {
+            controlPort?.send(_scanCancelMessage);
+          }
+          cancellationToken?.addListener(() {
+            controlPort?.send(_scanCancelMessage);
+          });
+          return;
+        }
+
+        if (message is! Map<dynamic, dynamic>) {
+          return;
+        }
+
+        final type = message['type'];
+        if (type == _scanProgressType) {
+          handleProgress(message);
+          return;
+        }
+
+        if (type == _scanCompleteType) {
+          handleCompletion(message, cancelled: false);
+          return;
+        }
+
+        if (type == _scanCancelledType) {
+          handleCompletion(message, cancelled: true);
+          return;
+        }
+      });
+
+      errorSubscription = errorPort.listen((message) {
+        if (completer.isCompleted) {
+          return;
+        }
+
+        completer.completeError(
+          DirectoryScanError('Failed to scan directories: $message'),
+        );
+      });
+
+      final result = await completer.future;
+      return result;
+    } finally {
+      await receiveSubscription?.cancel();
+      await errorSubscription?.cancel();
+      receivePort.close();
+      errorPort.close();
+      isolate?.kill(priority: Isolate.immediate);
+    }
+  }
+
+  DirectoryEntity _mapPayloadToDirectory(Map<dynamic, dynamic> payload) {
+    final pathValue = payload['path'] as String;
+    final modifiedEpoch = payload['modified'] as int;
+    return DirectoryEntity(
+      id: _generateId(pathValue),
+      path: pathValue,
+      name: payload['name'] as String,
+      thumbnailPath: null,
+      tagIds: const [],
+      lastModified: DateTime.fromMillisecondsSinceEpoch(modifiedEpoch),
+    );
+  }
+}
+
+class DirectoryScanProgress {
+  const DirectoryScanProgress({
+    required this.scannedDirectories,
+    required this.directoriesWithMediaCount,
+    this.currentPath,
+    this.directories = const <DirectoryEntity>[],
+    this.isComplete = false,
+    this.isCancelled = false,
+  });
+
+  final int scannedDirectories;
+  final int directoriesWithMediaCount;
+  final String? currentPath;
+  final List<DirectoryEntity> directories;
+  final bool isComplete;
+  final bool isCancelled;
+}
+
+typedef _CancelListener = void Function();
+
+class DirectoryScanCancellationToken {
+  DirectoryScanCancellationToken();
+
+  bool _isCancelled = false;
+  final List<_CancelListener> _listeners = <_CancelListener>[];
+
+  bool get isCancelled => _isCancelled;
+
+  void cancel() {
+    if (_isCancelled) {
+      return;
+    }
+    _isCancelled = true;
+    final listenersSnapshot = List<_CancelListener>.from(_listeners);
+    for (final listener in listenersSnapshot) {
+      listener();
+    }
+  }
+
+  void addListener(_CancelListener listener) {
+    if (_isCancelled) {
+      listener();
+      return;
+    }
+    _listeners.add(listener);
+  }
+
+  void removeListener(_CancelListener listener) {
+    _listeners.remove(listener);
+  }
+}
+
+class _DirectoryScanIsolateRequest {
+  const _DirectoryScanIsolateRequest({
+    required this.rootPath,
+    required this.mediaExtensions,
+    required this.excludedNames,
+    required this.sendPort,
+  });
+
+  final String rootPath;
+  final List<String> mediaExtensions;
+  final List<String> excludedNames;
+  final SendPort sendPort;
+}
+
+Future<void> _scanDirectoryRecursiveIsolate(
+  _DirectoryScanIsolateRequest request,
+) async {
+  final excludedNames = Set<String>.from(request.excludedNames);
+  final mediaExtensions = Set<String>.from(request.mediaExtensions);
+  final progressPort = request.sendPort;
+  final controlPort = ReceivePort();
+
+  progressPort.send(controlPort.sendPort);
+
+  final directoriesWithMedia = <Map<String, Object?>>[];
+  final directoriesToVisit = <Directory>[Directory(request.rootPath)];
+  var scannedDirectories = 0;
+  var cancelled = false;
+
+  controlPort.listen((message) {
+    if (message == LocalDirectoryDataSource._scanCancelMessage) {
+      cancelled = true;
+    }
+  });
+
+  while (directoriesToVisit.isNotEmpty && !cancelled) {
+    final directory = directoriesToVisit.removeLast();
+    scannedDirectories++;
+
+    progressPort.send({
+      'type': LocalDirectoryDataSource._scanProgressType,
+      'scanned': scannedDirectories,
+      'found': directoriesWithMedia.length,
+      'currentPath': directory.path,
+    });
+
+    try {
+      await for (final entity in directory.list(
+        recursive: false,
+        followLinks: false,
+      )) {
+        if (entity is! Directory) {
+          continue;
+        }
+
+        final dirName = path.basename(entity.path);
+
+        if (excludedNames.contains(dirName) || dirName.startsWith('.')) {
+          continue;
+        }
+
+        directoriesToVisit.add(entity);
+
+        if (await _directoryContainsMediaInIsolate(entity, mediaExtensions)) {
+          final stat = await entity.stat();
+          directoriesWithMedia.add({
+            'path': entity.path,
+            'name': dirName,
+            'modified': stat.modified.millisecondsSinceEpoch,
+          });
+          progressPort.send({
+            'type': LocalDirectoryDataSource._scanProgressType,
+            'scanned': scannedDirectories,
+            'found': directoriesWithMedia.length,
+            'currentPath': entity.path,
+          });
+        }
+      }
+    } catch (_) {
+      // Ignore directories we cannot access within the isolate to keep scanning.
+    }
+
+    if (scannedDirectories % 25 == 0) {
+      await Future<void>.delayed(Duration.zero);
+    }
+  }
+
+  progressPort.send({
+    'type': cancelled
+        ? LocalDirectoryDataSource._scanCancelledType
+        : LocalDirectoryDataSource._scanCompleteType,
+    'directories': directoriesWithMedia,
+    'scanned': scannedDirectories,
+    'found': directoriesWithMedia.length,
+  });
+
+  controlPort.close();
+}
+
+Future<bool> _directoryContainsMediaInIsolate(
+  Directory directory,
+  Set<String> mediaExtensions,
+) async {
+  try {
+    await for (final entity in directory.list(
+      recursive: false,
+      followLinks: false,
+    )) {
+      if (entity is! File) {
+        continue;
+      }
+      final extension = path
+          .extension(entity.path)
+          .toLowerCase()
+          .replaceFirst('.', '');
+
+      if (mediaExtensions.contains(extension)) {
+        return true;
+      }
+    }
+    return false;
+  } catch (_) {
+    return false;
   }
 }

--- a/lib/features/media_library/presentation/view_models/media_grid_view_model.dart
+++ b/lib/features/media_library/presentation/view_models/media_grid_view_model.dart
@@ -1064,7 +1064,7 @@ class MediaViewModelParams {
     String? bookmarkData,
     List<DirectoryNavigationTarget>? siblingDirectories,
     int? currentIndex,
-    {bool replaceCurrentRoute},
+    {bool replaceCurrentRoute}
   )?
   navigateToDirectory;
   final Future<String?> Function()? onPermissionRecoveryNeeded;

--- a/lib/features/media_library/presentation/widgets/duplicate_scan_status_bar.dart
+++ b/lib/features/media_library/presentation/widgets/duplicate_scan_status_bar.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:media_fast_view/features/media_library/domain/entities/directory_entity.dart';
+import 'package:media_fast_view/shared/providers/duplicate_media_scan_provider.dart';
+
+import '../../../../core/constants/ui_constants.dart';
+
+/// Displays lightweight progress feedback while duplicate scans run in the background.
+class DuplicateScanStatusBar extends ConsumerWidget {
+  const DuplicateScanStatusBar({
+    super.key,
+    required this.rootDirectory,
+  });
+
+  final DirectoryEntity rootDirectory;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final scanState = ref.watch(duplicateMediaScanProvider(rootDirectory));
+
+    return scanState.when(
+      data: (progress) {
+        final isScanning = !progress.isComplete && !progress.isCancelled;
+
+        if (!isScanning) {
+          return const SizedBox.shrink();
+        }
+
+        return Container(
+          width: double.infinity,
+          padding: const EdgeInsets.symmetric(
+            horizontal: UiSpacing.verticalGap,
+            vertical: UiSpacing.smallGap,
+          ),
+          color: Theme.of(context).colorScheme.surfaceVariant,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  const Icon(Icons.refresh),
+                  const SizedBox(width: UiSpacing.smallGap),
+                  Expanded(
+                    child: Text(
+                      'Scanning library for duplicates...',
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
+                  ),
+                  IconButton(
+                    tooltip: 'Restart duplicate scan',
+                    onPressed: () => ref.refresh(
+                      duplicateMediaScanProvider(rootDirectory),
+                    ),
+                    icon: const Icon(Icons.refresh),
+                  ),
+                ],
+              ),
+              const SizedBox(height: UiSpacing.extraSmallGap),
+              const LinearProgressIndicator(),
+            ],
+          ),
+        );
+      },
+      loading: () => const Padding(
+        padding: UiSpacing.gridPadding,
+        child: LinearProgressIndicator(),
+      ),
+      error: (error, _) => Padding(
+        padding: UiSpacing.gridPadding,
+        child: Text('Failed to scan duplicates: $error'),
+      ),
+    );
+  }
+}

--- a/lib/shared/providers/duplicate_media_scan_provider.dart
+++ b/lib/shared/providers/duplicate_media_scan_provider.dart
@@ -1,0 +1,35 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../features/media_library/data/data_sources/local_directory_data_source.dart';
+import '../../features/media_library/domain/entities/directory_entity.dart';
+import 'repository_providers.dart';
+
+/// Streams directory scan progress and results for duplicate media detection flows.
+final duplicateMediaScanProvider = StreamProvider.autoDispose
+    .family<DirectoryScanProgress, DirectoryEntity>((ref, rootDirectory) {
+  final controller = StreamController<DirectoryScanProgress>();
+  final cancellationToken = DirectoryScanCancellationToken();
+
+  ref.onDispose(() {
+    cancellationToken.cancel();
+    controller.close();
+  });
+
+  unawaited(() async {
+    try {
+      await ref.read(localDirectoryDataSourceProvider).scanDirectoriesWithMedia(
+            rootDirectory,
+            cancellationToken: cancellationToken,
+            onProgress: controller.add,
+          );
+    } catch (error, stackTrace) {
+      controller.addError(error, stackTrace);
+    } finally {
+      await controller.close();
+    }
+  }());
+
+  return controller.stream;
+});


### PR DESCRIPTION
## Summary
- offload directory scanning to a background isolate with progress callbacks and cancellation support
- add DirectoryScanProgress and DirectoryScanCancellationToken to surface progress updates and cancellation requests
- keep directory listing helper while preserving bookmark lifecycle and error handling

## Testing
- Not run (Dart/Flutter tooling not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a098fd72c8320b794bbdb49df7a18)