### PR TITLE
Guard grid screen debug logging

### DIFF
--- a/lib/features/media_library/presentation/screens/directory_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/directory_grid_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'dart:developer' as developer;
 import 'dart:ui';
 
 import 'package:desktop_drop/desktop_drop.dart';
@@ -50,6 +51,8 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
   Set<String> _directoryMarqueeBaseSelection = <String>{};
   Set<String> _directoryLastMarqueeSelection = <String>{};
   Map<String, Rect> _directoryCachedItemRects = <String, Rect>{};
+  List<String> _lastLoggedSelectedTagIds = const [];
+  List<String> _lastLoggedAvailableTags = const [];
 
   @override
   Widget build(BuildContext context) {
@@ -391,10 +394,7 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
     };
     final normalizedSelectedTagIds = List<String>.from(selectedTagIds);
 
-    // Debug logging for tag filter state
-    debugPrint(
-      'DirectoryGridScreen: Building tag filter with selectedTagIds: $normalizedSelectedTagIds',
-    );
+    _logDirectoryTagSelection(normalizedSelectedTagIds);
 
     final favoritesState = ref.watch(favoritesViewModelProvider);
     final hasFavoriteDirectories = switch (favoritesState) {
@@ -454,15 +454,19 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
     List<String> selectedTagIds,
     DirectoryViewModel viewModel,
   ) {
-    debugPrint(
-      'DirectoryGridScreen: Available tags: ${tags.map((t) => t.name).toList()}',
-    );
+    final tagNames = tags.map((tag) => tag.name).toList(growable: false);
+    if (!listEquals(_lastLoggedAvailableTags, tagNames)) {
+      _lastLoggedAvailableTags = List<String>.from(tagNames);
+      _logDirectoryDebug(
+        'DirectoryGridScreen: Available tags: $_lastLoggedAvailableTags',
+      );
+    }
 
     return SelectableTagChipStrip(
       tags: tags,
       selectedTagIds: selectedTagIds,
       onSelectionChanged: (newSelection) {
-        debugPrint(
+        _logDirectoryDebug(
           'DirectoryGridScreen: Tag selection changed: $newSelection',
         );
         viewModel.filterByTags(newSelection);
@@ -514,6 +518,23 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
       },
     );
     return _buildDirectoryMarqueeWrapper(viewModel: viewModel, child: gridView);
+  }
+
+  void _logDirectoryTagSelection(List<String> normalizedSelectedTagIds) {
+    if (listEquals(_lastLoggedSelectedTagIds, normalizedSelectedTagIds)) {
+      return;
+    }
+    _lastLoggedSelectedTagIds = List<String>.from(normalizedSelectedTagIds);
+    _logDirectoryDebug(
+      'DirectoryGridScreen: Building tag filter with selectedTagIds: $_lastLoggedSelectedTagIds',
+    );
+  }
+
+  void _logDirectoryDebug(String message) {
+    if (!kDebugMode) {
+      return;
+    }
+    developer.log(message, name: 'DirectoryGridScreen');
   }
 
   Widget _buildPermissionRevokedGrid(

--- a/lib/features/media_library/presentation/screens/media_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/media_grid_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'dart:developer' as developer;
 import 'dart:ui';
 
 import 'package:file_picker/file_picker.dart';
@@ -62,6 +63,11 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
   Map<String, Rect> _mediaCachedItemRects = <String, Rect>{};
   List<DirectoryNavigationTarget> _siblingNavigationTargets = const [];
   int _currentDirectoryNavigationIndex = 0;
+  Size? _lastLoggedScreenSize;
+  Size? _lastLoggedGridSize;
+  String? _lastLoggedDirectoryName;
+  int? _lastLoggedGridItemCount;
+  int? _lastLoggedGridColumns;
 
   bool get _isMacOS => !kIsWeb && defaultTargetPlatform == TargetPlatform.macOS;
 
@@ -115,9 +121,12 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
 
   @override
   Widget build(BuildContext context) {
-    debugPrint(
-      'MediaGridScreen: Building for ${widget.directoryName}, screen size: ${MediaQuery.of(context).size}',
-    );
+    final screenSize = MediaQuery.of(context).size;
+    if (_shouldLogBuild(screenSize)) {
+      _logMediaDebug(
+        'MediaGridScreen: Building for ${widget.directoryName}, screen size: $screenSize',
+      );
+    }
     _params = MediaViewModelParams(
       directoryPath: widget.directoryPath,
       directoryName: widget.directoryName,
@@ -642,9 +651,12 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
     Set<String> selectedMediaIds,
     bool isSelectionMode,
   ) {
-    debugPrint(
-      'MediaGridScreen: Building grid with ${media.length} items, $columns columns, screen size: ${MediaQuery.of(context).size}',
-    );
+    final screenSize = MediaQuery.of(context).size;
+    if (_shouldLogGrid(media.length, columns, screenSize)) {
+      _logMediaDebug(
+        'MediaGridScreen: Building grid with ${media.length} items, $columns columns, screen size: $screenSize',
+      );
+    }
     _pruneMediaItemKeys(media);
     final gridView = GridView.builder(
       padding: UiSpacing.gridPadding,
@@ -714,6 +726,39 @@ class _MediaGridScreenState extends ConsumerState<MediaGridScreen> {
         ],
       ),
     );
+  }
+
+  bool _shouldLogBuild(Size screenSize) {
+    final hasDirectoryChanged = _lastLoggedDirectoryName != widget.directoryName;
+    final hasScreenChanged = _lastLoggedScreenSize != screenSize;
+    if (hasDirectoryChanged || hasScreenChanged) {
+      _lastLoggedDirectoryName = widget.directoryName;
+      _lastLoggedScreenSize = screenSize;
+      return true;
+    }
+    return false;
+  }
+
+  bool _shouldLogGrid(int itemCount, int columns, Size screenSize) {
+    final hasItemCountChanged = _lastLoggedGridItemCount != itemCount;
+    final hasColumnChanged = _lastLoggedGridColumns != columns;
+    final hasScreenSizeChanged = _lastLoggedGridSize != screenSize;
+
+    if (hasItemCountChanged || hasColumnChanged || hasScreenSizeChanged) {
+      _lastLoggedGridItemCount = itemCount;
+      _lastLoggedGridColumns = columns;
+      _lastLoggedGridSize = screenSize;
+      return true;
+    }
+
+    return false;
+  }
+
+  void _logMediaDebug(String message) {
+    if (!kDebugMode) {
+      return;
+    }
+    developer.log(message, name: 'MediaGridScreen');
   }
 
   void _handleMediaPointerDown(


### PR DESCRIPTION
## Summary
- add guarded developer logging helpers to the directory and media grid screens
- emit tag filter and grid diagnostics only when inputs change to avoid per-frame logging
- keep selection and marquee callbacks lightweight while maintaining selection behavior

## Testing
- not run (environment missing Dart/Flutter tooling)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a1d7989a48320a2cdd86074ba468f)