### PR TITLE
Add tag color and shortcut configuration

### DIFF
--- a/lib/features/tagging/presentation/widgets/tag_edit_dialog.dart
+++ b/lib/features/tagging/presentation/widgets/tag_edit_dialog.dart
@@ -1,0 +1,200 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../shared/providers/tag_shortcut_preferences_provider.dart';
+import '../../../../shared/utils/tag_shortcut_preferences.dart';
+import '../../../../shared/utils/tag_usage_ranker.dart';
+import '../../domain/entities/tag_entity.dart';
+import '../view_models/tag_management_view_model.dart';
+import 'tag_color_picker.dart';
+
+class TagEditDialog extends ConsumerStatefulWidget {
+  const TagEditDialog({super.key, required this.tag});
+
+  final TagEntity tag;
+
+  static Future<void> show(BuildContext context, TagEntity tag) {
+    return showDialog(
+      context: context,
+      builder: (context) => TagEditDialog(tag: tag),
+    );
+  }
+
+  @override
+  ConsumerState<TagEditDialog> createState() => _TagEditDialogState();
+}
+
+class _TagEditDialogState extends ConsumerState<TagEditDialog> {
+  static const int _noShortcut = -1;
+
+  late int _selectedColor;
+  int _selectedShortcutSlot = _noShortcut;
+  bool _isSaving = false;
+  List<String> _storedShortcutIds = const <String>[];
+  Map<String, String> _tagNamesById = const <String, String>{};
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedColor = widget.tag.color;
+    _loadShortcutState();
+  }
+
+  Future<void> _loadShortcutState() async {
+    final shortcutPreferences = ref.read(tagShortcutPreferencesProvider);
+    final tagViewModel = ref.read(tagViewModelProvider.notifier);
+
+    final shortcuts = await shortcutPreferences.loadShortcutTagIds();
+    final slotIndex = shortcuts.indexOf(widget.tag.id);
+    final tagNames = {
+      for (final tag in tagViewModel.getAllTags()) tag.id: tag.name,
+    };
+
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _storedShortcutIds = shortcuts;
+      _selectedShortcutSlot = slotIndex == -1 ? _noShortcut : slotIndex + 1;
+      _tagNamesById = tagNames;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Edit Tag'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            widget.tag.name,
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 16),
+          TagColorPicker(
+            selectedColor: _selectedColor,
+            onColorSelected: (color) => setState(() => _selectedColor = color),
+          ),
+          const SizedBox(height: 16),
+          DropdownButtonFormField<int>(
+            value: _selectedShortcutSlot,
+            decoration: const InputDecoration(
+              labelText: 'Keyboard shortcut',
+              border: OutlineInputBorder(),
+            ),
+            items: [
+              const DropdownMenuItem<int>(
+                value: _noShortcut,
+                child: Text('No shortcut'),
+              ),
+              ...List<DropdownMenuItem<int>>.generate(
+                TagUsageRanker.defaultLimit,
+                (index) {
+                  final slot = index + 1;
+                  final occupant = _slotLabel(slot);
+                  return DropdownMenuItem<int>(
+                    value: slot,
+                    child: Text(occupant),
+                  );
+                },
+              ),
+            ],
+            onChanged: (value) {
+              if (value == null) {
+                return;
+              }
+              setState(() {
+                _selectedShortcutSlot = value;
+              });
+            },
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: _isSaving ? null : () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _isSaving ? null : () => _saveTag(context),
+          child: _isSaving
+              ? const SizedBox(
+                  height: 16,
+                  width: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Text('Save'),
+        ),
+      ],
+    );
+  }
+
+  String _slotLabel(int slot) {
+    final slotIndex = slot - 1;
+    final occupantId =
+        slotIndex < _storedShortcutIds.length ? _storedShortcutIds[slotIndex] : null;
+
+    if (occupantId != null && occupantId.isNotEmpty && occupantId != widget.tag.id) {
+      final occupantName = _tagNamesById[occupantId];
+      if (occupantName != null) {
+        return '$slot – $occupantName';
+      }
+    }
+    return '$slot';
+  }
+
+  Future<void> _saveTag(BuildContext context) async {
+    setState(() {
+      _isSaving = true;
+    });
+
+    final tagViewModel = ref.read(tagViewModelProvider.notifier);
+    final shortcutPreferences = ref.read(tagShortcutPreferencesProvider);
+    final updatedTag = widget.tag.copyWith(color: _selectedColor);
+
+    try {
+      await tagViewModel.updateTag(updatedTag);
+
+      final updatedShortcuts = List<String>.from(_storedShortcutIds)
+        ..removeWhere((id) => id == widget.tag.id);
+
+      if (_selectedShortcutSlot > 0) {
+        final targetIndex = _selectedShortcutSlot - 1;
+        while (updatedShortcuts.length <= targetIndex) {
+          updatedShortcuts.add('');
+        }
+        updatedShortcuts[targetIndex] = widget.tag.id;
+      }
+
+      while (updatedShortcuts.isNotEmpty && updatedShortcuts.last.isEmpty) {
+        updatedShortcuts.removeLast();
+      }
+
+      await shortcutPreferences.saveShortcutTagIds(updatedShortcuts);
+
+      if (mounted) {
+        Navigator.of(context).pop();
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Updated "${widget.tag.name}"')),
+        );
+      }
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Failed to update tag: $error')),
+      );
+    } finally {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _isSaving = false;
+      });
+    }
+  }
+}

--- a/lib/features/tagging/presentation/widgets/tag_management_dialog.dart
+++ b/lib/features/tagging/presentation/widgets/tag_management_dialog.dart
@@ -9,6 +9,7 @@ import '../../domain/use_cases/assign_tag_use_case.dart';
 import '../view_models/tag_management_view_model.dart';
 import '../view_models/tags_view_model.dart';
 import 'tag_creation_dialog.dart';
+import 'tag_edit_dialog.dart';
 
 /// A dialog for managing tags - viewing, adding, removing, and assigning.
 class TagManagementDialog extends ConsumerWidget {
@@ -52,7 +53,10 @@ class TagManagementDialog extends ConsumerWidget {
               // nested directories, causing the new tag to be lost on reload.
               await assignTagUseCase.toggleTagOnMedia(media!.id, tag);
               await tagsNotifier.refreshTags();
-            },
+          },
+      onTagLongPress: media == null
+          ? (tag) => TagEditDialog.show(context, tag)
+          : null,
       showCancelButton: true,
       cancelLabel: 'Close',
       showConfirmButton: false,

--- a/lib/shared/providers/tag_shortcut_preferences_provider.dart
+++ b/lib/shared/providers/tag_shortcut_preferences_provider.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../utils/tag_shortcut_preferences.dart';
+
+/// Provides access to persisted tag shortcut configuration.
+final tagShortcutPreferencesProvider =
+    Provider<TagShortcutPreferences>((ref) => TagShortcutPreferences());

--- a/lib/shared/utils/tag_shortcut_preferences.dart
+++ b/lib/shared/utils/tag_shortcut_preferences.dart
@@ -1,0 +1,25 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Persists and loads the ordered list of tag identifiers that should be
+/// exposed as keyboard shortcuts.
+class TagShortcutPreferences {
+  TagShortcutPreferences({SharedPreferences? preferences})
+      : _preferencesFuture =
+            preferences != null ? Future.value(preferences) : SharedPreferences.getInstance();
+
+  static const String _shortcutKey = 'tag_shortcut_ids';
+
+  final Future<SharedPreferences> _preferencesFuture;
+
+  /// Returns the stored tag identifiers in shortcut order (1-based externally).
+  Future<List<String>> loadShortcutTagIds() async {
+    final prefs = await _preferencesFuture;
+    return prefs.getStringList(_shortcutKey) ?? const <String>[];
+  }
+
+  /// Saves the provided [tagIds] in shortcut order.
+  Future<void> saveShortcutTagIds(List<String> tagIds) async {
+    final prefs = await _preferencesFuture;
+    await prefs.setStringList(_shortcutKey, tagIds);
+  }
+}

--- a/lib/shared/widgets/tag_selection_dialog.dart
+++ b/lib/shared/widgets/tag_selection_dialog.dart
@@ -11,6 +11,7 @@ typedef TagDeletionCallback = Future<void> Function(BuildContext context, TagEnt
 typedef TagCreationCallback = Future<void> Function(BuildContext context);
 typedef TagSelectionConfirmCallback<T> = Future<T?> Function(List<String> tagIds);
 typedef TagSelectionLoader = Future<List<String>> Function();
+typedef TagLongPressCallback = Future<void> Function(TagEntity tag);
 
 /// A flexible dialog for selecting and managing tags across multiple flows.
 ///
@@ -33,6 +34,7 @@ class TagSelectionDialog<T> extends ConsumerStatefulWidget {
     this.cancelResult,
     this.onSelectionChanged,
     this.onTagToggle,
+    this.onTagLongPress,
     this.onDeleteTag,
     this.onCreateTag,
     this.showCreateButton = false,
@@ -68,6 +70,9 @@ class TagSelectionDialog<T> extends ConsumerStatefulWidget {
 
   /// Invoked when a tag is toggled. Used for immediate persistence flows.
   final TagToggleCallback? onTagToggle;
+
+  /// Callback invoked when a tag chip is long-pressed.
+  final TagLongPressCallback? onTagLongPress;
 
   /// Callback that is invoked when the delete icon on a tag is pressed.
   final TagDeletionCallback? onDeleteTag;
@@ -306,6 +311,9 @@ class _TagSelectionDialogState<T>
                       tag: tag,
                       selected: _selectedTagIds.contains(tag.id),
                       onTap: () => _handleTagTapped(context, tag),
+                      onLongPress: widget.onTagLongPress == null
+                          ? null
+                          : () => widget.onTagLongPress!(tag),
                       showDeleteIcon: widget.showDeleteButtons,
                       onDeleted: widget.showDeleteButtons
                           ? () => widget.onDeleteTag?.call(context, tag)


### PR DESCRIPTION
## Summary
- add an edit dialog so existing tags can change colors and assign a keyboard shortcut slot
- persist preferred shortcut tag order and merge it with usage-based ranking in the full-screen viewer
- expose shared preferences provider for shortcut configuration and wire it through tag management

## Testing
- Not run (dart/flutter tooling unavailable in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b6d5a4a5883209a4c9498ad75a455)