### PR TITLE
Add tag color editing for existing tags

### DIFF
--- a/lib/features/tagging/presentation/widgets/tag_color_edit_dialog.dart
+++ b/lib/features/tagging/presentation/widgets/tag_color_edit_dialog.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../shared/utils/tag_cache_refresher.dart';
+import '../view_models/tag_management_view_model.dart';
+import 'tag_color_picker.dart';
+import '../../domain/entities/tag_entity.dart';
+
+/// Dialog for updating the color of an existing tag.
+class TagColorEditDialog extends ConsumerStatefulWidget {
+  const TagColorEditDialog({
+    super.key,
+    required this.tag,
+  });
+
+  final TagEntity tag;
+
+  static Future<bool?> show(BuildContext context, {required TagEntity tag}) {
+    return showDialog<bool>(
+      context: context,
+      builder: (context) => TagColorEditDialog(tag: tag),
+    );
+  }
+
+  @override
+  ConsumerState<TagColorEditDialog> createState() => _TagColorEditDialogState();
+}
+
+class _TagColorEditDialogState extends ConsumerState<TagColorEditDialog> {
+  late int _selectedColor = widget.tag.color;
+  bool _isSaving = false;
+  String? _errorMessage;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return AlertDialog(
+      title: Text('Edit "${widget.tag.name}" color'),
+      content: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 420),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Adjust the color used for this tag and any shortcut assignments.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 16),
+            TagColorPicker(
+              selectedColor: _selectedColor,
+              onColorSelected: (color) => setState(() {
+                _selectedColor = color;
+              }),
+            ),
+            if (_errorMessage != null) ...[
+              const SizedBox(height: 12),
+              Text(
+                _errorMessage!,
+                style: TextStyle(color: theme.colorScheme.error),
+              ),
+            ],
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: _isSaving ? null : () => Navigator.of(context).pop(false),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _isSaving ? null : _save,
+          child: _isSaving
+              ? const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Text('Save'),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _save() async {
+    if (_selectedColor == widget.tag.color) {
+      Navigator.of(context).pop(false);
+      return;
+    }
+
+    setState(() {
+      _isSaving = true;
+      _errorMessage = null;
+    });
+
+    try {
+      final updatedTag = widget.tag.copyWith(color: _selectedColor);
+      await ref.read(tagViewModelProvider.notifier).updateTag(updatedTag);
+      await ref.read(tagCacheRefresherProvider).refresh();
+
+      if (!mounted) {
+        return;
+      }
+
+      Navigator.of(context).pop(true);
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _isSaving = false;
+        _errorMessage = 'Failed to update tag color: $error';
+      });
+    }
+  }
+}

--- a/lib/shared/widgets/tag_selection_dialog.dart
+++ b/lib/shared/widgets/tag_selection_dialog.dart
@@ -5,6 +5,7 @@ import '../../features/tagging/domain/entities/tag_entity.dart';
 import '../../features/tagging/presentation/states/tag_state.dart';
 import '../../features/tagging/presentation/view_models/tag_management_view_model.dart';
 import '../../features/tagging/presentation/widgets/tag_chip.dart';
+import '../../features/tagging/presentation/widgets/tag_color_edit_dialog.dart';
 
 typedef TagToggleCallback = Future<void> Function(TagEntity tag, bool isSelected);
 typedef TagDeletionCallback = Future<void> Function(BuildContext context, TagEntity tag);
@@ -254,6 +255,16 @@ class _TagSelectionDialogState<T>
               color: theme.colorScheme.onSurfaceVariant,
             ),
           ),
+        if (widget.showDeleteButtons)
+          Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: Text(
+              'Long press a tag to edit its color.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
         if (widget.showCreateButton)
           Padding(
             padding: EdgeInsets.only(
@@ -306,6 +317,9 @@ class _TagSelectionDialogState<T>
                       tag: tag,
                       selected: _selectedTagIds.contains(tag.id),
                       onTap: () => _handleTagTapped(context, tag),
+                      onLongPress: widget.showDeleteButtons
+                          ? () => _handleTagLongPress(context, tag)
+                          : null,
                       showDeleteIcon: widget.showDeleteButtons,
                       onDeleted: widget.showDeleteButtons
                           ? () => widget.onDeleteTag?.call(context, tag)
@@ -453,6 +467,20 @@ class _TagSelectionDialogState<T>
       setState(() {
         _inFlightTagIds.remove(tag.id);
       });
+    }
+  }
+
+  Future<void> _handleTagLongPress(BuildContext context, TagEntity tag) async {
+    if (!widget.showDeleteButtons || _isProcessing) {
+      return;
+    }
+
+    final updated = await TagColorEditDialog.show(context, tag: tag);
+
+    if (updated == true && mounted) {
+      ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+        SnackBar(content: Text('Updated "${tag.name}" color')),
+      );
     }
   }
 }


### PR DESCRIPTION
## Summary
- add a color edit dialog so existing tags can be updated with new colors and caches refresh
- enable long-press editing from the tag management dialog with guidance text for users

## Testing
- Not run (dart tooling not available in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b6d5a4a5883209a4c9498ad75a455)