### PR TITLE
Stop full-screen video audio when exiting viewer

### DIFF
--- a/lib/features/full_screen/presentation/screens/full_screen_viewer_screen.dart
+++ b/lib/features/full_screen/presentation/screens/full_screen_viewer_screen.dart
@@ -84,6 +84,7 @@ class _FullScreenViewerScreenState
   @override
   void dispose() {
     _hideControlsTimer?.cancel();
+    _videoPlayerKey.currentState?.stopPlayback();
     _focusNode.dispose();
     super.dispose();
   }
@@ -679,6 +680,7 @@ class _FullScreenViewerScreenState
   }
 
   void _popWithResult() {
+    _videoPlayerKey.currentState?.stopPlayback();
     final currentDirectory = _viewModel.currentDirectory;
     if (currentDirectory == null) {
       Navigator.of(context).pop();

--- a/lib/features/full_screen/presentation/widgets/full_screen_video_player.dart
+++ b/lib/features/full_screen/presentation/widgets/full_screen_video_player.dart
@@ -170,6 +170,20 @@ class FullScreenVideoPlayerState extends State<FullScreenVideoPlayer> {
     super.dispose();
   }
 
+  Future<void> stopPlayback() async {
+    final controller = _controller;
+    if (controller == null) {
+      return;
+    }
+
+    try {
+      await controller.pause();
+      await controller.setVolume(0.0);
+    } catch (error) {
+      LoggingService.instance.error('Video stop error: $error');
+    }
+  }
+
   Future<void> seekTo(Duration position) async {
     if (_controller == null || !_controller!.value.isInitialized) {
       return;
@@ -212,6 +226,8 @@ class FullScreenVideoPlayerState extends State<FullScreenVideoPlayer> {
     }
 
     try {
+      await controller.pause();
+      await controller.setVolume(0.0);
       await controller.dispose();
     } catch (error, stackTrace) {
       LoggingService.instance.error(


### PR DESCRIPTION
### Motivation
- Fix a bug where video audio continues playing after returning from the full-screen viewer to the previous screen. 
- The lingering audio does not occur when navigating between sibling media, so the viewer must explicitly stop playback on exit. 
- Ensure the video controller is muted/paused before disposal to avoid background audio. 

### Description
- Add a `stopPlayback` helper on `FullScreenVideoPlayerState` that pauses the controller and sets its volume to `0.0` to mute audio. 
- Call `stopPlayback` from the full-screen viewer when closing (`_popWithResult`) and when the viewer widget is disposed. 
- Ensure `_disposeController` also pauses and mutes the controller before calling `dispose()` to avoid any race where audio continues after disposal. 
- Log errors from stop/dispose operations via `LoggingService` for easier debugging. 

### Testing
- Attempted to run `dart format` on the modified files (`lib/features/full_screen/presentation/screens/full_screen_viewer_screen.dart` and `lib/features/full_screen/presentation/widgets/full_screen_video_player.dart`), but the `dart` tool was not available in the environment so formatting could not be executed. 
- No automated unit or widget tests were executed as part of this change in the current environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965b1bfa9c88320b4171cb82b4cc52a)