### PR TITLE
Slideshow: compact two-row bottom controls for mobile

### DIFF
--- a/lib/features/favorites/presentation/widgets/slideshow_overlay.dart
+++ b/lib/features/favorites/presentation/widgets/slideshow_overlay.dart
@@ -265,6 +265,7 @@ class _PlaybackSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final useCompactLayout = MediaQuery.sizeOf(context).width <= 600;
     return MediaPlaybackControls(
       isPlaying: viewModel.isPlaying,
       isLooping: viewModel.isLooping,
@@ -306,6 +307,7 @@ class _PlaybackSection extends StatelessWidget {
       style: MediaPlaybackControlStyle(
         progressBackgroundColor: Colors.white.withValues(alpha: 0.3),
       ),
+      useCompactLayout: useCompactLayout,
     );
   }
 }
@@ -326,4 +328,3 @@ class _ControlsHint extends StatelessWidget {
     );
   }
 }
-


### PR DESCRIPTION
### Motivation
- Prevent the bottom overlay from overflowing on narrow screens by changing the controls layout to a compact two-row arrangement where primary navigation sits on the first row and the remaining controllers are on the second row.

### Description
- Added a `useCompactLayout` parameter to `MediaPlaybackControls` and implemented a compact, two-row layout that separates primary controls (`previous`, `play/pause`, `next`, `loop`, `mute`) from secondary controls (shuffle, playback speed, duration slider, progress bar). 
- Introduced `_buildPrimaryControls` and `_buildSecondaryControls` helper methods plus a `LayoutBuilder`-driven rendering path that sizes the slider and progress bar for compact mode and wraps secondary controls in a horizontal scroll when needed. 
- Extended `_buildDurationSlider` and `_buildProgressBar` to accept optional width parameters used in compact layout to avoid overflow. 
- Enabled compact layout in `SlideshowOverlay` for narrow screens by setting `useCompactLayout` when `MediaQuery.sizeOf(context).width <= 600`.

### Testing
- No automated unit or widget tests were executed in this environment. 
- An attempted `dart format` run (`dart format lib/shared/widgets/media_playback_controls.dart lib/features/favorites/presentation/widgets/slideshow_overlay.dart`) failed because `dart` was not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d0fd775488320b4167a41f0d5cc33)