### PR TITLE
Convert preview providers to autoDispose.family with short keep-alive and tests

### DIFF
--- a/test/shared/providers/repository_providers_test.dart
+++ b/test/shared/providers/repository_providers_test.dart
@@ -1,0 +1,158 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:media_fast_view/core/services/file_service.dart';
+import 'package:media_fast_view/shared/providers/repository_providers.dart';
+
+class _FakeFileService extends FileService {
+  _FakeFileService(this._contentsByPath);
+
+  final Map<String, List<FileSystemEntity>> _contentsByPath;
+  final Map<String, int> _readCounts = <String, int>{};
+
+  int readCountForPath(String path) {
+    return _readCounts[path] ?? 0;
+  }
+
+  @override
+  Future<List<FileSystemEntity>> getDirectoryContents(String directoryPath) async {
+    _readCounts[directoryPath] = (_readCounts[directoryPath] ?? 0) + 1;
+    return _contentsByPath[directoryPath] ?? <FileSystemEntity>[];
+  }
+}
+
+void main() {
+  group('Preview providers auto-dispose behavior', () {
+    test('directoryPreviewProvider reuses value during TTL then refetches', () async {
+      const directoryPath = '/tmp/preview-directory';
+      final fakeFileService = _FakeFileService(<String, List<FileSystemEntity>>{
+        directoryPath: <FileSystemEntity>[
+          File('$directoryPath/cover.jpg'),
+          File('$directoryPath/video.mp4'),
+        ],
+      });
+
+      final container = ProviderContainer(
+        overrides: <Override>[
+          fileServiceProvider.overrideWithValue(fakeFileService),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final firstSubscription = container.listen<AsyncValue<String?>>(
+        directoryPreviewProvider(directoryPath),
+        (_, __) {},
+        fireImmediately: true,
+      );
+      expect(
+        await container.read(directoryPreviewProvider(directoryPath).future),
+        equals('$directoryPath/cover.jpg'),
+      );
+      expect(fakeFileService.readCountForPath(directoryPath), equals(1));
+      firstSubscription.close();
+
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await container.pump();
+
+      final secondSubscription = container.listen<AsyncValue<String?>>(
+        directoryPreviewProvider(directoryPath),
+        (_, __) {},
+        fireImmediately: true,
+      );
+      expect(
+        await container.read(directoryPreviewProvider(directoryPath).future),
+        equals('$directoryPath/cover.jpg'),
+      );
+      expect(fakeFileService.readCountForPath(directoryPath), equals(1));
+      secondSubscription.close();
+
+      await Future<void>.delayed(const Duration(milliseconds: 650));
+      await container.pump();
+
+      final thirdSubscription = container.listen<AsyncValue<String?>>(
+        directoryPreviewProvider(directoryPath),
+        (_, __) {},
+        fireImmediately: true,
+      );
+      expect(
+        await container.read(directoryPreviewProvider(directoryPath).future),
+        equals('$directoryPath/cover.jpg'),
+      );
+      expect(fakeFileService.readCountForPath(directoryPath), equals(2));
+      thirdSubscription.close();
+    });
+
+    test('directoryPreviewStripProvider reuses value during TTL then refetches', () async {
+      const directoryPath = '/tmp/preview-strip-directory';
+      final fakeFileService = _FakeFileService(<String, List<FileSystemEntity>>{
+        directoryPath: <FileSystemEntity>[
+          File('$directoryPath/one.jpg'),
+          File('$directoryPath/two.jpg'),
+          File('$directoryPath/three.png'),
+        ],
+      });
+
+      final container = ProviderContainer(
+        overrides: <Override>[
+          fileServiceProvider.overrideWithValue(fakeFileService),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final firstSubscription = container.listen<AsyncValue<List<String>>>(
+        directoryPreviewStripProvider(directoryPath),
+        (_, __) {},
+        fireImmediately: true,
+      );
+      expect(
+        await container.read(directoryPreviewStripProvider(directoryPath).future),
+        equals(<String>[
+          '$directoryPath/one.jpg',
+          '$directoryPath/two.jpg',
+          '$directoryPath/three.png',
+        ]),
+      );
+      expect(fakeFileService.readCountForPath(directoryPath), equals(1));
+      firstSubscription.close();
+
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await container.pump();
+
+      final secondSubscription = container.listen<AsyncValue<List<String>>>(
+        directoryPreviewStripProvider(directoryPath),
+        (_, __) {},
+        fireImmediately: true,
+      );
+      expect(
+        await container.read(directoryPreviewStripProvider(directoryPath).future),
+        equals(<String>[
+          '$directoryPath/one.jpg',
+          '$directoryPath/two.jpg',
+          '$directoryPath/three.png',
+        ]),
+      );
+      expect(fakeFileService.readCountForPath(directoryPath), equals(1));
+      secondSubscription.close();
+
+      await Future<void>.delayed(const Duration(milliseconds: 650));
+      await container.pump();
+
+      final thirdSubscription = container.listen<AsyncValue<List<String>>>(
+        directoryPreviewStripProvider(directoryPath),
+        (_, __) {},
+        fireImmediately: true,
+      );
+      expect(
+        await container.read(directoryPreviewStripProvider(directoryPath).future),
+        equals(<String>[
+          '$directoryPath/one.jpg',
+          '$directoryPath/two.jpg',
+          '$directoryPath/three.png',
+        ]),
+      );
+      expect(fakeFileService.readCountForPath(directoryPath), equals(2));
+      thirdSubscription.close();
+    });
+  });
+}


### PR DESCRIPTION
### Motivation

- Reduce memory/handle leakage by making directory preview providers auto-dispose when no longer listened to and avoid long-lived cached state for many parameter combinations.
- Keep short reuse windows to avoid immediate re-fetch churn when UI briefly reconnects to the same preview provider.

### Description

- Converted `directoryPreviewProvider` and `directoryPreviewStripProvider` to `FutureProvider.autoDispose.family` and kept their public signatures compatible with existing `AsyncValue` consumers.
- Added a shared keep-alive helper `_configurePreviewProviderKeepAlive<T>` that calls `ref.keepAlive()` and uses `ref.onCancel`/`ref.onResume`/`ref.onDispose` with a TTL timer (500ms) to close the keep-alive link after a short delay.
- Hooked the keep-alive helper into both preview providers so results are kept warm briefly when listeners disconnect and will be disposed shortly after TTL.
- Added unit tests `test/shared/providers/repository_providers_test.dart` that use `ProviderContainer.listen` and a `_FakeFileService` override to assert that providers reuse cached values while TTL is active and refetch after TTL expiry.

### Testing

- Added tests: `test/shared/providers/repository_providers_test.dart` which verify reuse-within-TTL and refetch-after-disposal for both preview providers; these tests assert call counts on a fake `FileService` and use `ProviderContainer.listen` to control subscriptions.
- Attempted to run formatting and tooling but `dart`/`flutter` executables are not available in the current environment, so tests/formatting were not executed here (files have been formatted where possible by the patch).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bd454cfe88320a88fe98e897a8609)