### PR TITLE
Prefer static CocoaPods linkage and document iOS plugin policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,36 @@ flutter test
 
 Widget and integration test scaffolds live under `test/`. Add coverage for new view models or use cases as features evolve.
 
+## iOS CocoaPods Linkage Policy
+
+- `ios/Podfile` now defaults to CocoaPods static library integration for `Runner` (no unconditional `use_frameworks!`).
+- Dynamic framework packaging can be re-enabled only when needed:
+  - `USE_FRAMEWORKS=static pod install` to keep framework-style integration but static linkage.
+  - `USE_FRAMEWORKS=dynamic pod install` only for plugins that fail without dynamic frameworks.
+- Current iOS plugin set in `ios/Podfile.lock` (`file_picker`, `isar_flutter_libs`, `path_provider_foundation`, `shared_preferences_foundation`, `video_player_avfoundation`) does not require globally enabling dynamic frameworks.
+- If a future plugin fails with static libraries, scope framework usage narrowly:
+  1. First try `USE_FRAMEWORKS=static`.
+  2. If dynamic frameworks are unavoidable, document the specific plugin and failure mode in this section and keep framework enablement limited to iOS `Runner` only.
+
+### Controlled Build + Install Timing (Real iPhone)
+
+To avoid regressions from future dependency changes, run this before/after benchmark on a connected physical iPhone from `ios/`:
+
+```bash
+# Baseline (current default/static)
+flutter clean
+/usr/bin/time -lp flutter build ios --debug
+/usr/bin/time -lp flutter install -d <device_id>
+
+# Comparison (only if investigating framework overhead)
+flutter clean
+USE_FRAMEWORKS=dynamic pod install
+/usr/bin/time -lp flutter build ios --debug
+/usr/bin/time -lp flutter install -d <device_id>
+```
+
+Record build + install timing deltas in your PR whenever iOS plugins are added/updated.
+
 ## Roadmap & Known Gaps
 
 - Inline tag editing within the full-screen viewer, including keyboard shortcuts for quick tagging.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,24 @@ USE_FRAMEWORKS=dynamic pod install
 
 Record build + install timing deltas in your PR whenever iOS plugins are added/updated.
 
+### CocoaPods / Ruby ffi Troubleshooting
+
+If iOS debug build logs show:
+
+```text
+Ignoring ffi-1.15.5 because its extensions are not built. Try: gem pristine ffi --version 1.15.5
+```
+
+Repair the native gem extension and reinstall pods:
+
+```bash
+gem pristine ffi --version 1.15.5
+cd ios
+pod install
+```
+
+If the issue persists, reinstall CocoaPods gems for your Ruby version and rerun `pod install`.
+
 ## Roadmap & Known Gaps
 
 - Inline tag editing within the full-screen viewer, including keyboard shortcuts for quick tagging.

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -32,8 +32,13 @@ target 'Runner' do
   # If a future plugin requires framework packaging, enable static frameworks
   # with `USE_FRAMEWORKS=static` or dynamic frameworks with
   # `USE_FRAMEWORKS=dynamic` for the failing integration.
-  linkage_mode = ENV['USE_FRAMEWORKS']
-  if linkage_mode != nil
+  linkage_mode = ENV['USE_FRAMEWORKS']&.strip&.downcase
+  if linkage_mode != nil && !linkage_mode.empty?
+    supported_linkage_modes = ['static', 'dynamic']
+    unless supported_linkage_modes.include?(linkage_mode)
+      raise "Invalid USE_FRAMEWORKS value '#{linkage_mode}'. Supported values: static, dynamic"
+    end
+
     use_frameworks! :linkage => linkage_mode.to_sym
   end
 

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -28,7 +28,14 @@ require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelpe
 flutter_ios_podfile_setup
 
 target 'Runner' do
-  use_frameworks!
+  # Prefer static libraries for faster CocoaPods integration and app install.
+  # If a future plugin requires framework packaging, enable static frameworks
+  # with `USE_FRAMEWORKS=static` or dynamic frameworks with
+  # `USE_FRAMEWORKS=dynamic` for the failing integration.
+  linkage_mode = ENV['USE_FRAMEWORKS']
+  if linkage_mode != nil
+    use_frameworks! :linkage => linkage_mode.to_sym
+  end
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
   target 'RunnerTests' do


### PR DESCRIPTION
### Motivation

- Reduce unnecessary CocoaPods integration and app install overhead by avoiding unconditional global framework packaging for the iOS Runner.
- Allow framework linkage only when a specific plugin requires it so framework-related build/install regressions are easier to reason about and contain.
- Provide maintainers a documented escalation path and a repeatable timing procedure to measure any future plugin-induced overhead.

### Description

- Replace the unconditional `use_frameworks!` in `ios/Podfile` with an opt-in environment switch `USE_FRAMEWORKS` that calls `use_frameworks! :linkage => <static|dynamic>` only when set.
- Add an `iOS CocoaPods Linkage Policy` section to `README.md` describing the default static-first policy, the `USE_FRAMEWORKS=static|dynamic` opt-in, current plugin compatibility assumptions, and a controlled before/after real-device build+install timing workflow to record regressions.
- Note current `ios/Podfile.lock` plugins (`file_picker`, `isar_flutter_libs`, `path_provider_foundation`, `shared_preferences_foundation`, `video_player_avfoundation`) do not require globally enabling dynamic frameworks.

### Testing

- Ran `ruby -c ios/Podfile` to validate Podfile syntax and it succeeded.
- Inspected `ios/Podfile.lock` to confirm the currently referenced plugins appear compatible with static linkage.
- Attempted `USE_FRAMEWORKS=dynamic pod install` but it could not be run in this environment because the `pod` CLI is not available, so an integration `pod install` test was not executed here.
- Attempted `flutter build ios --debug` and `flutter install` timing measurements but they could not be executed because `flutter` is not installed in this environment, so end-to-end build/install timings must be run on a macOS machine with Xcode, CocoaPods, and a connected iPhone as documented.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bdbb643108320bc407430b828168a)