### PR TITLE
Add toggle and bulk directory-tagged-media counts

### DIFF
--- a/lib/features/media_library/data/repositories/filesystem_media_repository_impl.dart
+++ b/lib/features/media_library/data/repositories/filesystem_media_repository_impl.dart
@@ -3,6 +3,7 @@ import '../../../../core/services/bookmark_service.dart';
 import '../../../../core/services/permission_service.dart';
 import '../../../../core/utils/batch_update_result.dart';
 import '../../../../shared/utils/directory_id_utils.dart';
+import '../../domain/entities/directory_media_counts.dart';
 import '../../domain/entities/media_entity.dart';
 import '../../domain/repositories/directory_repository.dart';
 import '../../domain/repositories/media_repository.dart';
@@ -181,6 +182,12 @@ class FilesystemMediaRepositoryImpl implements MediaRepository {
   Future<List<MediaEntity>> getAllMedia() async {
     final models = await _mediaDataSource.getMedia();
     return models.map(_modelToEntity).toList();
+  }
+
+  @override
+  Future<Map<String, DirectoryMediaCounts>> getDirectoryMediaCounts() async {
+    final allMedia = await getAllMedia();
+    return _buildDirectoryMediaCounts(allMedia);
   }
 
   /// Gets media by ID from a specific directory.
@@ -408,4 +415,22 @@ class FilesystemMediaRepositoryImpl implements MediaRepository {
 
     return null;
   }
+}
+
+Map<String, DirectoryMediaCounts> _buildDirectoryMediaCounts(
+  List<MediaEntity> media,
+) {
+  final countsByDirectory = <String, DirectoryMediaCounts>{};
+
+  for (final item in media) {
+    final previous = countsByDirectory[item.directoryId] ??
+        const DirectoryMediaCounts();
+    countsByDirectory[item.directoryId] = DirectoryMediaCounts(
+      totalMediaCount: previous.totalMediaCount + 1,
+      taggedMediaCount: previous.taggedMediaCount +
+          (item.tagIds.isNotEmpty ? 1 : 0),
+    );
+  }
+
+  return countsByDirectory;
 }

--- a/lib/features/media_library/data/repositories/media_repository_impl.dart
+++ b/lib/features/media_library/data/repositories/media_repository_impl.dart
@@ -1,6 +1,7 @@
 import '../../../../core/services/logging_service.dart';
 import '../../../../core/utils/batch_update_result.dart';
 import '../../../../shared/utils/directory_id_utils.dart';
+import '../../domain/entities/directory_media_counts.dart';
 import '../../domain/entities/media_entity.dart';
 import '../../domain/repositories/media_repository.dart';
 import '../isar/isar_media_data_source.dart';
@@ -60,6 +61,12 @@ class MediaRepositoryImpl implements MediaRepository {
   Future<List<MediaEntity>> getAllMedia() async {
     final models = await _mediaDataSource.getMedia();
     return models.map(_modelToEntity).toList();
+  }
+
+  @override
+  Future<Map<String, DirectoryMediaCounts>> getDirectoryMediaCounts() async {
+    final allMedia = await getAllMedia();
+    return _buildDirectoryMediaCounts(allMedia);
   }
 
   @override
@@ -147,4 +154,22 @@ class MediaRepositoryImpl implements MediaRepository {
       media.map(_entityToModel).toList(growable: false),
     );
   }
+}
+
+Map<String, DirectoryMediaCounts> _buildDirectoryMediaCounts(
+  List<MediaEntity> media,
+) {
+  final countsByDirectory = <String, DirectoryMediaCounts>{};
+
+  for (final item in media) {
+    final previous = countsByDirectory[item.directoryId] ??
+        const DirectoryMediaCounts();
+    countsByDirectory[item.directoryId] = DirectoryMediaCounts(
+      totalMediaCount: previous.totalMediaCount + 1,
+      taggedMediaCount: previous.taggedMediaCount +
+          (item.tagIds.isNotEmpty ? 1 : 0),
+    );
+  }
+
+  return countsByDirectory;
 }

--- a/lib/features/media_library/domain/entities/directory_entity.dart
+++ b/lib/features/media_library/domain/entities/directory_entity.dart
@@ -1,3 +1,5 @@
+import 'directory_media_counts.dart';
+
 /// Domain entity representing a directory.
 class DirectoryEntity {
   const DirectoryEntity({
@@ -8,6 +10,7 @@ class DirectoryEntity {
     required this.tagIds,
     required this.lastModified,
     this.bookmarkData,
+    this.mediaCounts = const DirectoryMediaCounts(),
   });
 
   final String id;
@@ -17,6 +20,7 @@ class DirectoryEntity {
   final List<String> tagIds;
   final DateTime lastModified;
   final String? bookmarkData;
+  final DirectoryMediaCounts mediaCounts;
 
   /// Creates a copy with updated fields.
   DirectoryEntity copyWith({
@@ -27,6 +31,7 @@ class DirectoryEntity {
     List<String>? tagIds,
     DateTime? lastModified,
     String? bookmarkData,
+    DirectoryMediaCounts? mediaCounts,
   }) {
     return DirectoryEntity(
       id: id ?? this.id,
@@ -36,6 +41,7 @@ class DirectoryEntity {
       tagIds: tagIds ?? this.tagIds,
       lastModified: lastModified ?? this.lastModified,
       bookmarkData: bookmarkData ?? this.bookmarkData,
+      mediaCounts: mediaCounts ?? this.mediaCounts,
     );
   }
 
@@ -51,5 +57,5 @@ class DirectoryEntity {
 
   @override
   String toString() =>
-      'DirectoryEntity(id: $id, path: $path, name: $name, thumbnailPath: $thumbnailPath, tagIds: $tagIds, lastModified: $lastModified, bookmarkData: $bookmarkData)';
+      'DirectoryEntity(id: $id, path: $path, name: $name, thumbnailPath: $thumbnailPath, tagIds: $tagIds, lastModified: $lastModified, bookmarkData: $bookmarkData, mediaCounts: $mediaCounts)';
 }

--- a/lib/features/media_library/domain/entities/directory_media_counts.dart
+++ b/lib/features/media_library/domain/entities/directory_media_counts.dart
@@ -1,0 +1,10 @@
+/// Aggregate media counts for a directory derived from cached media records.
+class DirectoryMediaCounts {
+  const DirectoryMediaCounts({
+    this.totalMediaCount = 0,
+    this.taggedMediaCount = 0,
+  });
+
+  final int totalMediaCount;
+  final int taggedMediaCount;
+}

--- a/lib/features/media_library/domain/repositories/media_repository.dart
+++ b/lib/features/media_library/domain/repositories/media_repository.dart
@@ -1,4 +1,5 @@
 import '../../../../core/utils/batch_update_result.dart';
+import '../entities/directory_media_counts.dart';
 import '../entities/media_entity.dart';
 
 /// Repository interface for media operations.
@@ -16,6 +17,9 @@ abstract class MediaRepository {
 
   /// Retrieves all persisted media entries without touching the filesystem.
   Future<List<MediaEntity>> getAllMedia();
+
+  /// Aggregates cached media counts per directory without rescanning disk.
+  Future<Map<String, DirectoryMediaCounts>> getDirectoryMediaCounts();
 
   /// Retrieves a media item by its ID.
   Future<MediaEntity?> getMediaById(String id);

--- a/lib/features/media_library/presentation/screens/directory_grid_screen.dart
+++ b/lib/features/media_library/presentation/screens/directory_grid_screen.dart
@@ -15,6 +15,7 @@ import '../../../../core/services/directory_picker_service.dart';
 
 import '../../../../shared/providers/grid_columns_provider.dart';
 import '../../../../shared/providers/repository_providers.dart';
+import '../../../../shared/providers/settings_providers.dart';
 import '../../../../shared/widgets/permission_issue_panel.dart';
 import '../../../../shared/widgets/shortcut_help_overlay.dart';
 import '../../domain/entities/tag_entity.dart';
@@ -74,6 +75,9 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
     final viewModel = ref.read(directoryViewModelProvider.notifier);
     final selectedDirectoryIds = ref.watch(selectedDirectoryIdsProvider);
     final isSelectionMode = ref.watch(directorySelectionModeProvider);
+    final showTaggedMediaCounts = ref.watch(
+      showDirectoryTaggedMediaCountsProvider,
+    );
     final currentSortOption = switch (state) {
       DirectoryLoaded(:final sortOption) => sortOption,
       DirectoryPermissionRevoked(:final sortOption) => sortOption,
@@ -136,6 +140,7 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
                               viewModel,
                               selectedDirectoryIds,
                               isSelectionMode,
+                              showTaggedMediaCounts,
                             ),
                           DirectoryPermissionRevoked(
                             :final inaccessibleDirectories,
@@ -149,6 +154,7 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
                               viewModel,
                               selectedDirectoryIds,
                               isSelectionMode,
+                              showTaggedMediaCounts,
                             ),
                           DirectoryBookmarkInvalid(
                             :final invalidDirectories,
@@ -162,6 +168,7 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
                               viewModel,
                               selectedDirectoryIds,
                               isSelectionMode,
+                              showTaggedMediaCounts,
                             ),
                           DirectoryError(:final message) => _buildError(
                             message,
@@ -506,6 +513,7 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
     DirectoryViewModel viewModel,
     Set<String> selectedDirectoryIds,
     bool isSelectionMode,
+    bool showTaggedMediaCounts,
   ) {
     _pruneDirectoryItemKeys(directories);
     final gridView = GridView.builder(
@@ -540,6 +548,7 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
               viewModel.toggleDirectorySelection(directory.id),
           isSelected: isSelected,
           isSelectionMode: isSelectionMode,
+          showTaggedMediaCounts: showTaggedMediaCounts,
         );
       },
     );
@@ -570,6 +579,7 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
     DirectoryViewModel viewModel,
     Set<String> selectedDirectoryIds,
     bool isSelectionMode,
+    bool showTaggedMediaCounts,
   ) {
     final allDirectories = [
       ...accessibleDirectories,
@@ -644,6 +654,7 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
                         viewModel.toggleDirectorySelection(directory.id),
                     isSelected: isSelected,
                     isSelectionMode: isSelectionMode,
+                    showTaggedMediaCounts: showTaggedMediaCounts,
                   ),
                 );
               },
@@ -661,6 +672,7 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
     DirectoryViewModel viewModel,
     Set<String> selectedDirectoryIds,
     bool isSelectionMode,
+    bool showTaggedMediaCounts,
   ) {
     final allDirectories = [...accessibleDirectories, ...invalidDirectories];
     _pruneDirectoryItemKeys(allDirectories);
@@ -735,6 +747,7 @@ class _DirectoryGridScreenState extends ConsumerState<DirectoryGridScreen> {
                         viewModel.toggleDirectorySelection(directory.id),
                     isSelected: isSelected,
                     isSelectionMode: isSelectionMode,
+                    showTaggedMediaCounts: showTaggedMediaCounts,
                   ),
                 );
               },

--- a/lib/features/media_library/presentation/view_models/directory_grid_view_model.dart
+++ b/lib/features/media_library/presentation/view_models/directory_grid_view_model.dart
@@ -11,6 +11,7 @@ import '../../../../shared/providers/grid_columns_provider.dart';
 import '../../../../shared/providers/repository_providers.dart';
 import '../../data/data_sources/local_directory_data_source.dart';
 import '../../domain/entities/directory_entity.dart';
+import '../../domain/entities/directory_media_counts.dart';
 import '../../domain/use_cases/add_directory_use_case.dart';
 import '../../domain/use_cases/clear_directories_use_case.dart';
 import '../../domain/use_cases/get_directories_use_case.dart';
@@ -454,8 +455,19 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
     try {
       LoggingService.instance.debug('Fetching directories from use case');
       final directories = await _getDirectoriesUseCase();
+      final mediaCountsByDirectory = await _ref
+          .read(mediaRepositoryProvider)
+          .getDirectoryMediaCounts();
+      final directoriesWithMediaCounts = directories
+          .map(
+            (directory) => _applyMediaCounts(
+              directory,
+              mediaCountsByDirectory[directory.id],
+            ),
+          )
+          .toList(growable: false);
       LoggingService.instance.debug(
-        'Retrieved ${directories.length} directories from use case',
+        'Retrieved ${directoriesWithMediaCounts.length} directories from use case',
       );
 
       // Separate accessible and inaccessible directories
@@ -463,9 +475,9 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
       final inaccessibleDirectories = <DirectoryEntity>[];
 
       LoggingService.instance.debug(
-        'Checking directory accessibility for ${directories.length} directories',
+        'Checking directory accessibility for ${directoriesWithMediaCounts.length} directories',
       );
-      for (final directory in directories) {
+      for (final directory in directoriesWithMediaCounts) {
         try {
           if (await _isDirectoryAccessible(directory)) {
             accessibleDirectories.add(directory);
@@ -937,6 +949,15 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
         break;
     }
     return sorted;
+  }
+
+  DirectoryEntity _applyMediaCounts(
+    DirectoryEntity directory,
+    DirectoryMediaCounts? mediaCounts,
+  ) {
+    return directory.copyWith(
+      mediaCounts: mediaCounts ?? const DirectoryMediaCounts(),
+    );
   }
 }
 

--- a/lib/features/media_library/presentation/view_models/media_grid_view_model.dart
+++ b/lib/features/media_library/presentation/view_models/media_grid_view_model.dart
@@ -313,6 +313,7 @@ class MediaViewModel extends StateNotifier<MediaState> {
     if (result.successfulIds.isNotEmpty) {
       final updatedIds = result.successfulIds.toSet();
       _cachedMedia = _updateMediaTagsForSelection(sanitizedTags, updatedIds);
+      _ref.invalidate(directoryMediaCountsProvider);
     }
 
     if (result.hasFailures) {
@@ -369,6 +370,7 @@ class MediaViewModel extends StateNotifier<MediaState> {
     }
 
     _cachedMedia = updatedMedia;
+    _ref.invalidate(directoryMediaCountsProvider);
     _emitLoadedStateFromCache();
   }
 
@@ -466,6 +468,7 @@ class MediaViewModel extends StateNotifier<MediaState> {
       final persistStartTime = DateTime.now();
       await _mediaDataSource.removeMediaForDirectory(directoryId);
       await _mediaDataSource.upsertMedia(mediaModels);
+      _ref.invalidate(directoryMediaCountsProvider);
       final persistTime = DateTime.now().difference(persistStartTime);
 
       final totalTime = DateTime.now().difference(loadStartTime);
@@ -597,6 +600,7 @@ class MediaViewModel extends StateNotifier<MediaState> {
       // Merge filtered results to ensure tag updates are persisted without
       // discarding media from other directories or filters
       await _mediaDataSource.upsertMedia(mediaModels);
+      _ref.invalidate(directoryMediaCountsProvider);
 
       _cachedMedia = _sortMedia(media, _currentSortOption);
 

--- a/lib/features/media_library/presentation/widgets/directory_grid_item.dart
+++ b/lib/features/media_library/presentation/widgets/directory_grid_item.dart
@@ -17,6 +17,7 @@ class DirectoryGridItem extends StatefulWidget {
     required this.onSelectionToggle,
     required this.isSelected,
     required this.isSelectionMode,
+    required this.showTaggedMediaCounts,
   });
 
   final DirectoryEntity directory;
@@ -26,6 +27,7 @@ class DirectoryGridItem extends StatefulWidget {
   final VoidCallback onSelectionToggle;
   final bool isSelected;
   final bool isSelectionMode;
+  final bool showTaggedMediaCounts;
 
   @override
   State<DirectoryGridItem> createState() => _DirectoryGridItemState();
@@ -166,6 +168,21 @@ class _DirectoryGridItemState extends State<DirectoryGridItem>
                                                 .onSurfaceVariant,
                                           ),
                                     ),
+                                    if (widget.showTaggedMediaCounts) ...[
+                                      SizedBox(height: UiSpacing.extraSmallGap),
+                                      Text(
+                                        '${widget.directory.mediaCounts.taggedMediaCount} / '
+                                        '${widget.directory.mediaCounts.totalMediaCount} tagged',
+                                        style: Theme.of(context)
+                                            .textTheme
+                                            .bodySmall
+                                            ?.copyWith(
+                                              color: Theme.of(context)
+                                                  .colorScheme
+                                                  .onSurfaceVariant,
+                                            ),
+                                      ),
+                                    ],
                                     const Spacer(),
                                     Row(
                                       children: [

--- a/lib/features/media_library/presentation/widgets/media_grid_item.dart
+++ b/lib/features/media_library/presentation/widgets/media_grid_item.dart
@@ -9,9 +9,11 @@ import 'package:visibility_detector/visibility_detector.dart';
 import '../../../../core/constants/ui_constants.dart';
 import '../../../../shared/providers/repository_providers.dart';
 import '../../../../shared/providers/settings_providers.dart';
+import '../../../../shared/utils/directory_id_utils.dart';
 import '../../../../shared/widgets/file_operation_button.dart';
 import '../../../favorites/presentation/widgets/favorite_toggle_button.dart';
 import '../../../tagging/presentation/widgets/tag_management_dialog.dart';
+import '../../domain/entities/directory_media_counts.dart';
 import '../../domain/entities/media_entity.dart';
 
 /// Widget for displaying a media item in the grid.
@@ -361,6 +363,11 @@ class _MediaGridItemState extends State<MediaGridItem> {
   Widget _buildDirectoryContent(WidgetRef ref) {
     final previewAsync = ref.watch(directoryPreviewProvider(widget.media.path));
     final isCachingEnabled = ref.watch(thumbnailCachingProvider);
+    final showTaggedMediaCounts = ref.watch(showDirectoryTaggedMediaCountsProvider);
+    final directoryCountsAsync = ref.watch(directoryMediaCountsProvider);
+    final directoryCounts =
+        directoryCountsAsync.valueOrNull?[generateDirectoryId(widget.media.path)] ??
+        const DirectoryMediaCounts();
     return previewAsync.when(
       data: (String? previewPath) {
         return Column(
@@ -410,16 +417,34 @@ class _MediaGridItemState extends State<MediaGridItem> {
             Expanded(
               flex: UiGrid.directoryNameFlex,
               child: Container(
-                alignment: Alignment.center,
                 color: Theme.of(context).colorScheme.surfaceContainerHighest,
                 padding: UiSpacing.horizontalSmall,
-                child: Text(
-                  widget.media.name,
-                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: Theme.of(context).colorScheme.onSurfaceVariant,
-                  ),
-                  maxLines: UiContent.maxLinesSingle,
-                  overflow: TextOverflow.ellipsis,
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Text(
+                      widget.media.name,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                      maxLines: UiContent.maxLinesSingle,
+                      overflow: TextOverflow.ellipsis,
+                      textAlign: TextAlign.center,
+                    ),
+                    if (showTaggedMediaCounts) ...[
+                      const SizedBox(height: 4),
+                      Text(
+                        '${directoryCounts.taggedMediaCount} / '
+                        '${directoryCounts.totalMediaCount} tagged',
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                        maxLines: UiContent.maxLinesSingle,
+                        overflow: TextOverflow.ellipsis,
+                        textAlign: TextAlign.center,
+                      ),
+                    ],
+                  ],
                 ),
               ),
             ),

--- a/lib/features/settings/data/repositories/settings_repository_impl.dart
+++ b/lib/features/settings/data/repositories/settings_repository_impl.dart
@@ -15,6 +15,8 @@ class SettingsRepositoryImpl implements SettingsRepository {
   static const String _autoplayKey = 'video_autoplay_enabled';
   static const String _loopKey = 'video_loop_enabled';
   static const String _autoNavigateKey = 'auto_navigate_sibling_directories';
+  static const String _showDirectoryTaggedMediaCountsKey =
+      'show_directory_tagged_media_counts';
   static const String _slideshowControlsHideDelayKey =
       'slideshowControlsHideDelay';
 
@@ -28,6 +30,8 @@ class SettingsRepositoryImpl implements SettingsRepository {
     final deleteFromSourceEnabled = prefs.getBool(_deleteFromSourceKey) ?? false;
     final autoNavigateSiblingDirectories =
         prefs.getBool(_autoNavigateKey) ?? false;
+    final showDirectoryTaggedMediaCounts =
+        prefs.getBool(_showDirectoryTaggedMediaCountsKey) ?? false;
     final storedHideDelay = prefs.getInt(_slideshowControlsHideDelayKey);
     final hideDelaySeconds = (storedHideDelay ??
             const AppSettings.initial().slideshowControlsHideDelay.inSeconds)
@@ -46,6 +50,7 @@ class SettingsRepositoryImpl implements SettingsRepository {
         loopVideos: loop,
       ),
       autoNavigateSiblingDirectories: autoNavigateSiblingDirectories,
+      showDirectoryTaggedMediaCounts: showDirectoryTaggedMediaCounts,
       slideshowControlsHideDelay: Duration(
         seconds: hideDelaySeconds,
       ),
@@ -81,6 +86,12 @@ class SettingsRepositoryImpl implements SettingsRepository {
   Future<void> saveAutoNavigateSiblingDirectories(bool enabled) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_autoNavigateKey, enabled);
+  }
+
+  @override
+  Future<void> saveShowDirectoryTaggedMediaCounts(bool enabled) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_showDirectoryTaggedMediaCountsKey, enabled);
   }
 
   @override

--- a/lib/features/settings/domain/entities/app_settings.dart
+++ b/lib/features/settings/domain/entities/app_settings.dart
@@ -14,6 +14,7 @@ class AppSettings {
     required this.deleteFromSourceEnabled,
     required this.playbackSettings,
     required this.autoNavigateSiblingDirectories,
+    required this.showDirectoryTaggedMediaCounts,
     required this.slideshowControlsHideDelay,
   });
 
@@ -23,6 +24,7 @@ class AppSettings {
         deleteFromSourceEnabled = false,
         playbackSettings = const PlaybackSettings.initial(),
         autoNavigateSiblingDirectories = false,
+        showDirectoryTaggedMediaCounts = false,
         slideshowControlsHideDelay = AppConfig.defaultSlideshowControlsHideDelay;
 
   final ThemeMode themeMode;
@@ -30,6 +32,7 @@ class AppSettings {
   final bool deleteFromSourceEnabled;
   final PlaybackSettings playbackSettings;
   final bool autoNavigateSiblingDirectories;
+  final bool showDirectoryTaggedMediaCounts;
   final Duration slideshowControlsHideDelay;
 
   AppSettings copyWith({
@@ -38,6 +41,7 @@ class AppSettings {
     bool? deleteFromSourceEnabled,
     PlaybackSettings? playbackSettings,
     bool? autoNavigateSiblingDirectories,
+    bool? showDirectoryTaggedMediaCounts,
     Duration? slideshowControlsHideDelay,
   }) {
     return AppSettings(
@@ -49,6 +53,9 @@ class AppSettings {
       playbackSettings: playbackSettings ?? this.playbackSettings,
       autoNavigateSiblingDirectories:
           autoNavigateSiblingDirectories ?? this.autoNavigateSiblingDirectories,
+      showDirectoryTaggedMediaCounts:
+          showDirectoryTaggedMediaCounts ??
+          this.showDirectoryTaggedMediaCounts,
       slideshowControlsHideDelay:
           slideshowControlsHideDelay ?? this.slideshowControlsHideDelay,
     );

--- a/lib/features/settings/domain/repositories/settings_repository.dart
+++ b/lib/features/settings/domain/repositories/settings_repository.dart
@@ -17,5 +17,7 @@ abstract class SettingsRepository {
 
   Future<void> saveAutoNavigateSiblingDirectories(bool enabled);
 
+  Future<void> saveShowDirectoryTaggedMediaCounts(bool enabled);
+
   Future<void> saveSlideshowControlsHideDelay(Duration delay);
 }

--- a/lib/features/settings/domain/use_cases/update_show_directory_tagged_media_counts_use_case.dart
+++ b/lib/features/settings/domain/use_cases/update_show_directory_tagged_media_counts_use_case.dart
@@ -1,0 +1,12 @@
+import '../repositories/settings_repository.dart';
+
+/// Persists the directory card tagged media count preference.
+class UpdateShowDirectoryTaggedMediaCountsUseCase {
+  const UpdateShowDirectoryTaggedMediaCountsUseCase(this._repository);
+
+  final SettingsRepository _repository;
+
+  Future<void> call(bool enabled) {
+    return _repository.saveShowDirectoryTaggedMediaCounts(enabled);
+  }
+}

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -83,6 +83,10 @@ class SettingsScreen extends ConsumerWidget {
             settings.autoNavigateSiblingDirectories,
             viewModel,
           ),
+          _buildShowDirectoryTaggedMediaCountsSetting(
+            settings.showDirectoryTaggedMediaCounts,
+            viewModel,
+          ),
           const Divider(),
           _buildSectionHeader('Data Management'),
           _buildThumbnailCachingSetting(
@@ -260,6 +264,24 @@ class SettingsScreen extends ConsumerWidget {
         value: isEnabled,
         onChanged: (bool value) {
           viewModel.updateAutoNavigateSiblingDirectories(value);
+        },
+      ),
+    );
+  }
+
+  Widget _buildShowDirectoryTaggedMediaCountsSetting(
+    bool isEnabled,
+    SettingsViewModel viewModel,
+  ) {
+    return ListTile(
+      title: const Text('Show Directory Tagged Media Counts'),
+      subtitle: const Text(
+        'Display tagged versus total media counts on directory cards.',
+      ),
+      trailing: Switch(
+        value: isEnabled,
+        onChanged: (bool value) {
+          viewModel.updateShowDirectoryTaggedMediaCounts(value);
         },
       ),
     );

--- a/lib/features/settings/presentation/view_models/settings_view_model.dart
+++ b/lib/features/settings/presentation/view_models/settings_view_model.dart
@@ -7,6 +7,7 @@ import '../../domain/use_cases/get_app_settings_use_case.dart';
 import '../../domain/use_cases/update_auto_navigate_sibling_directories_use_case.dart';
 import '../../domain/use_cases/update_delete_from_source_use_case.dart';
 import '../../domain/use_cases/update_playback_settings_use_case.dart';
+import '../../domain/use_cases/update_show_directory_tagged_media_counts_use_case.dart';
 import '../../domain/use_cases/update_slideshow_controls_hide_delay_use_case.dart';
 import '../../domain/use_cases/update_theme_mode_use_case.dart';
 import '../../domain/use_cases/update_thumbnail_caching_use_case.dart';
@@ -40,6 +41,9 @@ class SettingsViewModel extends AsyncNotifier<AppSettings> {
   late final UpdateAutoNavigateSiblingDirectoriesUseCase
       _updateAutoNavigateSiblingDirectoriesUseCase =
       ref.read(updateAutoNavigateSiblingDirectoriesUseCaseProvider);
+  late final UpdateShowDirectoryTaggedMediaCountsUseCase
+      _updateShowDirectoryTaggedMediaCountsUseCase =
+      ref.read(updateShowDirectoryTaggedMediaCountsUseCaseProvider);
   late final UpdateSlideshowControlsHideDelayUseCase
       _updateSlideshowControlsHideDelayUseCase =
       ref.read(updateSlideshowControlsHideDelayUseCaseProvider);
@@ -100,6 +104,13 @@ class SettingsViewModel extends AsyncNotifier<AppSettings> {
       () => _updateAutoNavigateSiblingDirectoriesUseCase(enabled),
       (settings) =>
           settings.copyWith(autoNavigateSiblingDirectories: enabled),
+    );
+  }
+
+  Future<void> updateShowDirectoryTaggedMediaCounts(bool enabled) async {
+    await _updateSetting(
+      () => _updateShowDirectoryTaggedMediaCountsUseCase(enabled),
+      (settings) => settings.copyWith(showDirectoryTaggedMediaCounts: enabled),
     );
   }
 

--- a/lib/shared/providers/repository_providers.dart
+++ b/lib/shared/providers/repository_providers.dart
@@ -17,6 +17,7 @@ import '../../features/media_library/data/repositories/file_operations_repositor
 import '../../features/media_library/data/repositories/filesystem_media_repository_impl.dart';
 import '../../features/media_library/data/isar/isar_directory_data_source.dart';
 import '../../features/media_library/data/isar/isar_media_data_source.dart';
+import '../../features/media_library/domain/entities/directory_media_counts.dart';
 import '../../features/media_library/domain/repositories/directory_repository.dart';
 import '../../features/media_library/domain/repositories/file_operations_repository.dart';
 import '../../features/media_library/domain/repositories/media_repository.dart';
@@ -135,6 +136,11 @@ final mediaRepositoryProvider =
         );
       },
     );
+
+final directoryMediaCountsProvider =
+    FutureProvider.autoDispose<Map<String, DirectoryMediaCounts>>((ref) async {
+      return ref.watch(mediaRepositoryProvider).getDirectoryMediaCounts();
+    });
 
 final tagRepositoryProvider =
     StateNotifierProvider.autoDispose<TagRepositoryNotifier, TagRepository>(

--- a/lib/shared/providers/repository_providers.dart
+++ b/lib/shared/providers/repository_providers.dart
@@ -54,6 +54,7 @@ import '../../features/settings/domain/use_cases/get_app_settings_use_case.dart'
 import '../../features/settings/domain/use_cases/update_auto_navigate_sibling_directories_use_case.dart';
 import '../../features/settings/domain/use_cases/update_delete_from_source_use_case.dart';
 import '../../features/settings/domain/use_cases/update_playback_settings_use_case.dart';
+import '../../features/settings/domain/use_cases/update_show_directory_tagged_media_counts_use_case.dart';
 import '../../features/settings/domain/use_cases/update_slideshow_controls_hide_delay_use_case.dart';
 import '../../features/settings/domain/use_cases/update_theme_mode_use_case.dart';
 import '../../features/settings/domain/use_cases/update_thumbnail_caching_use_case.dart';
@@ -277,6 +278,13 @@ final updateAutoNavigateSiblingDirectoriesUseCaseProvider = Provider<
     ref.watch(settingsRepositoryProvider),
   );
 });
+
+final updateShowDirectoryTaggedMediaCountsUseCaseProvider =
+    Provider<UpdateShowDirectoryTaggedMediaCountsUseCase>((ref) {
+      return UpdateShowDirectoryTaggedMediaCountsUseCase(
+        ref.watch(settingsRepositoryProvider),
+      );
+    });
 
 final updateSlideshowControlsHideDelayUseCaseProvider =
     Provider<UpdateSlideshowControlsHideDelayUseCase>((ref) {

--- a/lib/shared/providers/settings_providers.dart
+++ b/lib/shared/providers/settings_providers.dart
@@ -49,6 +49,14 @@ final autoNavigateSiblingDirectoriesProvider = Provider<bool>((ref) {
   );
 });
 
+final showDirectoryTaggedMediaCountsProvider = Provider<bool>((ref) {
+  final settings = ref.watch(settingsProvider);
+  return settings.maybeWhen(
+    data: (value) => value.showDirectoryTaggedMediaCounts,
+    orElse: () => const AppSettings.initial().showDirectoryTaggedMediaCounts,
+  );
+});
+
 final slideshowControlsHideDelayProvider = Provider<Duration>((ref) {
   final settings = ref.watch(settingsProvider);
   return settings.maybeWhen(

--- a/lib/shared/utils/tag_cache_refresher.dart
+++ b/lib/shared/utils/tag_cache_refresher.dart
@@ -14,6 +14,7 @@ class TagCacheRefresher {
   /// Refreshes the tag selection and tagging dashboards to reflect new data.
   Future<void> refresh() async {
     final futures = <Future<void>>[];
+    _ref.invalidate(directoryMediaCountsProvider);
 
     try {
       final tagsViewModel = _ref.read(tagsViewModelProvider.notifier);

--- a/lib/shared/utils/tag_cache_refresher.dart
+++ b/lib/shared/utils/tag_cache_refresher.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/services/logging_service.dart';
+import '../../features/media_library/presentation/view_models/directory_grid_view_model.dart';
 import '../../features/tagging/presentation/view_models/tag_management_view_model.dart';
 import '../../features/tagging/presentation/view_models/tags_view_model.dart';
 
@@ -32,6 +33,16 @@ class TagCacheRefresher {
           .error('Failed to refresh TagViewModel cache: $error');
       LoggingService.instance
           .debug('TagViewModel refresh stack trace: $stackTrace');
+    }
+
+    try {
+      final directoryViewModel = _ref.read(directoryViewModelProvider.notifier);
+      futures.add(directoryViewModel.loadDirectories());
+    } catch (error, stackTrace) {
+      LoggingService.instance
+          .error('Failed to refresh DirectoryViewModel cache: $error');
+      LoggingService.instance
+          .debug('DirectoryViewModel refresh stack trace: $stackTrace');
     }
 
     if (futures.isNotEmpty) {

--- a/test/features/media_library/presentation/view_models/directory_grid_view_model_test.dart
+++ b/test/features/media_library/presentation/view_models/directory_grid_view_model_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:media_fast_view/core/services/bookmark_service.dart';
+import 'package:media_fast_view/core/utils/batch_update_result.dart';
 
 import '../../../../../lib/core/services/permission_service.dart';
 import '../../../../../lib/features/favorites/domain/entities/favorite_entity.dart';
@@ -8,6 +9,7 @@ import '../../../../../lib/features/favorites/domain/entities/favorite_item_type
 import '../../../../../lib/features/favorites/domain/repositories/favorites_repository.dart';
 import '../../../../../lib/features/media_library/data/data_sources/local_directory_data_source.dart';
 import '../../../../../lib/features/media_library/domain/entities/directory_entity.dart';
+import '../../../../../lib/features/media_library/domain/entities/directory_media_counts.dart';
 import '../../../../../lib/features/media_library/domain/entities/media_entity.dart';
 import '../../../../../lib/features/media_library/domain/repositories/directory_repository.dart';
 import '../../../../../lib/features/media_library/domain/repositories/media_repository.dart';
@@ -157,6 +159,28 @@ class InMemoryMediaRepository implements MediaRepository {
   }
 
   @override
+  Future<List<MediaEntity>> getAllMedia() async {
+    return List<MediaEntity>.from(_media);
+  }
+
+  @override
+  Future<Map<String, DirectoryMediaCounts>> getDirectoryMediaCounts() async {
+    final countsByDirectory = <String, DirectoryMediaCounts>{};
+
+    for (final item in _media) {
+      final previous = countsByDirectory[item.directoryId] ??
+          const DirectoryMediaCounts();
+      countsByDirectory[item.directoryId] = DirectoryMediaCounts(
+        totalMediaCount: previous.totalMediaCount + 1,
+        taggedMediaCount: previous.taggedMediaCount +
+            (item.tagIds.isNotEmpty ? 1 : 0),
+      );
+    }
+
+    return countsByDirectory;
+  }
+
+  @override
   Future<MediaEntity?> getMediaById(String id) async {
     try {
       return _media.firstWhere((item) => item.id == id);
@@ -176,6 +200,47 @@ class InMemoryMediaRepository implements MediaRepository {
     if (index != -1) {
       _media[index] = _media[index].copyWith(tagIds: tagIds);
     }
+  }
+
+  @override
+  Future<BatchUpdateResult> updateMediaTagsBatch(
+    Map<String, List<String>> mediaTags,
+  ) async {
+    final successfulIds = <String>[];
+    for (final entry in mediaTags.entries) {
+      final index = _media.indexWhere((item) => item.id == entry.key);
+      if (index == -1) {
+        continue;
+      }
+      _media[index] = _media[index].copyWith(tagIds: entry.value);
+      successfulIds.add(entry.key);
+    }
+    return BatchUpdateResult(
+      successfulIds: successfulIds,
+      failureReasons: const <String, String>{},
+    );
+  }
+
+  @override
+  Future<void> removeMediaNotInDirectories(List<String> directoryIds) async {
+    final allowedIds = directoryIds.toSet();
+    _media.removeWhere((item) => !allowedIds.contains(item.directoryId));
+  }
+
+  @override
+  Future<void> clearAllMedia() async {
+    _media.clear();
+  }
+
+  @override
+  Future<void> upsertMedia(List<MediaEntity> media) async {
+    final mediaById = {for (final item in _media) item.id: item};
+    for (final item in media) {
+      mediaById[item.id] = item;
+    }
+    _media
+      ..clear()
+      ..addAll(mediaById.values);
   }
 }
 
@@ -407,7 +472,6 @@ void main() {
         directoryRepository: directoryRepository,
         mediaRepository: mediaRepository,
         favoritesRepository: favoritesRepository,
-        sharedPreferences: sharedPreferences,
       );
       addTearDown(container.dispose);
 
@@ -434,4 +498,61 @@ void main() {
       ]);
     },
   );
+
+  test('loadDirectories enriches directories with cached media counts', () async {
+    mediaRepository = InMemoryMediaRepository([
+      MediaEntity(
+        id: 'media-1',
+        path: '/dir1/a.jpg',
+        name: 'a.jpg',
+        type: MediaType.image,
+        size: 100,
+        lastModified: DateTime(2024, 1, 1),
+        tagIds: const ['tag-1'],
+        directoryId: '1',
+      ),
+      MediaEntity(
+        id: 'media-2',
+        path: '/dir1/b.jpg',
+        name: 'b.jpg',
+        type: MediaType.image,
+        size: 100,
+        lastModified: DateTime(2024, 1, 1),
+        tagIds: const <String>[],
+        directoryId: '1',
+      ),
+      MediaEntity(
+        id: 'media-3',
+        path: '/dir2/c.jpg',
+        name: 'c.jpg',
+        type: MediaType.image,
+        size: 100,
+        lastModified: DateTime(2024, 1, 1),
+        tagIds: const ['tag-2'],
+        directoryId: '2',
+      ),
+    ]);
+
+    final container = await _createDirectoryTestContainer(
+      directoryRepository: directoryRepository,
+      mediaRepository: mediaRepository,
+      favoritesRepository: favoritesRepository,
+    );
+    addTearDown(container.dispose);
+
+    final viewModel = container.read(directoryViewModelProvider.notifier);
+    await viewModel.loadDirectories();
+
+    final state = container.read(directoryViewModelProvider) as DirectoryLoaded;
+    final directoryOne = state.directories.firstWhere((dir) => dir.id == '1');
+    final directoryTwo = state.directories.firstWhere((dir) => dir.id == '2');
+    final directoryThree = state.directories.firstWhere((dir) => dir.id == '3');
+
+    expect(directoryOne.mediaCounts.totalMediaCount, 2);
+    expect(directoryOne.mediaCounts.taggedMediaCount, 1);
+    expect(directoryTwo.mediaCounts.totalMediaCount, 1);
+    expect(directoryTwo.mediaCounts.taggedMediaCount, 1);
+    expect(directoryThree.mediaCounts.totalMediaCount, 0);
+    expect(directoryThree.mediaCounts.taggedMediaCount, 0);
+  });
 }

--- a/test/features/media_library/presentation/view_models/media_view_model_test.dart
+++ b/test/features/media_library/presentation/view_models/media_view_model_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:media_fast_view/core/utils/batch_update_result.dart';
 import 'package:media_fast_view/features/media_library/data/isar/isar_media_data_source.dart';
+import 'package:media_fast_view/features/media_library/domain/entities/directory_media_counts.dart';
 import 'package:mockito/mockito.dart';
 
 import '../../../../../lib/features/favorites/domain/entities/favorite_entity.dart';
@@ -52,6 +54,28 @@ class InMemoryMediaRepository implements MediaRepository {
   }
 
   @override
+  Future<List<MediaEntity>> getAllMedia() async {
+    return List<MediaEntity>.from(_media);
+  }
+
+  @override
+  Future<Map<String, DirectoryMediaCounts>> getDirectoryMediaCounts() async {
+    final countsByDirectory = <String, DirectoryMediaCounts>{};
+
+    for (final item in _media) {
+      final previous = countsByDirectory[item.directoryId] ??
+          const DirectoryMediaCounts();
+      countsByDirectory[item.directoryId] = DirectoryMediaCounts(
+        totalMediaCount: previous.totalMediaCount + 1,
+        taggedMediaCount: previous.taggedMediaCount +
+            (item.tagIds.isNotEmpty ? 1 : 0),
+      );
+    }
+
+    return countsByDirectory;
+  }
+
+  @override
   Future<MediaEntity?> getMediaById(String id) async {
     try {
       return _media.firstWhere((item) => item.id == id);
@@ -71,6 +95,47 @@ class InMemoryMediaRepository implements MediaRepository {
     if (index != -1) {
       _media[index] = _media[index].copyWith(tagIds: tagIds);
     }
+  }
+
+  @override
+  Future<BatchUpdateResult> updateMediaTagsBatch(
+    Map<String, List<String>> mediaTags,
+  ) async {
+    final successfulIds = <String>[];
+    for (final entry in mediaTags.entries) {
+      final index = _media.indexWhere((item) => item.id == entry.key);
+      if (index == -1) {
+        continue;
+      }
+      _media[index] = _media[index].copyWith(tagIds: entry.value);
+      successfulIds.add(entry.key);
+    }
+    return BatchUpdateResult(
+      successfulIds: successfulIds,
+      failureReasons: const <String, String>{},
+    );
+  }
+
+  @override
+  Future<void> removeMediaNotInDirectories(List<String> directoryIds) async {
+    final allowedIds = directoryIds.toSet();
+    _media.removeWhere((item) => !allowedIds.contains(item.directoryId));
+  }
+
+  @override
+  Future<void> clearAllMedia() async {
+    _media.clear();
+  }
+
+  @override
+  Future<void> upsertMedia(List<MediaEntity> media) async {
+    final mediaById = {for (final item in _media) item.id: item};
+    for (final item in media) {
+      mediaById[item.id] = item;
+    }
+    _media
+      ..clear()
+      ..addAll(mediaById.values);
   }
 }
 

--- a/test/features/media_library/presentation/widgets/directory_search_and_grid_test.dart
+++ b/test/features/media_library/presentation/widgets/directory_search_and_grid_test.dart
@@ -9,6 +9,7 @@ import 'package:media_fast_view/features/favorites/domain/use_cases/favorite_med
 import 'package:media_fast_view/features/favorites/presentation/view_models/favorites_view_model.dart';
 import 'package:media_fast_view/features/media_library/data/data_sources/local_directory_data_source.dart';
 import 'package:media_fast_view/features/media_library/domain/entities/directory_entity.dart';
+import 'package:media_fast_view/features/media_library/domain/entities/directory_media_counts.dart';
 import 'package:media_fast_view/features/media_library/domain/repositories/directory_repository.dart';
 import 'package:media_fast_view/features/media_library/domain/repositories/media_repository.dart';
 import 'package:media_fast_view/features/media_library/domain/use_cases/add_directory_use_case.dart';
@@ -25,6 +26,7 @@ import 'package:media_fast_view/features/tagging/domain/repositories/tag_reposit
 import 'package:media_fast_view/features/tagging/presentation/states/tag_state.dart';
 import 'package:media_fast_view/features/tagging/presentation/view_models/tag_management_view_model.dart';
 import 'package:media_fast_view/shared/providers/grid_columns_provider.dart';
+import 'package:media_fast_view/shared/providers/settings_providers.dart';
 import 'package:media_fast_view/shared/utils/directory_id_utils.dart';
 import 'package:media_fast_view/core/services/permission_service.dart';
 
@@ -315,6 +317,10 @@ void main() {
           name: 'Music',
           thumbnailPath: null,
           tagIds: const ['tag-1'],
+          mediaCounts: const DirectoryMediaCounts(
+            taggedMediaCount: 2,
+            totalMediaCount: 5,
+          ),
           lastModified: DateTime(2024, 1, 1),
         ),
         DirectoryEntity(
@@ -323,6 +329,10 @@ void main() {
           name: 'Pictures',
           thumbnailPath: null,
           tagIds: const [],
+          mediaCounts: const DirectoryMediaCounts(
+            taggedMediaCount: 0,
+            totalMediaCount: 0,
+          ),
           lastModified: DateTime(2024, 1, 2),
         ),
       ];
@@ -337,6 +347,7 @@ void main() {
               (ref) => _StubFavoritesViewModel(),
             ),
             tagViewModelProvider.overrideWith((ref) => _StubTagViewModel()),
+            showDirectoryTaggedMediaCountsProvider.overrideWith((ref) => false),
             directoryViewModelProvider.overrideWith((ref) {
               viewModel = _StubDirectoryViewModel(directories, ref);
               return viewModel;
@@ -350,6 +361,7 @@ void main() {
 
       expect(find.text('Music'), findsOneWidget);
       expect(find.text('Pictures'), findsOneWidget);
+      expect(find.text('2 / 5 tagged'), findsNothing);
 
       await tester.tap(
         find.descendant(
@@ -365,6 +377,52 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(viewModel.removedDirectoryId, directories.first.id);
+    });
+
+    testWidgets('shows tagged media counts when the setting is enabled', (
+      tester,
+    ) async {
+      final directories = [
+        DirectoryEntity(
+          id: generateDirectoryId('/music'),
+          path: '/music',
+          name: 'Music',
+          thumbnailPath: null,
+          tagIds: const ['tag-1'],
+          mediaCounts: const DirectoryMediaCounts(
+            taggedMediaCount: 2,
+            totalMediaCount: 5,
+          ),
+          lastModified: DateTime(2024, 1, 1),
+        ),
+      ];
+      late _StubDirectoryViewModel viewModel;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            gridColumnsProvider
+                .overrideWith((ref) => _StubGridColumnsNotifier()),
+            favoritesViewModelProvider.overrideWith(
+              (ref) => _StubFavoritesViewModel(),
+            ),
+            tagViewModelProvider.overrideWith((ref) => _StubTagViewModel()),
+            showDirectoryTaggedMediaCountsProvider.overrideWith((ref) => true),
+            directoryViewModelProvider.overrideWith((ref) {
+              viewModel = _StubDirectoryViewModel(directories, ref);
+              return viewModel;
+            }),
+          ],
+          child: const MaterialApp(
+            home: DirectoryGridScreen(),
+          ),
+        ),
+      );
+
+      expect(find.text('Music'), findsOneWidget);
+      expect(find.text('1 tags'), findsOneWidget);
+      expect(find.text('2 / 5 tagged'), findsOneWidget);
+      expect(viewModel.state, isA<DirectoryLoaded>());
     });
   });
 }

--- a/test/features/settings/presentation/screens/settings_screen_test.dart
+++ b/test/features/settings/presentation/screens/settings_screen_test.dart
@@ -2,117 +2,63 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:media_fast_view/features/favorites/presentation/view_models/favorites_view_model.dart';
 import 'package:media_fast_view/features/media_library/presentation/view_models/directory_grid_view_model.dart';
+import 'package:media_fast_view/features/settings/domain/entities/app_settings.dart';
+import 'package:media_fast_view/features/settings/domain/entities/playback_settings.dart';
+import 'package:media_fast_view/features/settings/domain/repositories/settings_repository.dart';
 import 'package:media_fast_view/features/settings/presentation/screens/settings_screen.dart';
 import 'package:media_fast_view/features/tagging/domain/use_cases/clear_tag_assignments_use_case.dart';
 import 'package:media_fast_view/features/tagging/domain/use_cases/clear_tags_use_case.dart';
 import 'package:media_fast_view/features/media_library/domain/use_cases/clear_media_cache_use_case.dart';
-import 'package:media_fast_view/shared/providers/auto_navigate_sibling_directories_provider.dart';
-import 'package:media_fast_view/shared/providers/delete_from_source_provider.dart';
 import 'package:media_fast_view/shared/providers/repository_providers.dart';
-import 'package:media_fast_view/shared/providers/slideshow_controls_hide_delay_provider.dart';
-import 'package:media_fast_view/shared/providers/theme_provider.dart';
-import 'package:media_fast_view/shared/providers/thumbnail_caching_provider.dart';
-import 'package:media_fast_view/shared/providers/video_playback_settings_provider.dart';
 import 'package:media_fast_view/shared/utils/tag_cache_refresher.dart';
 
-class _TestThemeNotifier extends ThemeNotifier {
-  _TestThemeNotifier({ThemeMode initial = ThemeMode.system}) {
-    state = initial;
-  }
+class _FakeSettingsRepository implements SettingsRepository {
+  _FakeSettingsRepository({AppSettings? initialSettings})
+    : _settings = initialSettings ?? const AppSettings.initial();
 
-  ThemeMode? lastTheme;
+  AppSettings _settings;
 
-  @override
-  Future<void> setThemeMode(ThemeMode themeMode) async {
-    lastTheme = themeMode;
-    state = themeMode;
-  }
-}
-
-class _TestThumbnailCachingNotifier extends ThumbnailCachingNotifier {
-  _TestThumbnailCachingNotifier({bool initial = true}) {
-    state = initial;
-  }
-
-  bool? lastValue;
+  AppSettings get settings => _settings;
 
   @override
-  Future<void> setThumbnailCaching(bool enabled) async {
-    lastValue = enabled;
-    state = enabled;
-  }
-}
-
-class _TestDeleteFromSourceNotifier extends DeleteFromSourceNotifier {
-  _TestDeleteFromSourceNotifier({bool initial = false}) {
-    state = initial;
-  }
-
-  bool? lastValue;
+  Future<AppSettings> loadSettings() async => _settings;
 
   @override
-  Future<void> setDeleteFromSource(bool enabled) async {
-    lastValue = enabled;
-    state = enabled;
-  }
-}
-
-class _TestVideoPlaybackSettingsNotifier extends VideoPlaybackSettingsNotifier {
-  _TestVideoPlaybackSettingsNotifier({
-    VideoPlaybackSettings initial = const VideoPlaybackSettings.initial(),
-  }) {
-    state = initial;
-  }
-
-  bool? lastAutoplay;
-  bool? lastLoop;
-
-  @override
-  Future<void> setAutoplayVideos(bool enabled) async {
-    lastAutoplay = enabled;
-    state = state.copyWith(autoplayVideos: enabled);
+  Future<void> saveThemeMode(ThemeMode themeMode) async {
+    _settings = _settings.copyWith(themeMode: themeMode);
   }
 
   @override
-  Future<void> setLoopVideos(bool enabled) async {
-    lastLoop = enabled;
-    state = state.copyWith(loopVideos: enabled);
+  Future<void> saveThumbnailCachingEnabled(bool enabled) async {
+    _settings = _settings.copyWith(thumbnailCachingEnabled: enabled);
   }
-}
-
-class _TestAutoNavigateSiblingDirectoriesNotifier
-    extends AutoNavigateSiblingDirectoriesNotifier {
-  _TestAutoNavigateSiblingDirectoriesNotifier({bool initial = false}) {
-    state = initial;
-  }
-
-  bool? lastValue;
 
   @override
-  Future<void> setAutoNavigateSiblingDirectories(bool enabled) async {
-    lastValue = enabled;
-    state = enabled;
+  Future<void> saveDeleteFromSourceEnabled(bool enabled) async {
+    _settings = _settings.copyWith(deleteFromSourceEnabled: enabled);
   }
-}
-
-class _TestSlideshowControlsHideDelayNotifier
-    extends SlideshowControlsHideDelayNotifier {
-  _TestSlideshowControlsHideDelayNotifier({
-    Duration initialDelay = const Duration(seconds: 5),
-  }) {
-    state = initialDelay;
-  }
-
-  Duration? lastDelay;
 
   @override
-  Future<void> setDelay(Duration delay) async {
-    lastDelay = delay;
-    state = delay;
+  Future<void> savePlaybackSettings(PlaybackSettings settings) async {
+    _settings = _settings.copyWith(playbackSettings: settings);
+  }
+
+  @override
+  Future<void> saveAutoNavigateSiblingDirectories(bool enabled) async {
+    _settings = _settings.copyWith(autoNavigateSiblingDirectories: enabled);
+  }
+
+  @override
+  Future<void> saveShowDirectoryTaggedMediaCounts(bool enabled) async {
+    _settings = _settings.copyWith(showDirectoryTaggedMediaCounts: enabled);
+  }
+
+  @override
+  Future<void> saveSlideshowControlsHideDelay(Duration delay) async {
+    _settings = _settings.copyWith(slideshowControlsHideDelay: delay);
   }
 }
 
@@ -130,58 +76,60 @@ class _MockClearTagAssignmentsUseCase extends Mock
 
 class _MockClearTagsUseCase extends Mock implements ClearTagsUseCase {}
 
+Future<void> _pumpSettingsScreen(
+  WidgetTester tester, {
+  required List<Override> overrides,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: overrides,
+      child: const MaterialApp(home: SettingsScreen()),
+    ),
+  );
+
+  await tester.pumpAndSettle();
+}
+
 void main() {
-  setUp(() {
-    SharedPreferences.setMockInitialValues({});
-  });
-
   group('SettingsScreen preference controls', () {
-    testWidgets('updates toggles and dropdowns via notifiers', (tester) async {
-      final themeNotifier = _TestThemeNotifier(initial: ThemeMode.light);
-      final thumbnailCachingNotifier =
-          _TestThumbnailCachingNotifier(initial: true);
-      final deleteFromSourceNotifier =
-          _TestDeleteFromSourceNotifier(initial: false);
-      final playbackNotifier = _TestVideoPlaybackSettingsNotifier(
-        initial: const VideoPlaybackSettings(
-          autoplayVideos: false,
-          loopVideos: false,
-        ),
-      );
-      final siblingNavigationNotifier =
-          _TestAutoNavigateSiblingDirectoriesNotifier(initial: false);
-      final slideshowNotifier = _TestSlideshowControlsHideDelayNotifier(
-        initialDelay: const Duration(seconds: 5),
-      );
-
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            themeProvider.overrideWith((ref) => themeNotifier),
-            thumbnailCachingProvider
-                .overrideWith((ref) => thumbnailCachingNotifier),
-            deleteFromSourceProvider
-                .overrideWith((ref) => deleteFromSourceNotifier),
-            videoPlaybackSettingsProvider
-                .overrideWith((ref) => playbackNotifier),
-            autoNavigateSiblingDirectoriesProvider
-                .overrideWith((ref) => siblingNavigationNotifier),
-            slideshowControlsHideDelayProvider
-                .overrideWith((ref) => slideshowNotifier),
-          ],
-          child: const MaterialApp(
-            home: SettingsScreen(),
+    testWidgets('shows the new switch and persists updated preferences', (
+      tester,
+    ) async {
+      final settingsRepository = _FakeSettingsRepository(
+        initialSettings: AppSettings.initial().copyWith(
+          themeMode: ThemeMode.light,
+          thumbnailCachingEnabled: true,
+          deleteFromSourceEnabled: false,
+          playbackSettings: PlaybackSettings(
+            autoplayVideos: false,
+            loopVideos: false,
           ),
+          autoNavigateSiblingDirectories: false,
+          showDirectoryTaggedMediaCounts: false,
+          slideshowControlsHideDelay: Duration(seconds: 5),
         ),
       );
 
-      await tester.pumpAndSettle();
+      await _pumpSettingsScreen(
+        tester,
+        overrides: [
+          settingsRepositoryProvider.overrideWithValue(settingsRepository),
+        ],
+      );
+
+      expect(
+        find.widgetWithText(
+          ListTile,
+          'Show Directory Tagged Media Counts',
+        ),
+        findsOneWidget,
+      );
 
       await tester.tap(find.byType(DropdownButton<ThemeMode>));
       await tester.pumpAndSettle();
       await tester.tap(find.text('Dark').last);
       await tester.pumpAndSettle();
-      expect(themeNotifier.lastTheme, ThemeMode.dark);
+      expect(settingsRepository.settings.themeMode, ThemeMode.dark);
 
       final autoplaySwitch = find.descendant(
         of: find.widgetWithText(ListTile, 'Autoplay Videos'),
@@ -189,7 +137,7 @@ void main() {
       );
       await tester.tap(autoplaySwitch);
       await tester.pumpAndSettle();
-      expect(playbackNotifier.lastAutoplay, isTrue);
+      expect(settingsRepository.settings.playbackSettings.autoplayVideos, isTrue);
 
       final loopSwitch = find.descendant(
         of: find.widgetWithText(ListTile, 'Loop Videos'),
@@ -197,7 +145,7 @@ void main() {
       );
       await tester.tap(loopSwitch);
       await tester.pumpAndSettle();
-      expect(playbackNotifier.lastLoop, isTrue);
+      expect(settingsRepository.settings.playbackSettings.loopVideos, isTrue);
 
       final siblingNavigationSwitch = find.descendant(
         of: find.widgetWithText(
@@ -208,7 +156,21 @@ void main() {
       );
       await tester.tap(siblingNavigationSwitch);
       await tester.pumpAndSettle();
-      expect(siblingNavigationNotifier.lastValue, isTrue);
+      expect(
+        settingsRepository.settings.autoNavigateSiblingDirectories,
+        isTrue,
+      );
+
+      final directoryCountsSwitch = find.descendant(
+        of: find.widgetWithText(
+          ListTile,
+          'Show Directory Tagged Media Counts',
+        ),
+        matching: find.byType(Switch),
+      );
+      await tester.tap(directoryCountsSwitch);
+      await tester.pumpAndSettle();
+      expect(settingsRepository.settings.showDirectoryTaggedMediaCounts, isTrue);
 
       final thumbnailCachingSwitch = find.descendant(
         of: find.widgetWithText(ListTile, 'Thumbnail Caching'),
@@ -216,7 +178,7 @@ void main() {
       );
       await tester.tap(thumbnailCachingSwitch);
       await tester.pumpAndSettle();
-      expect(thumbnailCachingNotifier.lastValue, isFalse);
+      expect(settingsRepository.settings.thumbnailCachingEnabled, isFalse);
 
       final deleteFromSourceSwitch = find.descendant(
         of: find.widgetWithText(ListTile, 'Delete From Source'),
@@ -224,26 +186,22 @@ void main() {
       );
       await tester.tap(deleteFromSourceSwitch);
       await tester.pumpAndSettle();
-      expect(deleteFromSourceNotifier.lastValue, isTrue);
+      expect(settingsRepository.settings.deleteFromSourceEnabled, isTrue);
 
       final slider = find.byType(Slider);
       final sliderWidget = tester.widget<Slider>(slider);
       sliderWidget.onChanged?.call(10);
       await tester.pumpAndSettle();
-      expect(slideshowNotifier.lastDelay, const Duration(seconds: 10));
+      expect(
+        settingsRepository.settings.slideshowControlsHideDelay,
+        const Duration(seconds: 10),
+      );
     });
   });
 
   group('SettingsScreen cache actions', () {
     testWidgets('invokes clear and refresh actions', (tester) async {
-      final themeNotifier = _TestThemeNotifier(initial: ThemeMode.light);
-      final thumbnailCachingNotifier = _TestThumbnailCachingNotifier();
-      final deleteFromSourceNotifier = _TestDeleteFromSourceNotifier();
-      final playbackNotifier = _TestVideoPlaybackSettingsNotifier();
-      final siblingNavigationNotifier =
-          _TestAutoNavigateSiblingDirectoriesNotifier();
-      final slideshowNotifier = _TestSlideshowControlsHideDelayNotifier();
-
+      final settingsRepository = _FakeSettingsRepository();
       final clearMediaCacheUseCase = _MockClearMediaCacheUseCase();
       final tagCacheRefresher = _MockTagCacheRefresher();
       final directoryViewModel = _MockDirectoryViewModel();
@@ -281,38 +239,20 @@ void main() {
       when(clearTagAssignmentsUseCase()).thenAnswer((_) async {});
       when(clearTagsUseCase()).thenAnswer((_) async {});
 
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            themeProvider.overrideWith((ref) => themeNotifier),
-            thumbnailCachingProvider
-                .overrideWith((ref) => thumbnailCachingNotifier),
-            deleteFromSourceProvider
-                .overrideWith((ref) => deleteFromSourceNotifier),
-            videoPlaybackSettingsProvider
-                .overrideWith((ref) => playbackNotifier),
-            autoNavigateSiblingDirectoriesProvider
-                .overrideWith((ref) => siblingNavigationNotifier),
-            slideshowControlsHideDelayProvider
-                .overrideWith((ref) => slideshowNotifier),
-            clearMediaCacheUseCaseProvider
-                .overrideWithValue(clearMediaCacheUseCase),
-            tagCacheRefresherProvider.overrideWithValue(tagCacheRefresher),
-            directoryViewModelProvider
-                .overrideWith((ref) => directoryViewModel),
-            favoritesViewModelProvider
-                .overrideWith((ref) => favoritesViewModel),
-            clearTagAssignmentsUseCaseProvider
-                .overrideWithValue(clearTagAssignmentsUseCase),
-            clearTagsUseCaseProvider.overrideWithValue(clearTagsUseCase),
-          ],
-          child: const MaterialApp(
-            home: SettingsScreen(),
+      await _pumpSettingsScreen(
+        tester,
+        overrides: [
+          settingsRepositoryProvider.overrideWithValue(settingsRepository),
+          clearMediaCacheUseCaseProvider.overrideWithValue(clearMediaCacheUseCase),
+          tagCacheRefresherProvider.overrideWithValue(tagCacheRefresher),
+          directoryViewModelProvider.overrideWith((ref) => directoryViewModel),
+          favoritesViewModelProvider.overrideWith((ref) => favoritesViewModel),
+          clearTagAssignmentsUseCaseProvider.overrideWithValue(
+            clearTagAssignmentsUseCase,
           ),
-        ),
+          clearTagsUseCaseProvider.overrideWithValue(clearTagsUseCase),
+        ],
       );
-
-      await tester.pumpAndSettle();
 
       await tester.tap(find.text('Clean Cached Media'));
       await tester.pumpAndSettle();

--- a/test/widgets/media_grid_item_test.dart
+++ b/test/widgets/media_grid_item_test.dart
@@ -4,9 +4,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:media_fast_view/core/services/file_service.dart';
+import 'package:media_fast_view/features/media_library/domain/entities/directory_media_counts.dart';
 import 'package:media_fast_view/features/media_library/domain/entities/media_entity.dart';
 import 'package:media_fast_view/features/media_library/presentation/widgets/media_grid_item.dart';
 import 'package:media_fast_view/shared/providers/repository_providers.dart';
+import 'package:media_fast_view/shared/providers/settings_providers.dart';
+import 'package:media_fast_view/shared/utils/directory_id_utils.dart';
 import 'package:mockito/mockito.dart';
 
 class _MockFileService extends Mock implements FileService {}
@@ -58,7 +61,11 @@ void main() {
     });
 
     testWidgets('renders directory media type', (WidgetTester tester) async {
-      final dirMedia = testMedia.copyWith(type: MediaType.directory);
+      final dirMedia = testMedia.copyWith(
+        type: MediaType.directory,
+        path: '/test/subdir',
+        name: 'subdir',
+      );
 
       when(mockFileService.getDirectoryContents(any)).thenAnswer((_) async => []);
 
@@ -84,6 +91,52 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byIcon(Icons.folder), findsOneWidget);
+      expect(find.text('0 / 0 tagged'), findsNothing);
+    });
+
+    testWidgets('shows cached tagged counts for directory media when enabled', (
+      WidgetTester tester,
+    ) async {
+      final dirMedia = testMedia.copyWith(
+        type: MediaType.directory,
+        path: '/test/subdir',
+        name: 'subdir',
+      );
+
+      when(mockFileService.getDirectoryContents(any)).thenAnswer((_) async => []);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            fileServiceProvider.overrideWithValue(mockFileService),
+            showDirectoryTaggedMediaCountsProvider.overrideWith((ref) => true),
+            directoryMediaCountsProvider.overrideWith(
+              (ref) async => <String, DirectoryMediaCounts>{
+                generateDirectoryId(dirMedia.path):
+                    const DirectoryMediaCounts(
+                      taggedMediaCount: 3,
+                      totalMediaCount: 7,
+                    ),
+              },
+            ),
+          ],
+          child: MaterialApp(
+            home: Scaffold(
+              body: MediaGridItem(
+                media: dirMedia,
+                onTap: () {},
+                onSelectionToggle: () {},
+                isSelected: false,
+                isSelectionMode: false,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.text('3 / 7 tagged'), findsOneWidget);
     });
 
     testWidgets('renders video media type', (WidgetTester tester) async {


### PR DESCRIPTION
### Motivation

- Provide a user preference to show tagged vs total media counts on directory cards and persist it across launches. 
- Avoid N+1 directory media queries by aggregating cached media once and attaching counts to DirectoryEntity instances so the grid can render counts efficiently. 
- Keep tag mutation flows consistent by refreshing directory counts when tags change.

### Description

- Added a persisted boolean setting `showDirectoryTaggedMediaCounts` to `AppSettings` with a default of `false` and supported it in `copyWith` (lib/features/settings/domain/entities/app_settings.dart). 
- Extended `SettingsRepository` with `saveShowDirectoryTaggedMediaCounts` and implemented loading/saving in `SettingsRepositoryImpl` using `SharedPreferences` (lib/features/settings/domain/repositories/settings_repository.dart, lib/features/settings/data/repositories/settings_repository_impl.dart). 
- Introduced `UpdateShowDirectoryTaggedMediaCountsUseCase` and registered its provider in `repository_providers.dart` (lib/features/settings/domain/use_cases/update_show_directory_tagged_media_counts_use_case.dart, lib/shared/providers/repository_providers.dart). 
- Wired the setting into Riverpod: added provider `showDirectoryTaggedMediaCountsProvider` and view-model method `updateShowDirectoryTaggedMediaCounts` (lib/shared/providers/settings_providers.dart, lib/features/settings/presentation/view_models/settings_view_model.dart). 
- Exposed a settings UI control: added a `ListTile` + `Switch` to `SettingsScreen` to toggle the preference (lib/features/settings/presentation/screens/settings_screen.dart). 
- Introduced `DirectoryMediaCounts` value object to hold `totalMediaCount` and `taggedMediaCount` (lib/features/media_library/domain/entities/directory_media_counts.dart). 
- Added an optional `mediaCounts` field on `DirectoryEntity` with safe defaults and updated `copyWith` (lib/features/media_library/domain/entities/directory_entity.dart). 
- Added `getDirectoryMediaCounts()` to the `MediaRepository` interface and implemented it in both repository implementations, aggregating counts from persisted media (lib/features/media_library/domain/repositories/media_repository.dart, lib/features/media_library/data/repositories/media_repository_impl.dart, lib/features/media_library/data/repositories/filesystem_media_repository_impl.dart). 
- Directory loading now requests bulk media counts and attaches them to each DirectoryEntity during `loadDirectories()` to avoid N+1 calls (lib/features/media_library/presentation/view_models/directory_grid_view_model.dart). 
- Directory grid UI reads the settings provider and passes the flag through to `DirectoryGridItem` in all grid code paths (normal, permission-revoked, bookmark-invalid) (lib/features/media_library/presentation/screens/directory_grid_screen.dart). 
- `DirectoryGridItem` accepts `showTaggedMediaCounts` and conditionally renders a secondary info line like `"<tagged> / <total> tagged"` while retaining the existing tags line (lib/features/media_library/presentation/widgets/directory_grid_item.dart). 
- Ensure tag-related flows refresh directory cache: `TagCacheRefresher.refresh()` now also triggers `directoryViewModel.loadDirectories()` so counts are updated after tag mutations (lib/shared/utils/tag_cache_refresher.dart). 
- Tests: updated and added widget and view-model tests to cover the new setting and count behavior (tests under test/features/... for settings and directory grid/view-models). 

### Testing

- Ran repository checks and committed changes; `git diff --check` passed. 
- Added/updated unit/widget tests: settings screen test verifies the new switch exists and that toggling it persists through a fake `SettingsRepository`; directory grid widget tests verify counts hidden when the setting is off and shown when on; directory view-model tests verify aggregated counts are applied from in-memory media fixtures. 
- Attempted `dart format` and `flutter test` but the execution environment does not have the Dart/Flutter SDK installed, so format and test runs were not executed here (these should run successfully in CI or a local dev environment with the SDK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c08a2bebf48320bc5d0a20ab5a3367)