### PR TITLE
Add tagged-percentage directory sort (Tagged % High-Low)

### DIFF
--- a/lib/features/media_library/presentation/view_models/directory_grid_view_model.dart
+++ b/lib/features/media_library/presentation/view_models/directory_grid_view_model.dart
@@ -25,6 +25,7 @@ enum DirectorySortOption {
   nameDescending,
   lastModifiedDescending,
   lastModifiedAscending,
+  taggedPercentageDescending,
 }
 
 extension DirectorySortOptionX on DirectorySortOption {
@@ -33,6 +34,7 @@ extension DirectorySortOptionX on DirectorySortOption {
     DirectorySortOption.nameDescending => 'Name (Z-A)',
     DirectorySortOption.lastModifiedDescending => 'Last Modified (Newest)',
     DirectorySortOption.lastModifiedAscending => 'Last Modified (Oldest)',
+    DirectorySortOption.taggedPercentageDescending => 'Tagged % (High-Low)',
   };
 }
 
@@ -947,8 +949,45 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
       case DirectorySortOption.lastModifiedAscending:
         sorted.sort((a, b) => a.lastModified.compareTo(b.lastModified));
         break;
+      case DirectorySortOption.taggedPercentageDescending:
+        sorted.sort(_compareByTaggedPercentageDescending);
+        break;
     }
     return sorted;
+  }
+
+  int _compareByTaggedPercentageDescending(
+    DirectoryEntity a,
+    DirectoryEntity b,
+  ) {
+    final percentageComparison = _taggedPercentage(b).compareTo(
+      _taggedPercentage(a),
+    );
+    if (percentageComparison != 0) {
+      return percentageComparison;
+    }
+
+    final taggedCountComparison = b.mediaCounts.taggedMediaCount.compareTo(
+      a.mediaCounts.taggedMediaCount,
+    );
+    if (taggedCountComparison != 0) {
+      return taggedCountComparison;
+    }
+
+    return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+  }
+
+  /// Returns a safe tagged ratio for sorting.
+  ///
+  /// Directories with `0 / 0` media counts are treated as `0%` tagged so they
+  /// remain below any directory with a positive tagging ratio.
+  double _taggedPercentage(DirectoryEntity directory) {
+    final totalMediaCount = directory.mediaCounts.totalMediaCount;
+    if (totalMediaCount == 0) {
+      return 0;
+    }
+
+    return directory.mediaCounts.taggedMediaCount / totalMediaCount;
   }
 
   DirectoryEntity _applyMediaCounts(

--- a/lib/features/media_library/presentation/view_models/directory_grid_view_model.dart
+++ b/lib/features/media_library/presentation/view_models/directory_grid_view_model.dart
@@ -25,6 +25,7 @@ enum DirectorySortOption {
   nameDescending,
   lastModifiedDescending,
   lastModifiedAscending,
+  taggedPercentageAscending,
   taggedPercentageDescending,
 }
 
@@ -34,6 +35,7 @@ extension DirectorySortOptionX on DirectorySortOption {
     DirectorySortOption.nameDescending => 'Name (Z-A)',
     DirectorySortOption.lastModifiedDescending => 'Last Modified (Newest)',
     DirectorySortOption.lastModifiedAscending => 'Last Modified (Oldest)',
+    DirectorySortOption.taggedPercentageAscending => 'Tagged % (Low-High)',
     DirectorySortOption.taggedPercentageDescending => 'Tagged % (High-Low)',
   };
 }
@@ -949,26 +951,48 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
       case DirectorySortOption.lastModifiedAscending:
         sorted.sort((a, b) => a.lastModified.compareTo(b.lastModified));
         break;
+      case DirectorySortOption.taggedPercentageAscending:
+        sorted.sort(
+          (a, b) => _compareByTaggedPercentage(
+            a,
+            b,
+            descending: false,
+          ),
+        );
+        break;
       case DirectorySortOption.taggedPercentageDescending:
-        sorted.sort(_compareByTaggedPercentageDescending);
+        sorted.sort(
+          (a, b) => _compareByTaggedPercentage(
+            a,
+            b,
+            descending: true,
+          ),
+        );
         break;
     }
     return sorted;
   }
 
-  int _compareByTaggedPercentageDescending(
+  int _compareByTaggedPercentage(
     DirectoryEntity a,
     DirectoryEntity b,
+    {
+      required bool descending,
+    }
   ) {
-    final percentageComparison = _taggedPercentage(b).compareTo(
+    final percentageComparison = _orderedComparison(
       _taggedPercentage(a),
+      _taggedPercentage(b),
+      descending: descending,
     );
     if (percentageComparison != 0) {
       return percentageComparison;
     }
 
-    final taggedCountComparison = b.mediaCounts.taggedMediaCount.compareTo(
+    final taggedCountComparison = _orderedComparison(
       a.mediaCounts.taggedMediaCount,
+      b.mediaCounts.taggedMediaCount,
+      descending: descending,
     );
     if (taggedCountComparison != 0) {
       return taggedCountComparison;
@@ -979,8 +1003,8 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
 
   /// Returns a safe tagged ratio for sorting.
   ///
-  /// Directories with `0 / 0` media counts are treated as `0%` tagged so they
-  /// remain below any directory with a positive tagging ratio.
+  /// Directories with `0 / 0` media counts are treated as `0%` tagged so the
+  /// sort stays deterministic without producing NaN or infinity values.
   double _taggedPercentage(DirectoryEntity directory) {
     final totalMediaCount = directory.mediaCounts.totalMediaCount;
     if (totalMediaCount == 0) {
@@ -988,6 +1012,14 @@ class DirectoryViewModel extends StateNotifier<DirectoryState> {
     }
 
     return directory.mediaCounts.taggedMediaCount / totalMediaCount;
+  }
+
+  int _orderedComparison(
+    num left,
+    num right, {
+    required bool descending,
+  }) {
+    return descending ? right.compareTo(left) : left.compareTo(right);
   }
 
   DirectoryEntity _applyMediaCounts(

--- a/lib/features/media_library/presentation/view_models/media_grid_view_model.dart
+++ b/lib/features/media_library/presentation/view_models/media_grid_view_model.dart
@@ -1,7 +1,6 @@
 import 'dart:collection';
-import 'dart:convert';
 import 'dart:io';
-import 'package:crypto/crypto.dart';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -9,6 +8,8 @@ import '../../../../core/services/bookmark_service.dart';
 import '../../../../core/services/permission_service.dart';
 import '../../../../shared/providers/grid_columns_provider.dart';
 import '../../../../shared/providers/repository_providers.dart';
+import '../../../../shared/utils/directory_id_utils.dart';
+import '../../domain/entities/directory_media_counts.dart';
 import '../../domain/use_cases/get_media_use_case.dart';
 import '../../domain/use_cases/update_directory_access_use_case.dart';
 import '../../domain/entities/media_entity.dart';
@@ -26,6 +27,8 @@ enum MediaSortOption {
   lastModifiedDescending,
   lastModifiedAscending,
   sizeDescending,
+  taggedPercentageAscending,
+  taggedPercentageDescending,
 }
 
 extension MediaSortOptionX on MediaSortOption {
@@ -35,6 +38,8 @@ extension MediaSortOptionX on MediaSortOption {
     MediaSortOption.lastModifiedDescending => 'Last Modified (Newest)',
     MediaSortOption.lastModifiedAscending => 'Last Modified (Oldest)',
     MediaSortOption.sizeDescending => 'Size',
+    MediaSortOption.taggedPercentageAscending => 'Tagged % (Low-High)',
+    MediaSortOption.taggedPercentageDescending => 'Tagged % (High-Low)',
   };
 }
 
@@ -189,6 +194,8 @@ class MediaViewModel extends StateNotifier<MediaState> {
   bool _showUntaggedOnly = false;
   late final ProviderSubscription<FavoritesState> _favoritesSubscription;
   Set<MediaType> _visibleMediaTypes = Set<MediaType>.from(MediaType.values);
+  Map<String, DirectoryMediaCounts> _directoryMediaCounts =
+      const <String, DirectoryMediaCounts>{};
 
   MediaSortOption get currentSortOption => _currentSortOption;
   Set<String> get selectedMediaIds =>
@@ -242,9 +249,7 @@ class MediaViewModel extends StateNotifier<MediaState> {
 
   /// Gets the directory ID generated from the directory path.
   String get directoryId {
-    final bytes = utf8.encode(_directoryPath);
-    final digest = sha256.convert(bytes);
-    return digest.toString();
+    return generateDirectoryId(_directoryPath);
   }
 
   @override
@@ -314,6 +319,8 @@ class MediaViewModel extends StateNotifier<MediaState> {
       final updatedIds = result.successfulIds.toSet();
       _cachedMedia = _updateMediaTagsForSelection(sanitizedTags, updatedIds);
       _ref.invalidate(directoryMediaCountsProvider);
+      await _refreshDirectoryMediaCounts();
+      _cachedMedia = _sortMedia(_cachedMedia, _currentSortOption);
     }
 
     if (result.hasFailures) {
@@ -371,6 +378,8 @@ class MediaViewModel extends StateNotifier<MediaState> {
 
     _cachedMedia = updatedMedia;
     _ref.invalidate(directoryMediaCountsProvider);
+    await _refreshDirectoryMediaCounts();
+    _cachedMedia = _sortMedia(_cachedMedia, _currentSortOption);
     _emitLoadedStateFromCache();
   }
 
@@ -469,6 +478,7 @@ class MediaViewModel extends StateNotifier<MediaState> {
       await _mediaDataSource.removeMediaForDirectory(directoryId);
       await _mediaDataSource.upsertMedia(mediaModels);
       _ref.invalidate(directoryMediaCountsProvider);
+      await _refreshDirectoryMediaCounts();
       final persistTime = DateTime.now().difference(persistStartTime);
 
       final totalTime = DateTime.now().difference(loadStartTime);
@@ -510,6 +520,7 @@ class MediaViewModel extends StateNotifier<MediaState> {
       // Check if this is a permission-related error
       final errorMessage = e.toString();
       _cachedMedia = const [];
+      _directoryMediaCounts = const <String, DirectoryMediaCounts>{};
       if (_isPermissionError(errorMessage)) {
         LoggingService.instance.warning(
           'Permission error detected, setting permission revoked state',
@@ -601,6 +612,7 @@ class MediaViewModel extends StateNotifier<MediaState> {
       // discarding media from other directories or filters
       await _mediaDataSource.upsertMedia(mediaModels);
       _ref.invalidate(directoryMediaCountsProvider);
+      await _refreshDirectoryMediaCounts();
 
       _cachedMedia = _sortMedia(media, _currentSortOption);
 
@@ -623,6 +635,7 @@ class MediaViewModel extends StateNotifier<MediaState> {
       // Check if this is a permission-related error
       final errorMessage = e.toString();
       _cachedMedia = const [];
+      _directoryMediaCounts = const <String, DirectoryMediaCounts>{};
       if (_isPermissionError(errorMessage)) {
         state = MediaPermissionRevoked(
           directoryPath: _directoryPath,
@@ -1012,8 +1025,95 @@ class MediaViewModel extends StateNotifier<MediaState> {
       case MediaSortOption.sizeDescending:
         sorted.sort((a, b) => b.size.compareTo(a.size));
         break;
+      case MediaSortOption.taggedPercentageAscending:
+        sorted.sort(
+          (a, b) => _compareByTaggedPercentage(
+            a,
+            b,
+            descending: false,
+          ),
+        );
+        break;
+      case MediaSortOption.taggedPercentageDescending:
+        sorted.sort(
+          (a, b) => _compareByTaggedPercentage(
+            a,
+            b,
+            descending: true,
+          ),
+        );
+        break;
     }
     return sorted;
+  }
+
+  Future<void> _refreshDirectoryMediaCounts() async {
+    _directoryMediaCounts = await _ref
+        .read(mediaRepositoryProvider)
+        .getDirectoryMediaCounts();
+  }
+
+  int _compareByTaggedPercentage(
+    MediaEntity a,
+    MediaEntity b, {
+    required bool descending,
+  }) {
+    final aIsDirectory = a.type == MediaType.directory;
+    final bIsDirectory = b.type == MediaType.directory;
+
+    if (aIsDirectory != bIsDirectory) {
+      return aIsDirectory ? -1 : 1;
+    }
+
+    if (!aIsDirectory && !bIsDirectory) {
+      return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+    }
+
+    final percentageComparison = _orderedComparison(
+      _taggedPercentage(a),
+      _taggedPercentage(b),
+      descending: descending,
+    );
+    if (percentageComparison != 0) {
+      return percentageComparison;
+    }
+
+    final taggedCountComparison = _orderedComparison(
+      _directoryCountsForMedia(a).taggedMediaCount,
+      _directoryCountsForMedia(b).taggedMediaCount,
+      descending: descending,
+    );
+    if (taggedCountComparison != 0) {
+      return taggedCountComparison;
+    }
+
+    return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+  }
+
+  DirectoryMediaCounts _directoryCountsForMedia(MediaEntity media) {
+    if (media.type != MediaType.directory) {
+      return const DirectoryMediaCounts();
+    }
+
+    return _directoryMediaCounts[generateDirectoryId(media.path)] ??
+        const DirectoryMediaCounts();
+  }
+
+  double _taggedPercentage(MediaEntity media) {
+    final counts = _directoryCountsForMedia(media);
+    if (counts.totalMediaCount == 0) {
+      return 0;
+    }
+
+    return counts.taggedMediaCount / counts.totalMediaCount;
+  }
+
+  int _orderedComparison(
+    num left,
+    num right, {
+    required bool descending,
+  }) {
+    return descending ? right.compareTo(left) : left.compareTo(right);
   }
 }
 

--- a/test/features/media_library/presentation/view_models/directory_grid_view_model_test.dart
+++ b/test/features/media_library/presentation/view_models/directory_grid_view_model_test.dart
@@ -555,4 +555,133 @@ void main() {
     expect(directoryThree.mediaCounts.totalMediaCount, 0);
     expect(directoryThree.mediaCounts.taggedMediaCount, 0);
   });
+
+  test(
+    'changeSortOption sorts directories by tagged percentage with stable ties',
+    () async {
+      directoryRepository = InMemoryDirectoryRepository([
+        DirectoryEntity(
+          id: '1',
+          path: '/alpha',
+          name: 'Alpha',
+          thumbnailPath: null,
+          tagIds: const [],
+          lastModified: DateTime(2024, 1, 1),
+        ),
+        DirectoryEntity(
+          id: '2',
+          path: '/beta',
+          name: 'Beta',
+          thumbnailPath: null,
+          tagIds: const [],
+          lastModified: DateTime(2024, 1, 2),
+        ),
+        DirectoryEntity(
+          id: '3',
+          path: '/gamma',
+          name: 'Gamma',
+          thumbnailPath: null,
+          tagIds: const [],
+          lastModified: DateTime(2024, 1, 3),
+        ),
+        DirectoryEntity(
+          id: '4',
+          path: '/empty',
+          name: 'Empty',
+          thumbnailPath: null,
+          tagIds: const [],
+          lastModified: DateTime(2024, 1, 4),
+        ),
+        DirectoryEntity(
+          id: '5',
+          path: '/aardvark',
+          name: 'Aardvark',
+          thumbnailPath: null,
+          tagIds: const [],
+          lastModified: DateTime(2024, 1, 5),
+        ),
+        DirectoryEntity(
+          id: '6',
+          path: '/sparse',
+          name: 'Sparse',
+          thumbnailPath: null,
+          tagIds: const [],
+          lastModified: DateTime(2024, 1, 6),
+        ),
+      ]);
+
+      List<MediaEntity> createMediaForDirectory({
+        required String directoryId,
+        required int taggedCount,
+        required int totalCount,
+      }) {
+        return List<MediaEntity>.generate(totalCount, (index) {
+          final isTagged = index < taggedCount;
+          return MediaEntity(
+            id: '$directoryId-media-$index',
+            path: '/$directoryId/$index.jpg',
+            name: '$index.jpg',
+            type: MediaType.image,
+            size: 100,
+            lastModified: DateTime(2024, 1, 1),
+            tagIds: isTagged ? ['tag-$directoryId'] : const <String>[],
+            directoryId: directoryId,
+          );
+        });
+      }
+
+      mediaRepository = InMemoryMediaRepository([
+        ...createMediaForDirectory(
+          directoryId: '1',
+          taggedCount: 1,
+          totalCount: 2,
+        ),
+        ...createMediaForDirectory(
+          directoryId: '2',
+          taggedCount: 2,
+          totalCount: 4,
+        ),
+        ...createMediaForDirectory(
+          directoryId: '3',
+          taggedCount: 3,
+          totalCount: 4,
+        ),
+        ...createMediaForDirectory(
+          directoryId: '5',
+          taggedCount: 1,
+          totalCount: 2,
+        ),
+        ...createMediaForDirectory(
+          directoryId: '6',
+          taggedCount: 4,
+          totalCount: 10,
+        ),
+      ]);
+
+      final container = await _createDirectoryTestContainer(
+        directoryRepository: directoryRepository,
+        mediaRepository: mediaRepository,
+        favoritesRepository: favoritesRepository,
+      );
+      addTearDown(container.dispose);
+
+      final viewModel = container.read(directoryViewModelProvider.notifier);
+      await viewModel.loadDirectories();
+
+      viewModel.changeSortOption(DirectorySortOption.taggedPercentageDescending);
+
+      final state =
+          container.read(directoryViewModelProvider) as DirectoryLoaded;
+      expect(
+        state.directories.map((directory) => directory.name).toList(),
+        ['Gamma', 'Beta', 'Aardvark', 'Alpha', 'Sparse', 'Empty'],
+      );
+      expect(state.sortOption, DirectorySortOption.taggedPercentageDescending);
+
+      final emptyDirectory = state.directories.last;
+      expect(emptyDirectory.name, 'Empty');
+      expect(emptyDirectory.mediaCounts.totalMediaCount, 0);
+      expect(emptyDirectory.mediaCounts.taggedMediaCount, 0);
+    },
+  );
 }

--- a/test/features/media_library/presentation/view_models/directory_grid_view_model_test.dart
+++ b/test/features/media_library/presentation/view_models/directory_grid_view_model_test.dart
@@ -557,7 +557,7 @@ void main() {
   });
 
   test(
-    'changeSortOption sorts directories by tagged percentage with stable ties',
+    'changeSortOption sorts directories by tagged percentage in both directions',
     () async {
       directoryRepository = InMemoryDirectoryRepository([
         DirectoryEntity(
@@ -670,18 +670,34 @@ void main() {
 
       viewModel.changeSortOption(DirectorySortOption.taggedPercentageDescending);
 
-      final state =
+      final descendingState =
           container.read(directoryViewModelProvider) as DirectoryLoaded;
       expect(
-        state.directories.map((directory) => directory.name).toList(),
+        descendingState.directories.map((directory) => directory.name).toList(),
         ['Gamma', 'Beta', 'Aardvark', 'Alpha', 'Sparse', 'Empty'],
       );
-      expect(state.sortOption, DirectorySortOption.taggedPercentageDescending);
+      expect(
+        descendingState.sortOption,
+        DirectorySortOption.taggedPercentageDescending,
+      );
 
-      final emptyDirectory = state.directories.last;
+      final emptyDirectory = descendingState.directories.last;
       expect(emptyDirectory.name, 'Empty');
       expect(emptyDirectory.mediaCounts.totalMediaCount, 0);
       expect(emptyDirectory.mediaCounts.taggedMediaCount, 0);
+
+      viewModel.changeSortOption(DirectorySortOption.taggedPercentageAscending);
+
+      final ascendingState =
+          container.read(directoryViewModelProvider) as DirectoryLoaded;
+      expect(
+        ascendingState.directories.map((directory) => directory.name).toList(),
+        ['Empty', 'Sparse', 'Aardvark', 'Alpha', 'Beta', 'Gamma'],
+      );
+      expect(
+        ascendingState.sortOption,
+        DirectorySortOption.taggedPercentageAscending,
+      );
     },
   );
 }

--- a/test/features/media_library/presentation/view_models/media_view_model_test.dart
+++ b/test/features/media_library/presentation/view_models/media_view_model_test.dart
@@ -15,6 +15,7 @@ import '../../../../../lib/features/media_library/domain/use_cases/get_media_use
 import '../../../../../lib/features/media_library/domain/use_cases/update_directory_access_use_case.dart';
 import '../../../../../lib/features/media_library/presentation/view_models/media_grid_view_model.dart';
 import '../../../../../lib/shared/providers/repository_providers.dart';
+import '../../../../../lib/shared/utils/directory_id_utils.dart';
 
 class InMemoryMediaRepository implements MediaRepository {
   InMemoryMediaRepository(this._media);
@@ -210,6 +211,9 @@ ProviderContainer _createMediaTestContainer({
     overrides: [
       favoritesRepositoryProvider.overrideWith((ref) {
         return FavoritesRepositoryNotifier(favoritesRepository);
+      }),
+      mediaRepositoryProvider.overrideWith((ref) {
+        return MediaRepositoryNotifier(mediaRepository);
       }),
       mediaViewModelProvider.overrideWithProvider((params) {
         return StateNotifierProvider.autoDispose<MediaViewModel, MediaState>(
@@ -475,5 +479,128 @@ void main() {
     viewModel.selectMediaRange(const ['m3'], append: true);
     expect(state.selectedMediaIds, {'m1', 'm2', 'm3'});
   });
+
+  test(
+    'changeSortOption sorts subdirectories by tagged percentage in both directions',
+    () async {
+      const childAlphaPath = '/dir1/alpha';
+      const childBetaPath = '/dir1/beta';
+      const childEmptyPath = '/dir1/empty';
+
+      mediaRepository = InMemoryMediaRepository([
+        MediaEntity(
+          id: 'dir-alpha',
+          path: childAlphaPath,
+          name: 'Alpha',
+          type: MediaType.directory,
+          size: 0,
+          lastModified: DateTime(2024, 1, 1),
+          tagIds: const [],
+          directoryId: '/dir1',
+        ),
+        MediaEntity(
+          id: 'dir-beta',
+          path: childBetaPath,
+          name: 'Beta',
+          type: MediaType.directory,
+          size: 0,
+          lastModified: DateTime(2024, 1, 2),
+          tagIds: const [],
+          directoryId: '/dir1',
+        ),
+        MediaEntity(
+          id: 'dir-empty',
+          path: childEmptyPath,
+          name: 'Empty',
+          type: MediaType.directory,
+          size: 0,
+          lastModified: DateTime(2024, 1, 3),
+          tagIds: const [],
+          directoryId: '/dir1',
+        ),
+        MediaEntity(
+          id: 'file-1',
+          path: '/dir1/file-1.jpg',
+          name: 'file-1.jpg',
+          type: MediaType.image,
+          size: 100,
+          lastModified: DateTime(2024, 1, 4),
+          tagIds: const ['local'],
+          directoryId: '/dir1',
+        ),
+        MediaEntity(
+          id: 'alpha-1',
+          path: '$childAlphaPath/1.jpg',
+          name: '1.jpg',
+          type: MediaType.image,
+          size: 100,
+          lastModified: DateTime(2024, 1, 5),
+          tagIds: const ['tag-a'],
+          directoryId: generateDirectoryId(childAlphaPath),
+        ),
+        MediaEntity(
+          id: 'alpha-2',
+          path: '$childAlphaPath/2.jpg',
+          name: '2.jpg',
+          type: MediaType.image,
+          size: 100,
+          lastModified: DateTime(2024, 1, 5),
+          tagIds: const <String>[],
+          directoryId: generateDirectoryId(childAlphaPath),
+        ),
+        MediaEntity(
+          id: 'beta-1',
+          path: '$childBetaPath/1.jpg',
+          name: '1.jpg',
+          type: MediaType.image,
+          size: 100,
+          lastModified: DateTime(2024, 1, 5),
+          tagIds: const ['tag-b'],
+          directoryId: generateDirectoryId(childBetaPath),
+        ),
+      ]);
+      getMediaUseCase = GetMediaUseCase(mediaRepository);
+
+      final container = _createMediaTestContainer(
+        mediaDataSource: mediaCache,
+        mediaRepository: mediaRepository,
+        getMediaUseCase: getMediaUseCase,
+        favoritesRepository: favoritesRepository,
+        updateDirectoryAccessUseCase: updateDirectoryAccessUseCase,
+      );
+      addTearDown(container.dispose);
+
+      final viewModel = container.read(mediaViewModelProvider(params).notifier);
+      await viewModel.loadMedia();
+
+      viewModel.changeSortOption(MediaSortOption.taggedPercentageDescending);
+
+      final descendingState = container.read(
+        mediaViewModelProvider(params),
+      ) as MediaLoaded;
+      expect(
+        descendingState.media.map((media) => media.name).toList(),
+        ['Beta', 'Alpha', 'Empty', 'file-1.jpg'],
+      );
+      expect(
+        descendingState.sortOption,
+        MediaSortOption.taggedPercentageDescending,
+      );
+
+      viewModel.changeSortOption(MediaSortOption.taggedPercentageAscending);
+
+      final ascendingState = container.read(
+        mediaViewModelProvider(params),
+      ) as MediaLoaded;
+      expect(
+        ascendingState.media.map((media) => media.name).toList(),
+        ['Empty', 'Alpha', 'Beta', 'file-1.jpg'],
+      );
+      expect(
+        ascendingState.sortOption,
+        MediaSortOption.taggedPercentageAscending,
+      );
+    },
+  );
 
 }

--- a/test/features/media_library/presentation/widgets/directory_search_and_grid_test.dart
+++ b/test/features/media_library/presentation/widgets/directory_search_and_grid_test.dart
@@ -441,7 +441,7 @@ void main() {
       expect(viewModel.state, isA<DirectoryLoaded>());
     });
 
-    testWidgets('shows tagged percentage sort option in the sort menu', (
+    testWidgets('shows tagged percentage sort options in the sort menu', (
       tester,
     ) async {
       final directories = [
@@ -479,19 +479,20 @@ void main() {
       await tester.tap(find.byTooltip('Sort'));
       await tester.pumpAndSettle();
 
+      expect(find.text('Tagged % (Low-High)'), findsOneWidget);
       expect(find.text('Tagged % (High-Low)'), findsOneWidget);
 
-      await tester.tap(find.text('Tagged % (High-Low)'));
+      await tester.tap(find.text('Tagged % (Low-High)'));
       await tester.pumpAndSettle();
 
       expect(
         viewModel.lastSortOption,
-        DirectorySortOption.taggedPercentageDescending,
+        DirectorySortOption.taggedPercentageAscending,
       );
       expect(viewModel.state, isA<DirectoryLoaded>());
       expect(
         (viewModel.state as DirectoryLoaded).sortOption,
-        DirectorySortOption.taggedPercentageDescending,
+        DirectorySortOption.taggedPercentageAscending,
       );
     });
   });

--- a/test/features/media_library/presentation/widgets/directory_search_and_grid_test.dart
+++ b/test/features/media_library/presentation/widgets/directory_search_and_grid_test.dart
@@ -107,6 +107,7 @@ class _StubDirectoryViewModel extends DirectoryViewModel {
   final List<DirectoryEntity> _directories;
   String? lastSearchQuery;
   String? removedDirectoryId;
+  DirectorySortOption lastSortOption = DirectorySortOption.nameAscending;
 
   @override
   Future<void> loadDirectories() async {
@@ -140,6 +141,21 @@ class _StubDirectoryViewModel extends DirectoryViewModel {
   @override
   Future<void> removeDirectory(String id) async {
     removedDirectoryId = id;
+  }
+
+  @override
+  void changeSortOption(DirectorySortOption option) {
+    lastSortOption = option;
+    state = DirectoryLoaded(
+      directories: _directories,
+      searchQuery: lastSearchQuery ?? '',
+      selectedTagIds: const [],
+      columns: 2,
+      sortOption: option,
+      selectedDirectoryIds: const {},
+      isSelectionMode: false,
+      showFavoritesOnly: false,
+    );
   }
 }
 
@@ -423,6 +439,60 @@ void main() {
       expect(find.text('1 tags'), findsOneWidget);
       expect(find.text('2 / 5 tagged'), findsOneWidget);
       expect(viewModel.state, isA<DirectoryLoaded>());
+    });
+
+    testWidgets('shows tagged percentage sort option in the sort menu', (
+      tester,
+    ) async {
+      final directories = [
+        DirectoryEntity(
+          id: generateDirectoryId('/music'),
+          path: '/music',
+          name: 'Music',
+          thumbnailPath: null,
+          tagIds: const [],
+          lastModified: DateTime(2024, 1, 1),
+        ),
+      ];
+      late _StubDirectoryViewModel viewModel;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            gridColumnsProvider
+                .overrideWith((ref) => _StubGridColumnsNotifier()),
+            favoritesViewModelProvider.overrideWith(
+              (ref) => _StubFavoritesViewModel(),
+            ),
+            tagViewModelProvider.overrideWith((ref) => _StubTagViewModel()),
+            directoryViewModelProvider.overrideWith((ref) {
+              viewModel = _StubDirectoryViewModel(directories, ref);
+              return viewModel;
+            }),
+          ],
+          child: const MaterialApp(
+            home: DirectoryGridScreen(),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byTooltip('Sort'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Tagged % (High-Low)'), findsOneWidget);
+
+      await tester.tap(find.text('Tagged % (High-Low)'));
+      await tester.pumpAndSettle();
+
+      expect(
+        viewModel.lastSortOption,
+        DirectorySortOption.taggedPercentageDescending,
+      );
+      expect(viewModel.state, isA<DirectoryLoaded>());
+      expect(
+        (viewModel.state as DirectoryLoaded).sortOption,
+        DirectorySortOption.taggedPercentageDescending,
+      );
     });
   });
 }

--- a/test/screens/media_grid_screen_test.dart
+++ b/test/screens/media_grid_screen_test.dart
@@ -2,31 +2,34 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:media_fast_view/features/media_library/presentation/screens/media_grid_screen.dart';
 import 'package:media_fast_view/features/media_library/presentation/models/directory_navigation_target.dart';
+import 'package:media_fast_view/features/media_library/presentation/screens/media_grid_screen.dart';
 
 void main() {
   group('MediaGridScreen', () {
     const testDirectoryPath = '/test/directory';
     const testDirectoryName = 'Test Directory';
 
-    testWidgets('renders with correct title and app bar actions', (WidgetTester tester) async {
-      await tester.pumpWidget(
-        const ProviderScope(
-          child: MaterialApp(
-            home: MediaGridScreen(
-              directoryPath: testDirectoryPath,
-              directoryName: testDirectoryName,
+    testWidgets(
+      'renders with correct title and app bar actions',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          const ProviderScope(
+            child: MaterialApp(
+              home: MediaGridScreen(
+                directoryPath: testDirectoryPath,
+                directoryName: testDirectoryName,
+              ),
             ),
           ),
-        ),
-      );
+        );
 
-      expect(find.text(testDirectoryName), findsOneWidget);
-      expect(find.byType(AppBar), findsOneWidget);
-      expect(find.byIcon(Icons.tag), findsOneWidget);
-      expect(find.byIcon(Icons.view_module), findsOneWidget);
-    });
+        expect(find.text(testDirectoryName), findsOneWidget);
+        expect(find.byType(AppBar), findsOneWidget);
+        expect(find.byIcon(Icons.tag), findsOneWidget);
+        expect(find.byIcon(Icons.view_module), findsOneWidget);
+      },
+    );
 
     testWidgets('builds without crashing', (WidgetTester tester) async {
       await tester.pumpWidget(
@@ -60,6 +63,26 @@ void main() {
       // Verify basic UI structure
       expect(find.byType(Column), findsWidgets);
       expect(find.byType(Container), findsWidgets);
+    });
+
+    testWidgets('shows tagged percentage sort options in the sort menu',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(
+            home: MediaGridScreen(
+              directoryPath: testDirectoryPath,
+              directoryName: testDirectoryName,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byTooltip('Sort'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Tagged % (Low-High)'), findsOneWidget);
+      expect(find.text('Tagged % (High-Low)'), findsOneWidget);
     });
 
     testWidgets('shows navigation arrows when sibling directories are provided',


### PR DESCRIPTION
### Motivation

- Provide a sort option that surfaces directories with the highest proportion of tagged media first so users can find well-tagged folders quickly.
- Reuse existing cached media counts attached to `DirectoryEntity` rather than introducing new data sources for percentage calculations.
- Ensure sorting is stable and deterministic to avoid UI flicker and unstable ordering when ratios are equal.

### Description

- Added `DirectorySortOption.taggedPercentageDescending` to `lib/features/media_library/presentation/view_models/directory_grid_view_model.dart` and exposed the label `Tagged % (High-Low)` via `DirectorySortOptionX.label` so the option appears in the existing sort menu automatically.
- Implemented sorting using a new comparator that computes a safe tagged percentage from `DirectoryEntity.mediaCounts`, treating `0 / 0` as `0.0` to avoid NaN/infinity and to keep empty directories below any with a positive ratio.
- Made sorting deterministic by adding tie-breakers after percentage comparison: first by `taggedMediaCount` descending, then by `name` ascending.
- Added automated test coverage: a view-model unit test that seeds directories/media to verify ratio-based ordering, the `0/0` edge case, and the tie-case (`1/2` vs `2/4`); and a widget test that asserts the new menu label and selection flow. Test files updated are `test/features/media_library/presentation/view_models/directory_grid_view_model_test.dart` and `test/features/media_library/presentation/widgets/directory_search_and_grid_test.dart`.

### Testing

- Added unit and widget tests as described above but did not execute the test suite in this environment because the Dart/Flutter SDK tooling is not available here, so no automated tests were run.
- Attempted to run `dart format` but it failed in this environment since `dart` is not installed, so formatting/tests were not executed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0abdb603c832083ae71a035d4f4bb)