### PR TITLE
Add start-muted video playback setting

### DIFF
--- a/lib/features/favorites/presentation/view_models/slideshow_view_model.dart
+++ b/lib/features/favorites/presentation/view_models/slideshow_view_model.dart
@@ -6,6 +6,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../media_library/domain/entities/media_entity.dart';
 import '../../../../shared/utils/tag_mutation_service.dart';
 import '../../../tagging/domain/entities/tag_entity.dart';
+import '../../../settings/domain/entities/playback_settings.dart';
+import '../../../../shared/providers/settings_providers.dart';
 
 /// Sealed class representing the state of slideshow.
 sealed class SlideshowState {
@@ -107,7 +109,9 @@ class SlideshowViewModel extends StateNotifier<SlideshowState> {
   SlideshowViewModel(
     this._mediaList, {
     required TagMutationService tagMutationService,
+    required PlaybackSettings playbackSettings,
   }) : _tagMutationService = tagMutationService,
+       _playbackSettings = playbackSettings,
        super(const SlideshowIdle()) {
     if (_mediaList.isNotEmpty) {
       _initializeSlideshow();
@@ -116,6 +120,7 @@ class SlideshowViewModel extends StateNotifier<SlideshowState> {
 
   final List<MediaEntity> _mediaList;
   final TagMutationService _tagMutationService;
+  final PlaybackSettings _playbackSettings;
   Timer? _timer;
   final Random _random = Random();
   bool _isShuffleEnabled = false;
@@ -270,7 +275,7 @@ class SlideshowViewModel extends StateNotifier<SlideshowState> {
       currentIndex: 0,
       isLooping: false,
       isVideoLooping: false,
-      isMuted: false,
+      isMuted: _playbackSettings.startMuted,
       progress: 0.0,
       isShuffleEnabled: _isShuffleEnabled,
       imageDisplayDuration: _imageDisplayDuration,
@@ -817,5 +822,6 @@ final slideshowViewModelProvider = StateNotifierProvider.autoDispose
       (ref, mediaList) => SlideshowViewModel(
         mediaList,
         tagMutationService: ref.watch(tagMutationServiceProvider),
+        playbackSettings: ref.watch(videoPlaybackSettingsProvider),
       ),
     );

--- a/lib/features/full_screen/presentation/view_models/full_screen_view_model.dart
+++ b/lib/features/full_screen/presentation/view_models/full_screen_view_model.dart
@@ -217,7 +217,7 @@ class FullScreenViewModel extends StateNotifier<FullScreenState> {
           mediaList: finalMediaList,
           currentIndex: currentIndex,
           isPlaying: isVideo && _playbackSettings.autoplayVideos,
-          isMuted: false,
+          isMuted: isVideo && _playbackSettings.startMuted,
           isLooping: isVideo && _playbackSettings.loopVideos,
           playbackSpeed: 1.0,
           currentPosition: Duration.zero,
@@ -293,6 +293,8 @@ class FullScreenViewModel extends StateNotifier<FullScreenState> {
         totalDuration: Duration.zero,
         isPlaying:
             nextMedia.type == MediaType.video && _playbackSettings.autoplayVideos,
+        isMuted:
+            nextMedia.type == MediaType.video && _playbackSettings.startMuted,
         isLooping:
             nextMedia.type == MediaType.video && _playbackSettings.loopVideos,
         currentMediaTags: nextTags,
@@ -331,6 +333,8 @@ class FullScreenViewModel extends StateNotifier<FullScreenState> {
         totalDuration: Duration.zero,
         isPlaying: previousMedia.type == MediaType.video &&
             _playbackSettings.autoplayVideos,
+        isMuted: previousMedia.type == MediaType.video &&
+            _playbackSettings.startMuted,
         isLooping: previousMedia.type == MediaType.video &&
             _playbackSettings.loopVideos,
         currentMediaTags: previousTags,
@@ -595,6 +599,8 @@ class FullScreenViewModel extends StateNotifier<FullScreenState> {
       totalDuration: Duration.zero,
       isPlaying:
           targetMedia.type == MediaType.video && _playbackSettings.autoplayVideos,
+      isMuted:
+          targetMedia.type == MediaType.video && _playbackSettings.startMuted,
       isLooping:
           targetMedia.type == MediaType.video && _playbackSettings.loopVideos,
       currentMediaTags: targetTags,

--- a/lib/features/settings/data/repositories/settings_repository_impl.dart
+++ b/lib/features/settings/data/repositories/settings_repository_impl.dart
@@ -14,6 +14,7 @@ class SettingsRepositoryImpl implements SettingsRepository {
   static const String _deleteFromSourceKey = 'delete_from_source_enabled';
   static const String _autoplayKey = 'video_autoplay_enabled';
   static const String _loopKey = 'video_loop_enabled';
+  static const String _startMutedKey = 'video_start_muted';
   static const String _autoNavigateKey = 'auto_navigate_sibling_directories';
   static const String _showDirectoryTaggedMediaCountsKey =
       'show_directory_tagged_media_counts';
@@ -26,6 +27,7 @@ class SettingsRepositoryImpl implements SettingsRepository {
     final themeIndex = prefs.getInt(_themeKey) ?? ThemeMode.system.index;
     final autoplay = prefs.getBool(_autoplayKey) ?? false;
     final loop = prefs.getBool(_loopKey) ?? false;
+    final startMuted = prefs.getBool(_startMutedKey) ?? false;
     final thumbnailCachingEnabled = prefs.getBool(_thumbnailCachingKey) ?? true;
     final deleteFromSourceEnabled = prefs.getBool(_deleteFromSourceKey) ?? false;
     final autoNavigateSiblingDirectories =
@@ -48,6 +50,7 @@ class SettingsRepositoryImpl implements SettingsRepository {
       playbackSettings: PlaybackSettings(
         autoplayVideos: autoplay,
         loopVideos: loop,
+        startMuted: startMuted,
       ),
       autoNavigateSiblingDirectories: autoNavigateSiblingDirectories,
       showDirectoryTaggedMediaCounts: showDirectoryTaggedMediaCounts,
@@ -80,6 +83,7 @@ class SettingsRepositoryImpl implements SettingsRepository {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_autoplayKey, settings.autoplayVideos);
     await prefs.setBool(_loopKey, settings.loopVideos);
+    await prefs.setBool(_startMutedKey, settings.startMuted);
   }
 
   @override

--- a/lib/features/settings/domain/entities/playback_settings.dart
+++ b/lib/features/settings/domain/entities/playback_settings.dart
@@ -6,22 +6,27 @@ class PlaybackSettings {
   const PlaybackSettings({
     required this.autoplayVideos,
     required this.loopVideos,
+    required this.startMuted,
   });
 
   const PlaybackSettings.initial()
       : autoplayVideos = false,
-        loopVideos = false;
+        loopVideos = false,
+        startMuted = false;
 
   final bool autoplayVideos;
   final bool loopVideos;
+  final bool startMuted;
 
   PlaybackSettings copyWith({
     bool? autoplayVideos,
     bool? loopVideos,
+    bool? startMuted,
   }) {
     return PlaybackSettings(
       autoplayVideos: autoplayVideos ?? this.autoplayVideos,
       loopVideos: loopVideos ?? this.loopVideos,
+      startMuted: startMuted ?? this.startMuted,
     );
   }
 }

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -73,6 +73,10 @@ class SettingsScreen extends ConsumerWidget {
             settings.playbackSettings.loopVideos,
             viewModel,
           ),
+          _buildStartMutedSetting(
+            settings.playbackSettings.startMuted,
+            viewModel,
+          ),
           _buildSlideshowControlsHideDelaySetting(
             settings.slideshowControlsHideDelay,
             viewModel,
@@ -207,6 +211,22 @@ class SettingsScreen extends ConsumerWidget {
         value: isEnabled,
         onChanged: (bool value) {
           viewModel.updateLoopVideos(value);
+        },
+      ),
+    );
+  }
+
+  Widget _buildStartMutedSetting(
+    bool isEnabled,
+    SettingsViewModel viewModel,
+  ) {
+    return ListTile(
+      title: const Text('Start Videos Muted'),
+      subtitle: const Text('Mute videos by default when they begin playback'),
+      trailing: Switch(
+        value: isEnabled,
+        onChanged: (bool value) {
+          viewModel.updateStartMuted(value);
         },
       ),
     );

--- a/lib/features/settings/presentation/view_models/settings_view_model.dart
+++ b/lib/features/settings/presentation/view_models/settings_view_model.dart
@@ -99,6 +99,12 @@ class SettingsViewModel extends AsyncNotifier<AppSettings> {
     );
   }
 
+  Future<void> updateStartMuted(bool enabled) async {
+    await _updatePlayback(
+      (playback) => playback.copyWith(startMuted: enabled),
+    );
+  }
+
   Future<void> updateAutoNavigateSiblingDirectories(bool enabled) async {
     await _updateSetting(
       () => _updateAutoNavigateSiblingDirectoriesUseCase(enabled),

--- a/test/features/favorites/presentation/view_models/slideshow_view_model_test.dart
+++ b/test/features/favorites/presentation/view_models/slideshow_view_model_test.dart
@@ -4,6 +4,7 @@ import 'package:mockito/mockito.dart';
 
 import 'package:media_fast_view/features/favorites/presentation/view_models/slideshow_view_model.dart';
 import 'package:media_fast_view/features/media_library/domain/entities/media_entity.dart';
+import 'package:media_fast_view/features/settings/domain/entities/playback_settings.dart';
 import 'package:media_fast_view/features/tagging/domain/entities/tag_entity.dart';
 import 'package:media_fast_view/shared/utils/tag_mutation_service.dart';
 
@@ -45,6 +46,7 @@ void main() {
     final viewModel = SlideshowViewModel(
       media,
       tagMutationService: tagMutationService,
+      playbackSettings: const PlaybackSettings.initial(),
     );
 
     expect(viewModel.state, isA<SlideshowPaused>());
@@ -56,6 +58,7 @@ void main() {
     final viewModel = SlideshowViewModel(
       media,
       tagMutationService: tagMutationService,
+      playbackSettings: const PlaybackSettings.initial(),
     );
 
     viewModel.startSlideshow();
@@ -73,6 +76,7 @@ void main() {
       final viewModel = SlideshowViewModel(
         media,
         tagMutationService: tagMutationService,
+        playbackSettings: const PlaybackSettings.initial(),
       );
 
       viewModel.startSlideshow();
@@ -92,6 +96,7 @@ void main() {
     final viewModel = SlideshowViewModel(
       media,
       tagMutationService: tagMutationService,
+      playbackSettings: const PlaybackSettings.initial(),
     );
 
     viewModel.startSlideshow();
@@ -114,6 +119,7 @@ void main() {
     final viewModel = SlideshowViewModel(
       media,
       tagMutationService: tagMutationService,
+      playbackSettings: const PlaybackSettings.initial(),
     );
 
     final result = await viewModel.toggleTag(tag);

--- a/test/features/favorites/presentation/widgets/slideshow_overlay_test.dart
+++ b/test/features/favorites/presentation/widgets/slideshow_overlay_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:media_fast_view/features/favorites/presentation/view_models/slideshow_view_model.dart';
 import 'package:media_fast_view/features/favorites/presentation/widgets/slideshow_overlay.dart';
 import 'package:media_fast_view/features/media_library/domain/entities/media_entity.dart';
+import 'package:media_fast_view/features/settings/domain/entities/playback_settings.dart';
 import 'package:media_fast_view/shared/providers/repository_providers.dart';
 import 'package:media_fast_view/shared/utils/tag_cache_refresher.dart';
 import 'package:media_fast_view/shared/utils/tag_lookup.dart';
@@ -61,6 +62,7 @@ void main() {
         tagLookup: _FakeTagLookup(),
         tagCacheRefresher: const _FakeTagCacheRefresher(),
       ),
+      playbackSettings: const PlaybackSettings.initial(),
     );
 
     var playPauseTapped = false;

--- a/test/features/full_screen/presentation/screens/full_screen_viewer_screen_test.dart
+++ b/test/features/full_screen/presentation/screens/full_screen_viewer_screen_test.dart
@@ -36,7 +36,11 @@ class _FakeFullScreenViewModel extends FullScreenViewModel {
           assignTagUseCase,
           tagLookup,
           tagCacheRefresher,
-          const PlaybackSettings(autoplayVideos: false, loopVideos: false),
+          const PlaybackSettings(
+            autoplayVideos: false,
+            loopVideos: false,
+            startMuted: false,
+          ),
           tagUsageRanker: const TagUsageRanker(limit: 10),
         );
 

--- a/test/features/full_screen/presentation/view_models/full_screen_view_model_test.dart
+++ b/test/features/full_screen/presentation/view_models/full_screen_view_model_test.dart
@@ -25,7 +25,11 @@ void main() {
   late FullScreenViewModel viewModel;
 
   const playbackSettings =
-      PlaybackSettings(autoplayVideos: false, loopVideos: false);
+      PlaybackSettings(
+        autoplayVideos: false,
+        loopVideos: false,
+        startMuted: false,
+      );
 
   setUp(() {
     loadMediaForViewingUseCase = MockLoadMediaForViewingUseCase();

--- a/test/features/settings/presentation/screens/settings_screen_test.dart
+++ b/test/features/settings/presentation/screens/settings_screen_test.dart
@@ -103,6 +103,7 @@ void main() {
           playbackSettings: PlaybackSettings(
             autoplayVideos: false,
             loopVideos: false,
+            startMuted: false,
           ),
           autoNavigateSiblingDirectories: false,
           showDirectoryTaggedMediaCounts: false,
@@ -146,6 +147,14 @@ void main() {
       await tester.tap(loopSwitch);
       await tester.pumpAndSettle();
       expect(settingsRepository.settings.playbackSettings.loopVideos, isTrue);
+
+      final startMutedSwitch = find.descendant(
+        of: find.widgetWithText(ListTile, 'Start Videos Muted'),
+        matching: find.byType(Switch),
+      );
+      await tester.tap(startMutedSwitch);
+      await tester.pumpAndSettle();
+      expect(settingsRepository.settings.playbackSettings.startMuted, isTrue);
 
       final siblingNavigationSwitch = find.descendant(
         of: find.widgetWithText(


### PR DESCRIPTION
### Motivation
- Provide a user-configurable toggle so videos can start muted by default, matching the existing persisted playback preferences (autoplay/loop).
- Keep playback preferences consistent and persisted across app launches using the same settings flow.

### Description
- Added a new `startMuted` flag to `PlaybackSettings` with `initial()` and `copyWith()` support and a new `video_start_muted` SharedPreferences key. (`lib/features/settings/domain/entities/playback_settings.dart`, `lib/features/settings/data/repositories/settings_repository_impl.dart`)
- Exposed `updateStartMuted(bool)` on `SettingsViewModel` and added a new "Start Videos Muted" switch to the Settings UI. (`lib/features/settings/presentation/view_models/settings_view_model.dart`, `lib/features/settings/presentation/screens/settings_screen.dart`)
- Wired the preference into playback initialization and navigation paths so full-screen viewer and navigation set `isMuted` based on `startMuted` when a video loads. (`lib/features/full_screen/presentation/view_models/full_screen_view_model.dart`)
- Updated the slideshow view model/provider to accept `PlaybackSettings` and initialize its muted state from `startMuted`, and updated providers/tests to pass/use the new field. (`lib/features/favorites/presentation/view_models/slideshow_view_model.dart`, `lib/shared/providers/settings_providers.dart`, various tests)

### Testing
- Attempted to run `dart format` on modified files, but formatting could not be executed because `dart` was not available in the environment (failed: `dart: command not found`).
- Attempted to run `flutter test test/features/settings/presentation/screens/settings_screen_test.dart`, but tests could not be executed because `flutter` was not available (failed: `flutter: command not found`).
- Updated and committed corresponding unit/widget tests to include the new `startMuted` field and constructor arguments; no automated tests were executed successfully in this environment due to missing tooling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6cecdc7f48320ad0b6489f07f0db0)