### PR TITLE
Replace per-directory cache on scan/filter and preserve persisted tags

### DIFF
--- a/lib/features/media_library/data/repositories/filesystem_media_repository_impl.dart
+++ b/lib/features/media_library/data/repositories/filesystem_media_repository_impl.dart
@@ -125,10 +125,9 @@ class FilesystemMediaRepositoryImpl implements MediaRepository {
         bookmarkData: effectiveBookmarkData,
       );
 
-      // Merge tags from local storage
-      final mergedModels = await _mergeTagsWithLocalStorage(
+      final mergedModels = await _replaceDirectoryCacheWithMergedScan(
+        directoryId,
         models,
-        directoryId: directoryId,
       );
 
       _permissionService.logPermissionEvent(
@@ -281,9 +280,9 @@ class FilesystemMediaRepositoryImpl implements MediaRepository {
       bookmarkData: bookmarkData,
       mediaPersistence: _mediaDataSource,
     );
-    final mergedModels = await _mergeTagsWithLocalStorage(
+    final mergedModels = await _replaceDirectoryCacheWithMergedScan(
+      directoryId,
       models,
-      directoryId: directoryId,
     );
     return mergedModels.map(_modelToEntity).toList();
   }
@@ -302,9 +301,9 @@ class FilesystemMediaRepositoryImpl implements MediaRepository {
       bookmarkData: bookmarkData,
       mediaPersistence: _mediaDataSource,
     );
-    final mergedModels = await _mergeTagsWithLocalStorage(
+    final mergedModels = await _replaceDirectoryCacheWithMergedScan(
+      directoryId,
       models,
-      directoryId: directoryId,
     );
     return mergedModels.map(_modelToEntity).toList();
   }
@@ -321,11 +320,11 @@ class FilesystemMediaRepositoryImpl implements MediaRepository {
     return _mediaDataSource.updateMediaTagsBatch(mediaTags);
   }
 
-  /// Merges tags from local storage with filesystem-scanned media.
-  Future<List<MediaModel>> _mergeTagsWithLocalStorage(
-    List<MediaModel> scannedMedia, {
-    required String directoryId,
-  }) async {
+  /// Replaces a directory cache with a merged filesystem scan result.
+  Future<List<MediaModel>> _replaceDirectoryCacheWithMergedScan(
+    String directoryId,
+    List<MediaModel> scannedMedia,
+  ) async {
     final existingMedia = await _mediaDataSource.getMediaForDirectory(
       directoryId,
     );
@@ -352,6 +351,7 @@ class FilesystemMediaRepositoryImpl implements MediaRepository {
         bookmarkData: entity.bookmarkData,
       );
     }).toList();
+    await _mediaDataSource.removeMediaForDirectory(directoryId);
     await _mediaDataSource.addMedia(mergedModels);
     return mergedModels;
   }

--- a/test/features/media_library/data/repositories/filesystem_media_repository_impl_test.dart
+++ b/test/features/media_library/data/repositories/filesystem_media_repository_impl_test.dart
@@ -40,6 +40,7 @@ void main() {
     when(isarMediaDataSource.getMedia()).thenAnswer((_) async => <MediaModel>[]);
     when(isarMediaDataSource.getMediaForDirectory(any)).thenAnswer((_) async => <MediaModel>[]);
     when(isarMediaDataSource.saveMedia(any)).thenAnswer((_) async {});
+    when(isarMediaDataSource.addMedia(any)).thenAnswer((_) async {});
     when(isarMediaDataSource.upsertMedia(any)).thenAnswer((_) async {});
     when(isarMediaDataSource.updateMediaTags(any, any)).thenAnswer((_) async {});
     when(isarMediaDataSource.removeMediaForDirectory(any)).thenAnswer((_) async {});
@@ -111,7 +112,7 @@ void main() {
       ).called(1);
     });
 
-    test('merges tags by querying persisted rows scoped to directory', () async {
+    test('replaces cached rows for directory and preserves tags for scanned IDs', () async {
       const directoryPath = '/test/scoped';
       final directoryId = generateDirectoryId(directoryPath);
       final scannedModel = MediaModel(
@@ -125,6 +126,16 @@ void main() {
         directoryId: directoryId,
       );
       final persistedModel = scannedModel.copyWith(tagIds: const ['from-cache']);
+      final removedModel = MediaModel(
+        id: 'media-removed',
+        path: '$directoryPath/removed.jpg',
+        name: 'removed.jpg',
+        type: MediaType.image,
+        size: 64,
+        lastModified: DateTime(2024),
+        tagIds: const ['removed-tag'],
+        directoryId: directoryId,
+      );
 
       when(
         filesystemDataSource.scanMediaForDirectory(
@@ -134,7 +145,7 @@ void main() {
         ),
       ).thenAnswer((_) async => <MediaModel>[scannedModel]);
       when(isarMediaDataSource.getMediaForDirectory(directoryId)).thenAnswer(
-        (_) async => <MediaModel>[persistedModel],
+        (_) async => <MediaModel>[persistedModel, removedModel],
       );
 
       final media = await repository.getMediaForDirectoryPath(directoryPath);
@@ -142,12 +153,16 @@ void main() {
       expect(media, hasLength(1));
       expect(media.first.tagIds, containsAll(const ['from-scan', 'from-cache']));
       verify(isarMediaDataSource.getMediaForDirectory(directoryId)).called(1);
+      verify(isarMediaDataSource.removeMediaForDirectory(directoryId)).called(1);
+      final captured = verify(isarMediaDataSource.addMedia(captureAny)).captured;
+      final persisted = captured.single as List<MediaModel>;
+      expect(persisted.map((model) => model.id), equals(const ['media-1']));
       verifyNever(isarMediaDataSource.getMedia());
     });
   });
 
   group('filterMediaByTagsForDirectory', () {
-    test('queries persisted rows scoped to the requested directory', () async {
+    test('replaces cached rows for directory and removes deleted files', () async {
       const directoryPath = '/test/filter';
       final directoryId = generateDirectoryId(directoryPath);
       final scannedModel = MediaModel(
@@ -161,6 +176,16 @@ void main() {
         directoryId: directoryId,
       );
       final persistedModel = scannedModel.copyWith(tagIds: const ['from-cache']);
+      final removedModel = MediaModel(
+        id: 'media-filter-removed',
+        path: '$directoryPath/removed.jpg',
+        name: 'removed.jpg',
+        type: MediaType.image,
+        size: 700,
+        lastModified: DateTime(2024),
+        tagIds: const ['from-cache'],
+        directoryId: directoryId,
+      );
 
       when(
         filesystemDataSource.filterMediaByTags(
@@ -172,7 +197,7 @@ void main() {
         ),
       ).thenAnswer((_) async => <MediaModel>[scannedModel]);
       when(isarMediaDataSource.getMediaForDirectory(directoryId)).thenAnswer(
-        (_) async => <MediaModel>[persistedModel],
+        (_) async => <MediaModel>[persistedModel, removedModel],
       );
 
       final media = await repository.filterMediaByTagsForDirectory(
@@ -183,7 +208,64 @@ void main() {
       expect(media, hasLength(1));
       expect(media.first.tagIds, containsAll(const ['from-scan', 'from-cache']));
       verify(isarMediaDataSource.getMediaForDirectory(directoryId)).called(1);
+      verify(isarMediaDataSource.removeMediaForDirectory(directoryId)).called(1);
+      final captured = verify(isarMediaDataSource.addMedia(captureAny)).captured;
+      final persisted = captured.single as List<MediaModel>;
+      expect(persisted.map((model) => model.id), equals(const ['media-filter']));
       verifyNever(isarMediaDataSource.getMedia());
+    });
+  });
+
+  group('filterMediaByTagsFromDirectory', () {
+    test('replaces only target directory cache and preserves scanned tags', () async {
+      const directoryPath = '/test/filter/from-directory';
+      final directoryId = generateDirectoryId(directoryPath);
+      final scannedModel = MediaModel(
+        id: 'media-filter-directory',
+        path: '$directoryPath/file.jpg',
+        name: 'file.jpg',
+        type: MediaType.image,
+        size: 512,
+        lastModified: DateTime(2024),
+        tagIds: const ['from-scan'],
+        directoryId: directoryId,
+      );
+      final persistedModel = scannedModel.copyWith(tagIds: const ['from-cache']);
+      final removedModel = scannedModel.copyWith(
+        id: 'media-filter-directory-removed',
+        path: '$directoryPath/removed.jpg',
+      );
+
+      when(
+        filesystemDataSource.filterMediaByTags(
+          any,
+          any,
+          any,
+          bookmarkData: anyNamed('bookmarkData'),
+          mediaPersistence: anyNamed('mediaPersistence'),
+        ),
+      ).thenAnswer((_) async => <MediaModel>[scannedModel]);
+      when(isarMediaDataSource.getMediaForDirectory(directoryId)).thenAnswer(
+        (_) async => <MediaModel>[persistedModel, removedModel],
+      );
+
+      final media = await repository.filterMediaByTagsFromDirectory(
+        const ['tag-1'],
+        directoryPath,
+        directoryId,
+      );
+
+      expect(media, hasLength(1));
+      expect(media.first.tagIds, containsAll(const ['from-scan', 'from-cache']));
+      verify(isarMediaDataSource.getMediaForDirectory(directoryId)).called(1);
+      verify(isarMediaDataSource.removeMediaForDirectory(directoryId)).called(1);
+      final captured = verify(isarMediaDataSource.addMedia(captureAny)).captured;
+      final persisted = captured.single as List<MediaModel>;
+      expect(
+        persisted.map((model) => model.id),
+        equals(const ['media-filter-directory']),
+      );
+      verifyNever(isarMediaDataSource.removeMediaForDirectory('other-directory'));
     });
   });
 


### PR DESCRIPTION
### Motivation
- Ensure filesystem scans and tag-filter flows replace the persisted rows for the scanned directory so deleted files are pruned while preserving any persisted tag assignments for scanned items.
- Centralize and clarify the persistence semantics so replacement is scoped to the target directory and non-target directories remain untouched.

### Description
- Introduced a helper `Future<List<MediaModel>> _replaceDirectoryCacheWithMergedScan(String directoryId, List<MediaModel> scannedMedia)` that loads existing rows for the directory, merges persisted tag IDs onto scanned rows, calls `removeMediaForDirectory(directoryId)`, and writes back only the merged scanned rows.
- Replaced calls to the previous merge helper with ` _replaceDirectoryCacheWithMergedScan` in `getMediaForDirectoryPath`, `filterMediaByTagsForDirectory`, and `filterMediaByTagsFromDirectory` so those flows always use replacement semantics for the target directory only.
- Kept other directories untouched; tests assert `removeMediaForDirectory` is called only for the target directory and never for unrelated directories.
- Updated tests to stub `addMedia` on the mocked Isar data source and added assertions that deleted/removed files are pruned and that merged tag IDs are preserved for scanned items.

### Testing
- Updated unit tests in `test/features/media_library/data/repositories/filesystem_media_repository_impl_test.dart` to cover replacement semantics and tag merging, but automated execution was not possible in this environment due to missing SDK tools.
- Attempted to run `dart format lib/features/media_library/data/repositories/filesystem_media_repository_impl.dart test/features/media_library/data/repositories/filesystem_media_repository_impl_test.dart`, which failed with `dart: command not found`.
- Attempted to run `flutter test test/features/media_library/data/repositories/filesystem_media_repository_impl_test.dart`, which failed with `flutter: command not found`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6d4891a248320bda2a8f6216d9d47)